### PR TITLE
fix(filters): only show pagination warning for additive filters

### DIFF
--- a/src/components/Filters/Filters.test.tsx
+++ b/src/components/Filters/Filters.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import Filters from './Filters'
+
+vi.mock('../../hooks/useGitHubPRs', () => ({ usePullRequests: vi.fn() }))
+vi.mock('../../store/prStore', () => ({ usePRStore: vi.fn() }))
+
+import { usePullRequests } from '../../hooks/useGitHubPRs'
+import { usePRStore, type PRFilters } from '../../store/prStore'
+const mockUsePullRequests = vi.mocked(usePullRequests)
+const mockUsePRStore = vi.mocked(usePRStore)
+
+const defaultQuery = {
+  isLoading: false,
+  isFetching: false,
+  hasNextPage: true,
+  truncated: false,
+  loadedCount: 50,
+  totalCount: 100,
+  repos: [],
+}
+
+function mockStore(filterOverrides: Partial<PRFilters> = {}) {
+  const state = {
+    filters: {
+      section: 'review-requested',
+      repos: [],
+      hiddenAuthors: [],
+      showDrafts: false,
+      showHidden: false,
+      search: '',
+      ...filterOverrides,
+    } as PRFilters,
+    priorityIds: [],
+    hiddenIds: [],
+    setFilters: vi.fn(),
+    resetFilters: vi.fn(),
+    toggleHide: vi.fn(),
+    togglePriority: vi.fn(),
+    addHiddenAuthor: vi.fn(),
+    removeHiddenAuthor: vi.fn(),
+  }
+  mockUsePRStore.mockImplementation((selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUsePullRequests.mockReturnValue(defaultQuery as never)
+  mockStore()
+})
+
+describe('Filters — pagination warning', () => {
+  it('GIVEN only muted authors active THEN warning is absent', () => {
+    mockStore({ hiddenAuthors: ['renovate', 'dependabot'] })
+    render(<Filters />)
+    expect(screen.queryByText(/Filters apply to/)).not.toBeInTheDocument()
+  })
+
+  it('GIVEN repo filter selected THEN warning is present', () => {
+    mockStore({ repos: ['org/repo'] })
+    render(<Filters />)
+    expect(screen.getByText(/Filters apply to/)).toBeInTheDocument()
+  })
+
+  it('GIVEN showDrafts active THEN warning is present', () => {
+    mockStore({ showDrafts: true })
+    render(<Filters />)
+    expect(screen.getByText(/Filters apply to/)).toBeInTheDocument()
+  })
+
+  it('GIVEN showHidden active THEN warning is present', () => {
+    mockStore({ showHidden: true })
+    render(<Filters />)
+    expect(screen.getByText(/Filters apply to/)).toBeInTheDocument()
+  })
+
+  it('GIVEN no additive filters and no next page THEN warning is absent', () => {
+    mockUsePullRequests.mockReturnValue({ ...defaultQuery, hasNextPage: false } as never)
+    mockStore({ repos: ['org/repo'] })
+    render(<Filters />)
+    expect(screen.queryByText(/Filters apply to/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -105,7 +105,7 @@ export default function Filters() {
         </div>
       )}
 
-      {(filters.repos.length > 0 || filters.hiddenAuthors.length > 0) && hasNextPage && !truncated && (
+      {(filters.repos.length > 0 || filters.showDrafts || filters.showHidden) && hasNextPage && !truncated && (
         <p className="text-xs text-[var(--color-warning)]">
           ⚠ Filters apply to {loadedCount} of ~{totalCount} PRs
         </p>


### PR DESCRIPTION
## What

Restrict the "⚠ Filters apply to X of ~Y PRs" warning to additive/selective filters only (`repos`, `showDrafts`, `showHidden`). Previously it also fired when `hiddenAuthors` was non-empty, which was wrong.

## Why

Muted authors is a subtractive filter — it hides PRs you don't want to see. Unloaded pages could only contain *more* PRs to hide, which is harmless. The warning exists to alert that unloaded pages might contain PRs you *want* to see, which only applies to opt-in/additive filters.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes

---
_This pull request was created with AI assistance._