### PR TITLE
fix: replace Events API with /user/repos; eliminate N+1 commit fetches

### DIFF
--- a/src/hooks/useBranches.ts
+++ b/src/hooks/useBranches.ts
@@ -35,7 +35,7 @@ export function useBranches(repos: string[]) {
             if (chunk.length < 100) break
           }
 
-          const filtered = allBranches.filter((b) => !DEFAULT_BRANCHES.has(b.name))
+          const filtered = allBranches.filter((b) => !DEFAULT_BRANCHES.has(b.name as string))
           if (filtered.length === 0) return []
 
           const allPrs: Record<string, unknown>[] = []

--- a/src/hooks/useBranches.ts
+++ b/src/hooks/useBranches.ts
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAuthStore } from '../store/authStore'
+import type { Branch } from '../types/github'
+
+const GH = 'https://api.github.com'
+const DEFAULT_BRANCHES = new Set(['main', 'master', 'develop', 'development', 'staging', 'production'])
+
+export function useBranches(repos: string[]) {
+  const token = useAuthStore((s) => s.token)
+  const login = useAuthStore((s) => s.user?.login)
+
+  return useQuery<Branch[]>({
+    queryKey: ['branches', repos],
+    enabled: !!token && repos.length > 0,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const headers = {
+        Authorization: `Bearer ${token!}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      }
+      const getList = async (path: string): Promise<any[]> => {
+        const r = await fetch(`${GH}${path}`, { headers })
+        if (!r.ok) return []
+        const d = await r.json()
+        return Array.isArray(d) ? d : []
+      }
+
+      const perRepo = await Promise.all(
+        repos.map(async (repo) => {
+          const allBranches: any[] = []
+          for (let page = 1; ; page++) {
+            const chunk = await getList(`/repos/${repo}/branches?per_page=100&page=${page}`)
+            allBranches.push(...chunk)
+            if (chunk.length < 100) break
+          }
+
+          const filtered = allBranches.filter((b) => !DEFAULT_BRANCHES.has(b.name))
+          if (filtered.length === 0) return []
+
+          const allPrs: any[] = []
+          for (let page = 1; page <= 3; page++) {
+            const chunk = await getList(`/repos/${repo}/pulls?state=all&per_page=100&page=${page}`)
+            allPrs.push(...chunk)
+            if (chunk.length < 100) break
+          }
+
+          const prByBranch = new Map<string, { number: number; state: string }>(
+            allPrs.map((pr: any) => [
+              pr.head.ref,
+              { number: pr.number, state: pr.merged_at ? 'MERGED' : pr.state.toUpperCase() },
+            ])
+          )
+
+          return filtered
+            .filter((b: any) => !login || b.commit.author?.login === login)
+            .map((b: any): Branch => ({
+              name: b.name,
+              repo,
+              lastCommitDate: b.commit.commit.author.date,
+              linkedPr: prByBranch.get(b.name),
+            }))
+        })
+      )
+
+      return perRepo
+        .flat()
+        .sort((a, b) => new Date(b.lastCommitDate).getTime() - new Date(a.lastCommitDate).getTime())
+    },
+  })
+}

--- a/src/hooks/useBranches.ts
+++ b/src/hooks/useBranches.ts
@@ -19,7 +19,7 @@ export function useBranches(repos: string[]) {
         Accept: 'application/vnd.github+json',
         'X-GitHub-Api-Version': '2022-11-28',
       }
-      const getList = async (path: string): Promise<any[]> => {
+      const getList = async (path: string): Promise<Record<string, unknown>[]> => {
         const r = await fetch(`${GH}${path}`, { headers })
         if (!r.ok) return []
         const d = await r.json()
@@ -28,7 +28,7 @@ export function useBranches(repos: string[]) {
 
       const perRepo = await Promise.all(
         repos.map(async (repo) => {
-          const allBranches: any[] = []
+          const allBranches: Record<string, unknown>[] = []
           for (let page = 1; ; page++) {
             const chunk = await getList(`/repos/${repo}/branches?per_page=100&page=${page}`)
             allBranches.push(...chunk)
@@ -38,7 +38,7 @@ export function useBranches(repos: string[]) {
           const filtered = allBranches.filter((b) => !DEFAULT_BRANCHES.has(b.name))
           if (filtered.length === 0) return []
 
-          const allPrs: any[] = []
+          const allPrs: Record<string, unknown>[] = []
           for (let page = 1; page <= 3; page++) {
             const chunk = await getList(`/repos/${repo}/pulls?state=all&per_page=100&page=${page}`)
             allPrs.push(...chunk)
@@ -46,20 +46,30 @@ export function useBranches(repos: string[]) {
           }
 
           const prByBranch = new Map<string, { number: number; state: string }>(
-            allPrs.map((pr: any) => [
-              pr.head.ref,
-              { number: pr.number, state: pr.merged_at ? 'MERGED' : pr.state.toUpperCase() },
+            allPrs.map((pr) => [
+              (pr.head as Record<string, unknown>).ref as string,
+              {
+                number: pr.number as number,
+                state: pr.merged_at ? 'MERGED' : (pr.state as string).toUpperCase(),
+              },
             ])
           )
 
           return filtered
-            .filter((b: any) => !login || b.commit.author?.login === login)
-            .map((b: any): Branch => ({
-              name: b.name,
-              repo,
-              lastCommitDate: b.commit.commit.author.date,
-              linkedPr: prByBranch.get(b.name),
-            }))
+            .filter((b) => {
+              const author = (b.commit as Record<string, unknown>).author as Record<string, unknown> | null
+              return !login || author?.login === login
+            })
+            .map((b): Branch => {
+              const commit = b.commit as Record<string, unknown>
+              const inner = (commit.commit as Record<string, unknown>).author as Record<string, unknown>
+              return {
+                name: b.name as string,
+                repo,
+                lastCommitDate: inner.date as string,
+                linkedPr: prByBranch.get(b.name as string),
+              }
+            })
         })
       )
 

--- a/src/hooks/useRepos.ts
+++ b/src/hooks/useRepos.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAuthStore } from '../store/authStore'
+
+const GH = 'https://api.github.com'
+
+export type Repo = { full_name: string; name: string }
+
+export function useRepos() {
+  const token = useAuthStore((s) => s.token)
+
+  return useQuery<Repo[]>({
+    queryKey: ['repos'],
+    enabled: !!token,
+    staleTime: 5 * 60_000,
+    queryFn: async () => {
+      const headers = {
+        Authorization: `Bearer ${token!}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      }
+      const repos: any[] = []
+      for (let page = 1; page <= 3; page++) {
+        const r = await fetch(
+          `${GH}/user/repos?affiliation=owner,collaborator&sort=pushed&per_page=100&page=${page}`,
+          { headers }
+        )
+        if (!r.ok) break
+        const chunk = await r.json()
+        repos.push(...chunk)
+        if (chunk.length < 100) break
+      }
+      return repos.map((r) => ({ full_name: r.full_name, name: r.name }))
+    },
+  })
+}

--- a/src/hooks/useRepos.ts
+++ b/src/hooks/useRepos.ts
@@ -18,7 +18,7 @@ export function useRepos() {
         Accept: 'application/vnd.github+json',
         'X-GitHub-Api-Version': '2022-11-28',
       }
-      const repos: any[] = []
+      const repos: Repo[] = []
       for (let page = 1; page <= 3; page++) {
         const r = await fetch(
           `${GH}/user/repos?affiliation=owner,collaborator&sort=pushed&per_page=100&page=${page}`,

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -36,18 +36,20 @@ export default function DashboardPage() {
             </div>
           )}
 
-          <div className="flex items-center gap-1 shrink-0">
-            {(['prs', 'branches'] as const).map((v) => (
-              <button key={v} onClick={() => setView(v)}
-                className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
-                  ${view === v
-                    ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
-                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)]'
-                  }`}>
-                {v === 'prs' ? 'Pull Requests' : 'Branches'}
-              </button>
-            ))}
-          </div>
+          {BRANCHES_ENABLED && (
+            <div className="flex items-center gap-1 shrink-0">
+              {(['prs', 'branches'] as const).map((v) => (
+                <button key={v} onClick={() => setView(v)}
+                  className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
+                    ${view === v
+                      ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
+                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)]'
+                    }`}>
+                  {v === 'prs' ? 'Pull Requests' : 'Branches'}
+                </button>
+              ))}
+            </div>
+          )}
 
           <div className="relative flex-1 max-w-sm mx-auto">
             <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]" />

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -36,6 +36,19 @@ export default function DashboardPage() {
             </div>
           )}
 
+          <div className="flex items-center gap-1 shrink-0">
+            {(['prs', 'branches'] as const).map((v) => (
+              <button key={v} onClick={() => setView(v)}
+                className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
+                  ${view === v
+                    ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
+                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)]'
+                  }`}>
+                {v === 'prs' ? 'Pull Requests' : 'Branches'}
+              </button>
+            ))}
+          </div>
+
           <div className="relative flex-1 max-w-sm mx-auto">
             <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]" />
             <input

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -82,3 +82,10 @@ export interface GitHubUser {
   avatarUrl: string
   name: string
 }
+
+export type Branch = {
+  name: string
+  repo: string
+  lastCommitDate: string
+  linkedPr?: { number: number; state: string }
+}


### PR DESCRIPTION
## Summary
- `useRepos`: replace `/users/${login}/events` (capped at 90 events/90 days) with `/user/repos?affiliation=owner,collaborator&sort=pushed&per_page=100` — paginate up to 3 pages, no recency cap
- `useBranches`: drop `Promise.all` of per-branch `/commits/` fetches (O(n) extra requests); read `b.commit.commit.author.date` and `b.commit.author?.login` already present in the `/branches` response

## Test plan
- [ ] `npm test` passes
- [ ] Browse Branches tab → DevTools Network shows no `/repos/.../commits/` requests, only `/repos/.../branches` and `/repos/.../pulls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)