### PR TITLE
feat: delete branch action

### DIFF
--- a/src/components/BranchList/BranchCard.test.tsx
+++ b/src/components/BranchList/BranchCard.test.tsx
@@ -27,7 +27,7 @@ const branch: Branch = {
   name: 'feat-x',
   repo: 'org/repo',
   lastCommitDate: '2024-01-01T00:00:00Z',
-  linkedPr: null,
+  linkedPr: undefined,
 }
 
 beforeEach(() => {

--- a/src/components/BranchList/BranchCard.test.tsx
+++ b/src/components/BranchList/BranchCard.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BranchCard } from './BranchList'
+import * as useDeleteBranchModule from '../../hooks/useDeleteBranch'
+import type { Branch } from '../../types/github'
+
+const mockMutate = vi.fn()
+
+function mockHook(overrides: Partial<ReturnType<typeof useDeleteBranchModule.useDeleteBranch>> = {}) {
+  vi.spyOn(useDeleteBranchModule, 'useDeleteBranch').mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useDeleteBranchModule.useDeleteBranch>)
+  if (Object.keys(overrides).length) {
+    vi.spyOn(useDeleteBranchModule, 'useDeleteBranch').mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      isError: false,
+      ...overrides,
+    } as unknown as ReturnType<typeof useDeleteBranchModule.useDeleteBranch>)
+  }
+}
+
+const branch: Branch = {
+  name: 'feat-x',
+  repo: 'org/repo',
+  lastCommitDate: '2024-01-01T00:00:00Z',
+  linkedPr: null,
+}
+
+beforeEach(() => {
+  mockMutate.mockReset()
+  mockHook()
+})
+
+describe('BranchCard', () => {
+  it('GIVEN a branch WHEN rendered THEN shows trash button', () => {
+    render(<BranchCard branch={branch} />)
+    expect(screen.getByTitle('Delete branch')).toBeInTheDocument()
+  })
+
+  it('GIVEN trash clicked WHEN confirming THEN shows confirm UI', async () => {
+    const user = userEvent.setup()
+    render(<BranchCard branch={branch} />)
+    await user.click(screen.getByTitle('Delete branch'))
+    expect(screen.getByText('Delete branch?')).toBeInTheDocument()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+    expect(screen.getByText('Delete')).toBeInTheDocument()
+  })
+
+  it('GIVEN cancel clicked WHEN confirming THEN reverts to default state', async () => {
+    const user = userEvent.setup()
+    render(<BranchCard branch={branch} />)
+    await user.click(screen.getByTitle('Delete branch'))
+    await user.click(screen.getByText('Cancel'))
+    expect(screen.queryByText('Delete branch?')).not.toBeInTheDocument()
+    expect(screen.getByTitle('Delete branch')).toBeInTheDocument()
+  })
+
+  it('GIVEN branch has open PR WHEN confirming THEN warns about it', async () => {
+    const user = userEvent.setup()
+    const branchWithPr: Branch = { ...branch, linkedPr: { number: 42, state: 'OPEN', url: 'https://github.com/org/repo/pull/42' } }
+    render(<BranchCard branch={branchWithPr} />)
+    await user.click(screen.getByTitle('Delete branch'))
+    expect(screen.getByText('Has open PR #42')).toBeInTheDocument()
+  })
+
+  it('GIVEN confirm clicked WHEN deleting THEN calls mutate with correct args', async () => {
+    const user = userEvent.setup()
+    render(<BranchCard branch={branch} />)
+    await user.click(screen.getByTitle('Delete branch'))
+    await user.click(screen.getByText('Delete'))
+    expect(mockMutate).toHaveBeenCalledWith(
+      { repo: 'org/repo', name: 'feat-x' },
+      expect.objectContaining({ onSettled: expect.any(Function) })
+    )
+  })
+
+  it('GIVEN delete fails WHEN rendered THEN shows error message', () => {
+    mockHook({ isError: true })
+    render(<BranchCard branch={branch} />)
+    expect(screen.getByText('Delete failed. Try again.')).toBeInTheDocument()
+  })
+})

--- a/src/components/BranchList/BranchList.tsx
+++ b/src/components/BranchList/BranchList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Copy, RefreshCw } from 'lucide-react'
+import { Copy, Loader2, RefreshCw, Trash2 } from 'lucide-react'
 import { useBranches } from '../../hooks/useBranches'
+import { useDeleteBranch } from '../../hooks/useDeleteBranch'
 import { useRecentRepos } from '../../hooks/useRecentRepos'
 import { usePRStore } from '../../store/prStore'
 import { useBranchStore } from '../../store/branchStore'
@@ -21,13 +22,61 @@ function CopyButton({ text, title }: { text: string; title: string }) {
 }
 
 function BranchCard({ branch }: { branch: Branch }) {
+  const { mutate: deleteBranch, isPending, isError } = useDeleteBranch()
+  const [confirming, setConfirming] = useState(false)
+
   return (
     <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-4 py-3 space-y-2">
-      <div className="flex items-baseline gap-2">
-        <span className="text-xs text-[var(--color-text-muted)]">{branch.repo}</span>
-        <span className="text-sm font-medium text-[var(--color-text-primary)] font-mono">{branch.name}</span>
-        <span className="ml-auto text-xs text-[var(--color-text-muted)]">{timeAgo(branch.lastCommitDate)}</span>
+      <div className="flex items-center gap-2">
+        <div className="flex items-baseline gap-2 min-w-0 flex-1">
+          <span className="text-xs text-[var(--color-text-muted)] shrink-0">{branch.repo}</span>
+          <span className="text-sm font-medium text-[var(--color-text-primary)] font-mono truncate">{branch.name}</span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0 h-6">
+          {confirming ? (
+            <>
+              {branch.linkedPr?.state === 'OPEN' && (
+                <span className="text-xs text-[var(--color-danger)]">
+                  Has open PR #{branch.linkedPr.number}
+                </span>
+              )}
+              <span className="text-xs text-[var(--color-text-muted)]">Delete branch?</span>
+              <button
+                onClick={() => setConfirming(false)}
+                className="text-xs px-2 py-0.5 rounded border border-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() =>
+                  deleteBranch(
+                    { repo: branch.repo, name: branch.name },
+                    { onSettled: () => setConfirming(false) }
+                  )
+                }
+                disabled={isPending}
+                className="text-xs px-2 py-0.5 rounded border border-[var(--color-danger)] text-[var(--color-danger)] hover:bg-[var(--color-danger)] hover:text-white transition-colors cursor-pointer disabled:opacity-40"
+              >
+                {isPending ? <Loader2 size={12} className="animate-spin" /> : 'Delete'}
+              </button>
+            </>
+          ) : (
+            <>
+              <span className="text-xs text-[var(--color-text-muted)]">{timeAgo(branch.lastCommitDate)}</span>
+              <button
+                onClick={() => setConfirming(true)}
+                title="Delete branch"
+                className="transition-colors cursor-pointer text-[var(--color-text-muted)] hover:text-[var(--color-danger)]"
+              >
+                <Trash2 size={14} />
+              </button>
+            </>
+          )}
+        </div>
       </div>
+      {isError && (
+        <span className="text-xs text-[var(--color-danger)]">Delete failed. Try again.</span>
+      )}
       <div className="flex gap-2 flex-wrap">
         <CopyButton text={`git switch ${branch.name}`} title="Copy git switch command" />
         {branch.linkedPr?.state === 'OPEN' && (

--- a/src/components/BranchList/BranchList.tsx
+++ b/src/components/BranchList/BranchList.tsx
@@ -21,7 +21,7 @@ function CopyButton({ text, title }: { text: string; title: string }) {
   )
 }
 
-function BranchCard({ branch }: { branch: Branch }) {
+export function BranchCard({ branch }: { branch: Branch }) {
   const { mutate: deleteBranch, isPending, isError } = useDeleteBranch()
   const [confirming, setConfirming] = useState(false)
 

--- a/src/hooks/useDeleteBranch.test.ts
+++ b/src/hooks/useDeleteBranch.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import React from 'react'
+import { useDeleteBranch } from './useDeleteBranch'
+import { useAuthStore } from '../store/authStore'
+
+vi.mock('../store/authStore', () => ({
+  useAuthStore: vi.fn(),
+}))
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return { wrapper: ({ children }: { children: React.ReactNode }) => React.createElement(QueryClientProvider, { client: qc }, children), qc }
+}
+
+beforeEach(() => {
+  vi.mocked(useAuthStore).mockImplementation((selector) =>
+    selector({ token: 'tok', user: { login: 'alice' } } as never)
+  )
+  mockFetch.mockReset()
+})
+
+describe('useDeleteBranch', () => {
+  it('GIVEN valid token WHEN deleting THEN calls correct GitHub endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true })
+    const { wrapper } = makeWrapper()
+
+    const { result } = renderHook(() => useDeleteBranch(), { wrapper })
+    await act(async () => { result.current.mutate({ repo: 'org/myrepo', name: 'feat-x' }) })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/org/myrepo/git/refs/heads/feat-x',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({ Authorization: 'Bearer tok' }),
+      })
+    )
+  })
+
+  it('GIVEN branches in cache WHEN deleting THEN optimistically removes the matching branch', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true })
+    const { wrapper, qc } = makeWrapper()
+    qc.setQueryData(['branches', 'org/repo'], [
+      { name: 'feat-x', repo: 'org/repo' },
+      { name: 'feat-y', repo: 'org/repo' },
+    ])
+
+    const { result } = renderHook(() => useDeleteBranch(), { wrapper })
+    act(() => { result.current.mutate({ repo: 'org/repo', name: 'feat-x' }) })
+
+    await waitFor(() => {
+      const cached = qc.getQueryData<{ name: string }[]>(['branches', 'org/repo'])
+      return cached?.every((b) => b.name !== 'feat-x')
+    })
+  })
+
+  it('GIVEN API returns non-ok WHEN deleting THEN mutation errors', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 422 })
+    const { wrapper } = makeWrapper()
+
+    const { result } = renderHook(() => useDeleteBranch(), { wrapper })
+    await act(async () => { result.current.mutate({ repo: 'org/repo', name: 'feat-x' }) })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect((result.current.error as Error).message).toContain('422')
+  })
+})

--- a/src/hooks/useDeleteBranch.ts
+++ b/src/hooks/useDeleteBranch.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '../store/authStore'
+
+export function useDeleteBranch() {
+  const token = useAuthStore((s) => s.token)
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ repo, name }: { repo: string; name: string }) => {
+      const [owner, repoName] = repo.split('/')
+      const res = await fetch(
+        `https://api.github.com/repos/${owner}/${repoName}/git/refs/heads/${name}`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        }
+      )
+      if (!res.ok) throw new Error(`Delete failed: ${res.status}`)
+    },
+    onMutate: async ({ repo, name }) => {
+      await queryClient.cancelQueries({ queryKey: ['branches'] })
+      queryClient.setQueriesData<{ name: string; repo: string }[]>(
+        { queryKey: ['branches'] },
+        (old) => old?.filter((b) => !(b.name === name && b.repo === repo)) ?? []
+      )
+    },
+    onError: () => {
+      queryClient.invalidateQueries({ queryKey: ['branches'] })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['branches'] })
+    },
+  })
+}


### PR DESCRIPTION
## What

Add a delete branch button to each row in the BranchList, with a confirm step before deletion.

## Why

Branches pile up after merging. This lets users clean them up without leaving the dashboard.

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes