### PR TITLE
feat: CI checks badge and conflict indicator on PR cards

### DIFF
--- a/src/components/PRCard/ChecksPanel.tsx
+++ b/src/components/PRCard/ChecksPanel.tsx
@@ -1,0 +1,91 @@
+import { useRef, useEffect } from 'react'
+import { CheckCircle, XCircle, Clock, ExternalLink } from 'lucide-react'
+import type { CheckRunContext, StatusContextItem, CheckRollupState } from '../../types/github'
+
+interface Props {
+  checks: (CheckRunContext | StatusContextItem)[]
+  rollupState?: CheckRollupState | null
+  onClose: () => void
+}
+
+function CheckIcon({ check }: { check: CheckRunContext | StatusContextItem }) {
+  if (check.__typename === 'CheckRun') {
+    const { status, conclusion } = check
+    if (
+      conclusion === 'SUCCESS' ||
+      (status === 'COMPLETED' && (conclusion === 'NEUTRAL' || conclusion === 'SKIPPED'))
+    ) {
+      return <CheckCircle size={12} className="text-[var(--color-success)] shrink-0" />
+    }
+    if (
+      conclusion === 'FAILURE' ||
+      conclusion === 'TIMED_OUT' ||
+      conclusion === 'STARTUP_FAILURE' ||
+      conclusion === 'CANCELLED' ||
+      conclusion === 'ACTION_REQUIRED'
+    ) {
+      return <XCircle size={12} className="text-[var(--color-danger)] shrink-0" />
+    }
+    return <Clock size={12} className="text-[var(--color-warning)] shrink-0" />
+  }
+
+  const { state } = check
+  if (state === 'SUCCESS') return <CheckCircle size={12} className="text-[var(--color-success)] shrink-0" />
+  if (state === 'ERROR' || state === 'FAILURE') return <XCircle size={12} className="text-[var(--color-danger)] shrink-0" />
+  return <Clock size={12} className="text-[var(--color-warning)] shrink-0" />
+}
+
+export default function ChecksPanel({ checks, rollupState, onClose }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [onClose])
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute left-0 top-full mt-1 z-50 min-w-60 max-w-80 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-[var(--shadow-card-hover)] py-1"
+    >
+      {checks.length === 0 ? (
+        <p className="px-3 py-2 text-xs text-[var(--color-text-muted)]">No checks found</p>
+      ) : (
+        checks.map((check, i) => {
+          const name = check.__typename === 'CheckRun' ? check.name : check.context
+          const url = check.__typename === 'CheckRun' ? check.detailsUrl : check.targetUrl
+          return (
+            <div
+              key={i}
+              className="flex items-center gap-2 px-3 py-1.5 hover:bg-[var(--color-surface-overlay)]"
+            >
+              <CheckIcon check={check} />
+              <span className="text-xs text-[var(--color-text-secondary)] flex-1 truncate">{name}</span>
+              {url && (
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="shrink-0 text-[var(--color-text-muted)] hover:text-[var(--color-accent)]"
+                >
+                  <ExternalLink size={11} />
+                </a>
+              )}
+            </div>
+          )
+        })
+      )}
+      {(rollupState === 'PENDING' || rollupState === 'EXPECTED') && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-t border-[var(--color-border)]">
+          <Clock size={12} className="text-[var(--color-warning)] shrink-0" />
+          <span className="text-xs text-[var(--color-text-muted)]">Some checks may still be pending or not yet shown</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/PRCard/PRCard.test.tsx
+++ b/src/components/PRCard/PRCard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import PRCard from './PRCard'
 import { usePRStore } from '../../store/prStore'
-import type { PullRequest } from '../../types/github'
+import type { PullRequest, ReviewState } from '../../types/github'
 
 const pr: PullRequest = {
   id: 'pr-42',
@@ -19,6 +19,8 @@ const pr: PullRequest = {
   reviews: { nodes: [] },
   additions: 100,
   deletions: 50,
+  mergeable: 'MERGEABLE',
+  commits: { nodes: [] },
   isHidden: false,
 }
 
@@ -71,5 +73,144 @@ describe('PRCard', () => {
     const starBtn = screen.getByTitle('Remove priority')
     await user.click(starBtn)
     expect(usePRStore.getState().priorityIds).not.toContain('pr-42')
+  })
+
+  describe('ChecksPanel rollup state footer', () => {
+    const greenCheck = {
+      __typename: 'CheckRun' as const,
+      name: 'CI',
+      status: 'COMPLETED' as const,
+      conclusion: 'SUCCESS' as const,
+      detailsUrl: null,
+    }
+
+    function makePrWithRollup(state: 'PENDING' | 'EXPECTED' | 'SUCCESS') {
+      return {
+        ...pr,
+        commits: {
+          nodes: [{
+            commit: {
+              statusCheckRollup: {
+                state,
+                contexts: { nodes: [greenCheck] },
+              },
+            },
+          }],
+        },
+      }
+    }
+
+    it('GIVEN rollup EXPECTED with all-green contexts WHEN checks opened THEN footer note appears', async () => {
+      const user = userEvent.setup()
+      render(<PRCard pr={makePrWithRollup('EXPECTED')} />)
+      await user.click(screen.getByText('Checks pending'))
+      expect(screen.getByText('Some checks may still be pending or not yet shown')).toBeInTheDocument()
+    })
+
+    it('GIVEN rollup PENDING with all-green contexts WHEN checks opened THEN footer note appears', async () => {
+      const user = userEvent.setup()
+      render(<PRCard pr={makePrWithRollup('PENDING')} />)
+      await user.click(screen.getByText('Checks pending'))
+      expect(screen.getByText('Some checks may still be pending or not yet shown')).toBeInTheDocument()
+    })
+
+    it('GIVEN rollup SUCCESS WHEN checks opened THEN no footer note', async () => {
+      const user = userEvent.setup()
+      render(<PRCard pr={makePrWithRollup('SUCCESS')} />)
+      await user.click(screen.getByText('Checks pass'))
+      expect(screen.queryByText('Some checks may still be pending or not yet shown')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('review state badge', () => {
+    function prWithReview(state: ReviewState) {
+      return { ...pr, myReviewState: state }
+    }
+
+    it('GIVEN myReviewState APPROVED WHEN rendered THEN shows Approved badge', () => {
+      render(<PRCard pr={prWithReview('APPROVED')} />)
+      expect(screen.getByText('Approved')).toBeInTheDocument()
+    })
+
+    it('GIVEN myReviewState CHANGES_REQUESTED WHEN rendered THEN shows Changes requested badge', () => {
+      render(<PRCard pr={prWithReview('CHANGES_REQUESTED')} />)
+      expect(screen.getByText('Changes requested')).toBeInTheDocument()
+    })
+
+    it('GIVEN myReviewState COMMENTED WHEN rendered THEN shows Commented badge', () => {
+      render(<PRCard pr={prWithReview('COMMENTED')} />)
+      expect(screen.getByText('Commented')).toBeInTheDocument()
+    })
+
+    it('GIVEN no myReviewState WHEN rendered THEN no review badge', () => {
+      render(<PRCard pr={{ ...pr, myReviewState: null }} />)
+      expect(screen.queryByText('Approved')).not.toBeInTheDocument()
+      expect(screen.queryByText('Changes requested')).not.toBeInTheDocument()
+    })
+
+    it('GIVEN isAuthored=true with APPROVED state WHEN rendered THEN no review badge shown', () => {
+      render(<PRCard pr={prWithReview('APPROVED')} isAuthored />)
+      expect(screen.queryByText('Approved')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('CI checks badge', () => {
+    function prWithCheckState(state: 'SUCCESS' | 'FAILURE' | 'PENDING') {
+      return {
+        ...pr,
+        commits: {
+          nodes: [{
+            commit: {
+              statusCheckRollup: { state, contexts: { nodes: [] } },
+            },
+          }],
+        },
+      }
+    }
+
+    it('GIVEN SUCCESS rollup WHEN rendered THEN shows Checks pass badge', () => {
+      render(<PRCard pr={prWithCheckState('SUCCESS')} />)
+      expect(screen.getByText('Checks pass')).toBeInTheDocument()
+    })
+
+    it('GIVEN FAILURE rollup WHEN rendered THEN shows Checks failed badge', () => {
+      render(<PRCard pr={prWithCheckState('FAILURE')} />)
+      expect(screen.getByText('Checks failed')).toBeInTheDocument()
+    })
+
+    it('GIVEN PENDING rollup WHEN rendered THEN shows Checks pending badge', () => {
+      render(<PRCard pr={prWithCheckState('PENDING')} />)
+      expect(screen.getByText('Checks pending')).toBeInTheDocument()
+    })
+
+    it('GIVEN no commits WHEN rendered THEN no CI badge', () => {
+      render(<PRCard pr={{ ...pr, commits: { nodes: [] } }} />)
+      expect(screen.queryByText('Checks pass')).not.toBeInTheDocument()
+      expect(screen.queryByText('Checks failed')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('conflict badge', () => {
+    it('GIVEN mergeable CONFLICTING WHEN rendered THEN shows Conflict badge', () => {
+      render(<PRCard pr={{ ...pr, mergeable: 'CONFLICTING' }} />)
+      expect(screen.getByText('Conflict')).toBeInTheDocument()
+    })
+
+    it('GIVEN mergeable MERGEABLE WHEN rendered THEN no Conflict badge', () => {
+      render(<PRCard pr={{ ...pr, mergeable: 'MERGEABLE' }} />)
+      expect(screen.queryByText('Conflict')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('draft badge', () => {
+    it('GIVEN isDraft true WHEN rendered THEN shows Draft badge', () => {
+      render(<PRCard pr={{ ...pr, isDraft: true }} />)
+      expect(screen.getByText('Draft')).toBeInTheDocument()
+    })
+
+    it('GIVEN isDraft false WHEN rendered THEN no Draft badge', () => {
+      render(<PRCard pr={pr} />)
+      expect(screen.queryByText('Draft')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/components/PRCard/PRCard.tsx
+++ b/src/components/PRCard/PRCard.tsx
@@ -1,13 +1,24 @@
-import type { ReactElement } from 'react'
-import { GitMerge, MessageSquare, Check, AlertCircle, Star, ExternalLink, FileCode, EyeOff, Eye } from 'lucide-react'
-import type { PullRequest, ReviewState } from '../../types/github'
+import { useState, type ReactElement } from 'react'
+import { GitMerge, MessageSquare, Check, AlertCircle, Star, ExternalLink, FileCode, EyeOff, Eye, CheckCircle, XCircle, Clock } from 'lucide-react'
+import type { PullRequest, ReviewState, CheckRollupState } from '../../types/github'
 import { usePRStore } from '../../store/prStore'
 import { useAuthStore } from '../../store/authStore'
 import ReviewerAvatars from './ReviewerAvatars'
+import ChecksPanel from './ChecksPanel'
+import { deriveCheckState, deriveCheckContexts } from '../../lib/prUtils'
+import { timeAgo } from '../../lib/timeAgo'
 
 interface Props {
   pr: PullRequest
   isAuthored?: boolean
+}
+
+const ciStateBadge: Record<CheckRollupState, { label: string; color: string; bg: string; icon: ReactElement }> = {
+  SUCCESS:  { label: 'Checks pass',    color: 'text-[var(--color-success)]',  bg: 'bg-[var(--color-success-subtle)]',  icon: <CheckCircle size={11} /> },
+  FAILURE:  { label: 'Checks failed',  color: 'text-[var(--color-danger)]',   bg: 'bg-[var(--color-danger-subtle)]',   icon: <XCircle size={11} /> },
+  ERROR:    { label: 'Checks error',   color: 'text-[var(--color-danger)]',   bg: 'bg-[var(--color-danger-subtle)]',   icon: <XCircle size={11} /> },
+  PENDING:  { label: 'Checks pending', color: 'text-[var(--color-warning)]',  bg: 'bg-[var(--color-warning-subtle)]',  icon: <Clock size={11} /> },
+  EXPECTED: { label: 'Checks pending', color: 'text-[var(--color-warning)]',  bg: 'bg-[var(--color-warning-subtle)]',  icon: <Clock size={11} /> },
 }
 
 const reviewBadge: Record<
@@ -46,20 +57,9 @@ const reviewBadge: Record<
   },
 }
 
-function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime()
-  const seconds = Math.floor(diff / 1000)
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  return `${Math.floor(days / 30)}mo ago`
-}
 
 export default function PRCard({ pr, isAuthored = false }: Props) {
+  const [checksOpen, setChecksOpen] = useState(false)
   const togglePriority = usePRStore((s) => s.togglePriority)
   const toggleHide = usePRStore((s) => s.toggleHide)
   const priorityIds = usePRStore((s) => s.priorityIds)
@@ -67,6 +67,9 @@ export default function PRCard({ pr, isAuthored = false }: Props) {
   const isPriority = priorityIds.includes(pr.id)
   const isHidden = pr.isHidden ?? false
   const badge = !isAuthored && pr.myReviewState ? reviewBadge[pr.myReviewState] : null
+  const checkState = deriveCheckState(pr)
+  const ciBadge = checkState ? ciStateBadge[checkState] : null
+  const showConflict = pr.mergeable === 'CONFLICTING'
 
   return (
     <div
@@ -76,6 +79,7 @@ export default function PRCard({ pr, isAuthored = false }: Props) {
         shadow-[var(--shadow-card)] hover:shadow-[var(--shadow-card-hover)]
         transition-all duration-150
         ${isHidden ? 'opacity-50' : ''}
+        ${checksOpen ? 'z-10' : ''}
         border-[var(--color-border)]
       `}
     >
@@ -155,6 +159,30 @@ export default function PRCard({ pr, isAuthored = false }: Props) {
                 >
                   {badge.icon}
                   {badge.label}
+                </span>
+              )}
+
+              {/* CI checks badge */}
+              {ciBadge && (
+                <div className="relative">
+                  <button
+                    onClick={() => setChecksOpen((o) => !o)}
+                    className={`flex items-center gap-1 text-xs px-1.5 py-0.5 rounded cursor-pointer ${ciBadge.color} ${ciBadge.bg}`}
+                  >
+                    {ciBadge.icon}
+                    {ciBadge.label}
+                  </button>
+                  {checksOpen && (
+                    <ChecksPanel checks={deriveCheckContexts(pr)} rollupState={checkState} onClose={() => setChecksOpen(false)} />
+                  )}
+                </div>
+              )}
+
+              {/* Conflict badge */}
+              {showConflict && (
+                <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded text-[var(--color-warning)] bg-[var(--color-warning-subtle)]">
+                  <AlertCircle size={11} />
+                  Conflict
                 </span>
               )}
 

--- a/src/components/PRList/PRList.test.tsx
+++ b/src/components/PRList/PRList.test.tsx
@@ -27,6 +27,8 @@ function makePR(id: string, title: string): PullRequest {
     reviews: { nodes: [] },
     additions: 0,
     deletions: 0,
+    mergeable: 'MERGEABLE',
+    commits: { nodes: [] },
     isHidden: false,
   }
 }

--- a/src/hooks/useGitHubPRs.test.ts
+++ b/src/hooks/useGitHubPRs.test.ts
@@ -17,6 +17,8 @@ function makePR(id: string, createdAt: string): PullRequest {
     reviews: { nodes: [] },
     additions: 10,
     deletions: 5,
+    mergeable: 'MERGEABLE',
+    commits: { nodes: [] },
   }
 }
 

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { ClientError } from 'graphql-request'
+import { isAuthError } from './github'
+
+function makeClientError(opts: {
+  status?: number
+  errors?: Array<{ type?: string; message?: string }>
+}): ClientError {
+  const error = Object.create(ClientError.prototype) as ClientError
+  Object.assign(error, {
+    response: {
+      status: opts.status ?? 200,
+      errors: opts.errors ?? [],
+    },
+  })
+  return error
+}
+
+describe('isAuthError', () => {
+  it('GIVEN status 401 WHEN called THEN returns true', () => {
+    expect(isAuthError(makeClientError({ status: 401 }))).toBe(true)
+  })
+
+  it('GIVEN status 403 WHEN called THEN returns true', () => {
+    expect(isAuthError(makeClientError({ status: 403 }))).toBe(true)
+  })
+
+  it('GIVEN error type FORBIDDEN WHEN called THEN returns true', () => {
+    expect(isAuthError(makeClientError({ errors: [{ type: 'FORBIDDEN' }] }))).toBe(true)
+  })
+
+  it('GIVEN error message Bad credentials WHEN called THEN returns true', () => {
+    expect(isAuthError(makeClientError({ errors: [{ message: 'Bad credentials' }] }))).toBe(true)
+  })
+
+  it('GIVEN unrelated ClientError WHEN called THEN returns false', () => {
+    expect(isAuthError(makeClientError({ status: 500 }))).toBe(false)
+  })
+
+  it('GIVEN non-ClientError WHEN called THEN returns false', () => {
+    expect(isAuthError(new Error('network error'))).toBe(false)
+  })
+
+  it('GIVEN null WHEN called THEN returns false', () => {
+    expect(isAuthError(null)).toBe(false)
+  })
+})

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -51,6 +51,32 @@ export const PULL_REQUESTS_QUERY = /* GraphQL */ `
           updatedAt
           additions
           deletions
+          mergeable
+          commits(last: 1) {
+            nodes {
+              commit {
+                statusCheckRollup {
+                  state
+                  contexts(first: 100) {
+                    nodes {
+                      __typename
+                      ... on CheckRun {
+                        name
+                        status
+                        conclusion
+                        detailsUrl
+                      }
+                      ... on StatusContext {
+                        context
+                        state
+                        targetUrl
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
           author {
             login
             avatarUrl

--- a/src/lib/prUtils.test.ts
+++ b/src/lib/prUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { PullRequest } from '../types/github'
-import { deriveReviewerSummary } from './prUtils'
+import { deriveReviewerSummary, buildSearchQuery, deriveCheckState, deriveCheckContexts } from './prUtils'
 
 function makePR(overrides: Partial<PullRequest> = {}): PullRequest {
   return {
@@ -17,9 +17,108 @@ function makePR(overrides: Partial<PullRequest> = {}): PullRequest {
     reviews: { nodes: [] },
     additions: 0,
     deletions: 0,
+    mergeable: 'MERGEABLE',
+    commits: { nodes: [] },
     ...overrides,
   }
 }
+
+describe('buildSearchQuery', () => {
+  it('GIVEN review-requested section WHEN called THEN includes review-requested filter', () => {
+    const actual = buildSearchQuery('review-requested', 'alice')
+    expect(actual).toContain('review-requested:alice')
+    expect(actual).toContain('is:open is:pr archived:false')
+  })
+
+  it('GIVEN authored section WHEN called THEN includes author filter', () => {
+    const actual = buildSearchQuery('authored', 'alice')
+    expect(actual).toContain('author:alice')
+  })
+
+  it('GIVEN mentioned section WHEN called THEN includes mentions filter', () => {
+    const actual = buildSearchQuery('mentioned', 'alice')
+    expect(actual).toContain('mentions:alice')
+  })
+
+  it('GIVEN unknown section WHEN called THEN falls back to review-requested', () => {
+    const actual = buildSearchQuery('unknown', 'alice')
+    expect(actual).toContain('review-requested:alice')
+  })
+})
+
+describe('deriveCheckState', () => {
+  it('GIVEN PR with no commits WHEN called THEN returns null', () => {
+    const pr = makePR({ commits: { nodes: [] } })
+    expect(deriveCheckState(pr)).toBeNull()
+  })
+
+  it('GIVEN PR with null statusCheckRollup WHEN called THEN returns null', () => {
+    const pr = makePR({
+      commits: { nodes: [{ commit: { statusCheckRollup: null } }] },
+    })
+    expect(deriveCheckState(pr)).toBeNull()
+  })
+
+  it('GIVEN PR with SUCCESS rollup WHEN called THEN returns SUCCESS', () => {
+    const pr = makePR({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: { state: 'SUCCESS', contexts: { nodes: [] } },
+          },
+        }],
+      },
+    })
+    expect(deriveCheckState(pr)).toBe('SUCCESS')
+  })
+
+  it('GIVEN PR with FAILURE rollup WHEN called THEN returns FAILURE', () => {
+    const pr = makePR({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: { state: 'FAILURE', contexts: { nodes: [] } },
+          },
+        }],
+      },
+    })
+    expect(deriveCheckState(pr)).toBe('FAILURE')
+  })
+})
+
+describe('deriveCheckContexts', () => {
+  it('GIVEN PR with no commits WHEN called THEN returns empty array', () => {
+    const pr = makePR({ commits: { nodes: [] } })
+    expect(deriveCheckContexts(pr)).toEqual([])
+  })
+
+  it('GIVEN PR with null statusCheckRollup WHEN called THEN returns empty array', () => {
+    const pr = makePR({
+      commits: { nodes: [{ commit: { statusCheckRollup: null } }] },
+    })
+    expect(deriveCheckContexts(pr)).toEqual([])
+  })
+
+  it('GIVEN PR with check contexts WHEN called THEN returns those nodes', () => {
+    const checkNode = {
+      __typename: 'CheckRun' as const,
+      name: 'CI',
+      status: 'COMPLETED' as const,
+      conclusion: 'SUCCESS' as const,
+      detailsUrl: null,
+    }
+    const pr = makePR({
+      commits: {
+        nodes: [{
+          commit: {
+            statusCheckRollup: { state: 'SUCCESS', contexts: { nodes: [checkNode] } },
+          },
+        }],
+      },
+    })
+    expect(deriveCheckContexts(pr)).toEqual([checkNode])
+  })
+})
 
 describe('deriveReviewerSummary', () => {
   it('GIVEN empty reviews and requests WHEN called THEN all buckets are empty', () => {

--- a/src/lib/prUtils.ts
+++ b/src/lib/prUtils.ts
@@ -1,4 +1,4 @@
-import type { PullRequest, ReviewState } from '../types/github'
+import type { PullRequest, ReviewState, CheckRollupState, CheckRunContext, StatusContextItem } from '../types/github'
 
 export interface Reviewer {
   login: string
@@ -62,6 +62,14 @@ export function deriveReviewerSummary(pr: PullRequest, authorLogin: string): Rev
   }
 
   return buckets
+}
+
+export function deriveCheckState(pr: PullRequest): CheckRollupState | null {
+  return pr.commits.nodes[0]?.commit?.statusCheckRollup?.state ?? null
+}
+
+export function deriveCheckContexts(pr: PullRequest): (CheckRunContext | StatusContextItem)[] {
+  return pr.commits.nodes[0]?.commit?.statusCheckRollup?.contexts.nodes ?? []
 }
 
 export function sortAndPartition(

--- a/src/lib/timeAgo.test.ts
+++ b/src/lib/timeAgo.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { timeAgo } from './timeAgo'
+
+const NOW = new Date('2024-06-01T12:00:00Z').getTime()
+
+afterEach(() => vi.useRealTimers())
+
+function freeze() {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+}
+
+function dateSecondsAgo(s: number) {
+  return new Date(NOW - s * 1000).toISOString()
+}
+
+describe('timeAgo', () => {
+  it('GIVEN date 30s ago WHEN called THEN returns Xs ago', () => {
+    freeze()
+    expect(timeAgo(dateSecondsAgo(30))).toBe('30s ago')
+  })
+
+  it('GIVEN date 5m ago WHEN called THEN returns Xm ago', () => {
+    freeze()
+    expect(timeAgo(dateSecondsAgo(5 * 60))).toBe('5m ago')
+  })
+
+  it('GIVEN date 3h ago WHEN called THEN returns Xh ago', () => {
+    freeze()
+    expect(timeAgo(dateSecondsAgo(3 * 3600))).toBe('3h ago')
+  })
+
+  it('GIVEN date 10d ago WHEN called THEN returns Xd ago', () => {
+    freeze()
+    expect(timeAgo(dateSecondsAgo(10 * 86400))).toBe('10d ago')
+  })
+
+  it('GIVEN date 2mo ago WHEN called THEN returns Xmo ago', () => {
+    freeze()
+    expect(timeAgo(dateSecondsAgo(60 * 86400))).toBe('2mo ago')
+  })
+})

--- a/src/lib/timeAgo.ts
+++ b/src/lib/timeAgo.ts
@@ -1,0 +1,12 @@
+export function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return `${Math.floor(days / 30)}mo ago`
+}

--- a/src/store/authStore.test.ts
+++ b/src/store/authStore.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAuthStore } from './authStore'
+
+const user = { login: 'alice', avatarUrl: 'https://example.com/alice.png', name: 'Alice' }
+
+beforeEach(() => {
+  useAuthStore.setState({ token: null, user: null, sessionExpired: false })
+})
+
+describe('authStore', () => {
+  it('setToken sets token and clears sessionExpired', () => {
+    useAuthStore.setState({ sessionExpired: true })
+    useAuthStore.getState().setToken('tok123')
+    const state = useAuthStore.getState()
+    expect(state.token).toBe('tok123')
+    expect(state.sessionExpired).toBe(false)
+  })
+
+  it('setUser sets user object', () => {
+    useAuthStore.getState().setUser(user)
+    expect(useAuthStore.getState().user).toEqual(user)
+  })
+
+  it('logout clears token, user, and sessionExpired', () => {
+    useAuthStore.setState({ token: 'tok', user, sessionExpired: true })
+    useAuthStore.getState().logout()
+    const state = useAuthStore.getState()
+    expect(state.token).toBeNull()
+    expect(state.user).toBeNull()
+    expect(state.sessionExpired).toBe(false)
+  })
+
+  it('expireSession sets sessionExpired true and clears token and user', () => {
+    useAuthStore.setState({ token: 'tok', user })
+    useAuthStore.getState().expireSession()
+    const state = useAuthStore.getState()
+    expect(state.sessionExpired).toBe(true)
+    expect(state.token).toBeNull()
+    expect(state.user).toBeNull()
+  })
+})

--- a/src/store/prStore.test.ts
+++ b/src/store/prStore.test.ts
@@ -69,4 +69,27 @@ describe('prStore', () => {
     usePRStore.getState().removeHiddenAuthor('unknown')
     expect(usePRStore.getState().filters.hiddenAuthors).toHaveLength(1)
   })
+
+  it('toggleHide adds id when not hidden', () => {
+    usePRStore.getState().toggleHide('pr-1')
+    expect(usePRStore.getState().hiddenIds).toContain('pr-1')
+  })
+
+  it('toggleHide removes id when already hidden', () => {
+    usePRStore.getState().toggleHide('pr-1')
+    usePRStore.getState().toggleHide('pr-1')
+    expect(usePRStore.getState().hiddenIds).not.toContain('pr-1')
+  })
+
+  it('resetFilters resets all filters to defaults', () => {
+    usePRStore.getState().setFilters({ search: 'foo', section: 'authored', showDrafts: true })
+    usePRStore.getState().resetFilters()
+    const { filters } = usePRStore.getState()
+    expect(filters.search).toBe('')
+    expect(filters.section).toBe('review-requested')
+    expect(filters.showDrafts).toBe(false)
+    expect(filters.repos).toEqual([])
+    expect(filters.hiddenAuthors).toEqual([])
+    expect(filters.showHidden).toBe(false)
+  })
 })

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,4 +1,24 @@
 export type ReviewState = 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'PENDING' | 'DISMISSED'
+export type MergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+export type CheckRollupState = 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED'
+export type CheckRunConclusion =
+  | 'ACTION_REQUIRED' | 'CANCELLED' | 'FAILURE' | 'NEUTRAL'
+  | 'SKIPPED' | 'STALE' | 'SUCCESS' | 'TIMED_OUT' | 'STARTUP_FAILURE' | null
+
+export interface CheckRunContext {
+  __typename: 'CheckRun'
+  name: string
+  status: 'QUEUED' | 'IN_PROGRESS' | 'COMPLETED' | 'WAITING' | 'REQUESTED' | 'PENDING'
+  conclusion: CheckRunConclusion
+  detailsUrl: string | null
+}
+
+export interface StatusContextItem {
+  __typename: 'StatusContext'
+  context: string
+  state: CheckRollupState
+  targetUrl: string | null
+}
 
 export interface ReviewRequest {
   requestedReviewer:
@@ -40,6 +60,17 @@ export interface PullRequest {
   }
   additions: number
   deletions: number
+  mergeable: MergeableState
+  commits: {
+    nodes: {
+      commit: {
+        statusCheckRollup: {
+          state: CheckRollupState
+          contexts: { nodes: (CheckRunContext | StatusContextItem)[] }
+        } | null
+      }
+    }[]
+  }
   // Derived / local fields (not from API)
   isTopPriority?: boolean
   myReviewState?: ReviewState | null


### PR DESCRIPTION
## What

- Added `statusCheckRollup` + `mergeable` fields to the GitHub GraphQL query
- New `ChecksPanel` dropdown component listing individual checks with pass/fail/pending icons
- CI badge and conflict badge rendered on `PRCard`, CI badge opens `ChecksPanel` on click
- Extracted `timeAgo` from `PRCard` into its own module (`src/lib/timeAgo.ts`)
- New types: `MergeableState`, `CheckRollupState`, `CheckRunContext`, `StatusContextItem`
- New utils: `deriveCheckState`, `deriveCheckContexts`
- Tests for all new logic (timeAgo, prUtils, github query, stores, PRCard badges)

## Why

PR cards had no visibility into CI status or merge conflicts. Reviewers had to open GitHub to check whether checks passed or if a branch had conflicts.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes

---
_This pull request was created with AI assistance._