### PR TITLE
feat: improve trust signals and privacy messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Client-only GitHub PR dashboard. No backend. Talks directly to the GitHub GraphQ
 - Filter by your own review state: changes requested / commented / not reviewed
 - Star PRs as **top priority** — pinned to a separate section
 - Hide PRs you don't care about; toggle to show drafts / hidden
-- PR cards show repo, author, diff size, draft + review-state badges, relative timestamps
+- PR cards show repo, author, diff size, draft + review-state badges, CI status, conflict indicator, relative timestamps
 - PAT stored in `localStorage`, never sent to any server; auto sign-out on token expiry
 
 ## Quick start

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { X } from 'lucide-react'
+import { Lock, X } from 'lucide-react'
 import { usePRStore, type PRSection } from '../../store/prStore'
 import { usePullRequests } from '../../hooks/useGitHubPRs'
 
@@ -145,6 +145,12 @@ export default function Filters() {
         )}
       </div>
 
+      <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center cursor-default">
+        <Lock size={16} className="text-[var(--color-text-muted)]" />
+        <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+          Your GitHub token is never transmitted or shared. It only lives in your localStorage.
+        </p>
+      </div>
     </aside>
   )
 }

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { Lock } from 'lucide-react'
 import { createGitHubClient, VIEWER_QUERY } from '../lib/github'
 import { useAuthStore } from '../store/authStore'
 import type { GitHubUser } from '../types/github'
@@ -43,7 +44,7 @@ export default function AuthPage() {
             Donna
           </h1>
           <p className="mt-2 text-sm text-[var(--color-text-secondary)]">
-            Your PR assistant
+            The GitHub PR inbox you actually want to open.
           </p>
         </div>
 
@@ -72,6 +73,21 @@ export default function AuthPage() {
             </p>
           )}
 
+          <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center">
+            <Lock size={16} className="text-[var(--color-text-muted)]" />
+            <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+              Your GitHub token is never transmitted or shared. It only lives in your localStorage.{' '}
+              <a
+                href="https://github.com/settings/tokens/new?scopes=repo,read:org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--color-accent)] hover:underline"
+              >
+                Generate one →
+              </a>
+            </p>
+          </div>
+
           <button
             onClick={handleConnect}
             disabled={loading || !token.trim()}
@@ -79,18 +95,6 @@ export default function AuthPage() {
           >
             {loading ? 'Connecting…' : 'Connect'}
           </button>
-
-          <p className="text-xs text-[var(--color-text-muted)] text-center">
-            Your token is stored locally and never sent to any server.{' '}
-            <a
-              href="https://github.com/settings/tokens/new?scopes=repo,read:org"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--color-accent)] hover:underline"
-            >
-              Generate one →
-            </a>
-          </p>
           <p className="text-xs text-[var(--color-text-muted)] text-center">
             Using an organization with SSO?{' '}
             <a

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -14,9 +14,11 @@ export default function DashboardPage() {
       {/* Top navbar */}
       <header className="sticky top-0 z-10 border-b border-[var(--color-border)] bg-[var(--color-surface-raised)]/90 backdrop-blur-sm shadow-[0_1px_8px_0_rgba(0,0,0,0.4)] px-6 py-3">
         <div className="max-w-6xl mx-auto flex items-center justify-between gap-4">
-          <h1 className="text-sm font-semibold text-[var(--color-text-primary)] tracking-tight shrink-0">
-            Donna
-          </h1>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <h1 className="text-sm font-semibold text-[var(--color-text-primary)] tracking-tight">
+              Donna
+            </h1>
+          </div>
 
           <div className="relative flex-1 max-w-sm mx-auto">
             <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]" />


### PR DESCRIPTION
## What

Add prominent privacy/trust badges with a Lock icon on the auth page and filters sidebar. Update the auth page tagline. Minor heading wrapper fix in DashboardPage. README updated to reflect existing CI/conflict features.

## Why

The previous token disclaimer was easy to miss (small text below the button). Making it a distinct badge with an icon improves user trust and reduces friction for new users hesitant to enter a PAT.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes

---
_This pull request was created with AI assistance._