### PR TITLE
fix: handle null author on PRs and reviews

### DIFF
--- a/src/components/PRCard/PRCard.test.tsx
+++ b/src/components/PRCard/PRCard.test.tsx
@@ -30,6 +30,12 @@ beforeEach(() => {
 })
 
 describe('PRCard', () => {
+  it('GIVEN author is null WHEN rendered THEN does not crash', () => {
+    const prNoAuthor: PullRequest = { ...pr, author: null }
+    render(<PRCard pr={prNoAuthor} />)
+    expect(screen.getByText('Fix the thing')).toBeInTheDocument()
+  })
+
   it('renders opened timestamp', () => {
     render(<PRCard pr={pr} />)
     expect(screen.getByText(/opened/)).toBeInTheDocument()

--- a/src/components/PRCard/PRCard.tsx
+++ b/src/components/PRCard/PRCard.tsx
@@ -106,16 +106,18 @@ export default function PRCard({ pr }: Props) {
             {/* Meta row */}
             <div className="flex items-center flex-wrap gap-2 mt-2">
               {/* Author */}
-              <div className="flex items-center gap-1.5">
-                <img
-                  src={pr.author.avatarUrl}
-                  alt={pr.author.login}
-                  className="w-4 h-4 rounded-full"
-                />
-                <span className="text-xs text-[var(--color-text-secondary)]">
-                  {pr.author.login}
-                </span>
-              </div>
+              {pr.author && (
+                <div className="flex items-center gap-1.5">
+                  <img
+                    src={pr.author.avatarUrl}
+                    alt={pr.author.login}
+                    className="w-4 h-4 rounded-full"
+                  />
+                  <span className="text-xs text-[var(--color-text-secondary)]">
+                    {pr.author.login}
+                  </span>
+                </div>
+              )}
 
               {/* Number + age */}
               <span className="text-xs text-[var(--color-text-muted)]">

--- a/src/hooks/useGitHubPRs.test.ts
+++ b/src/hooks/useGitHubPRs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sortAndPartition } from './useGitHubPRs'
+import { sortAndPartition, deriveMyReviewState } from './useGitHubPRs'
 import type { PullRequest } from '../types/github'
 
 function makePR(id: string, createdAt: string): PullRequest {
@@ -23,6 +23,42 @@ function makePR(id: string, createdAt: string): PullRequest {
 const old = makePR('1', '2024-01-01T00:00:00Z')
 const mid = makePR('2', '2024-06-01T00:00:00Z')
 const newest = makePR('3', '2024-12-01T00:00:00Z')
+
+describe('deriveMyReviewState', () => {
+  function makePRWithReviews(reviews: PullRequest['reviews']['nodes']): PullRequest {
+    return { ...makePR('1', '2024-01-01T00:00:00Z'), reviews: { nodes: reviews } }
+  }
+
+  it('GIVEN review with null author WHEN filtering THEN does not crash', () => {
+    const pr = makePRWithReviews([
+      { state: 'APPROVED', submittedAt: '2024-01-01T00:00:00Z', author: null },
+    ])
+    const actual = deriveMyReviewState(pr, 'user')
+    expect(actual).toBeNull()
+  })
+
+  it('GIVEN mix of null and real author WHEN filtering THEN returns real author state', () => {
+    const pr = makePRWithReviews([
+      { state: 'COMMENTED', submittedAt: '2024-01-01T00:00:00Z', author: null },
+      { state: 'APPROVED', submittedAt: '2024-01-02T00:00:00Z', author: { login: 'user', avatarUrl: '' } },
+    ])
+    const actual = deriveMyReviewState(pr, 'user')
+    expect(actual).toBe('APPROVED')
+  })
+
+  it('GIVEN no reviews THEN returns null', () => {
+    const pr = makePRWithReviews([])
+    expect(deriveMyReviewState(pr, 'user')).toBeNull()
+  })
+
+  it('GIVEN multiple reviews by same user THEN returns most recent', () => {
+    const pr = makePRWithReviews([
+      { state: 'COMMENTED', submittedAt: '2024-01-01T00:00:00Z', author: { login: 'user', avatarUrl: '' } },
+      { state: 'APPROVED', submittedAt: '2024-01-03T00:00:00Z', author: { login: 'user', avatarUrl: '' } },
+    ])
+    expect(deriveMyReviewState(pr, 'user')).toBe('APPROVED')
+  })
+})
 
 describe('sortAndPartition', () => {
   describe('sort order', () => {

--- a/src/hooks/useGitHubPRs.ts
+++ b/src/hooks/useGitHubPRs.ts
@@ -33,8 +33,8 @@ function buildSearchQuery(section: string, login: string): string {
   }
 }
 
-function deriveMyReviewState(pr: PullRequest, login: string): ReviewState | null {
-  const myReviews = pr.reviews.nodes.filter((r) => r.author.login === login)
+export function deriveMyReviewState(pr: PullRequest, login: string): ReviewState | null {
+  const myReviews = pr.reviews.nodes.filter((r) => r.author?.login === login)
   if (!myReviews.length) return null
   const sorted = [...myReviews].sort(
     (a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime()

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -11,7 +11,7 @@ export interface Review {
   author: {
     login: string
     avatarUrl: string
-  }
+  } | null
   submittedAt: string
 }
 
@@ -26,7 +26,7 @@ export interface PullRequest {
   author: {
     login: string
     avatarUrl: string
-  }
+  } | null
   repository: {
     name: string
     nameWithOwner: string


### PR DESCRIPTION
## What

Handle `null` author fields returned by the GitHub GraphQL API on `PullRequest` and `Review` objects.

## Why

When a PR author is deleted or is a bot, GitHub returns `author: null`. This caused a crash (`TypeError: Cannot read properties of null (reading 'avatarUrl')`) in production on `adelbeke.github.io`.

Additionally, CORS errors were a symptom of the same root issue — the crash occurred during data processing, leaving the app in a broken state.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes