### PR TITLE
fix(ux): SSO authorization hints and sort dropdown padding

### DIFF
--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -72,7 +72,7 @@ export default function Filters() {
         <select
           value={filters.sortOrder}
           onChange={(e) => setFilters({ sortOrder: e.target.value as 'newest' | 'oldest' })}
-          className="w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded-md px-2 py-1.5 text-xs text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-accent)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] transition-colors cursor-pointer"
+          className="w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded-md pl-2 pr-7 py-1.5 text-xs text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-accent)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] transition-colors cursor-pointer"
         >
           <option value="newest">Newest first</option>
           <option value="oldest">Oldest first</option>

--- a/src/components/PRList/PRList.tsx
+++ b/src/components/PRList/PRList.tsx
@@ -76,6 +76,17 @@ export default function PRList() {
         <div className="text-center py-16 text-[var(--color-text-muted)]">
           <p className="text-sm">No pull requests found.</p>
           <p className="text-xs mt-1">Try adjusting your filters.</p>
+          <p className="text-xs mt-3 text-[var(--color-text-muted)]">
+            Missing PRs from an organization?{' '}
+            <a
+              href="https://github.com/settings/tokens"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--color-accent)] hover:underline"
+            >
+              Authorize your token for SSO →
+            </a>
+          </p>
         </div>
       )}
 

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -89,6 +89,18 @@ export default function AuthPage() {
               Generate one →
             </a>
           </p>
+          <p className="text-xs text-[var(--color-text-muted)] text-center">
+            Using an organization with SSO?{' '}
+            <a
+              href="https://github.com/settings/tokens"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--color-accent)] hover:underline"
+            >
+              Authorize the token for SSO
+            </a>{' '}
+            after generating it.
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

- Empty state in PR list now shows a link to authorize the GitHub token for SSO when no PRs are found
- Auth page adds a subtle SSO note below the token privacy line
- Sort dropdown padding changed from `px-2` to `pl-2 pr-7` so text isn't cramped against the native browser arrow

## Why

Users with GitHub org SSO tokens get no PRs silently, with no hint that they need to authorize for SSO. The Sort dropdown's native arrow was also visually cramped due to symmetric 8px padding.

---
_This pull request was created with AI assistance._