### PR TITLE
feat: release workflow + electron-builder config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+
+jobs:
+  bump:
+    if: github.actor == 'adelbeke'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      branch: ${{ steps.v.outputs.branch }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm }
+      - name: Bump version
+        id: v
+        run: |
+          git config user.email "${{ secrets.GIT_USER_EMAIL }}"
+          git config user.name "${{ secrets.GIT_USER_NAME }}"
+          npm version ${{ inputs.version_type }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          BRANCH="release/v$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          git checkout -b "$BRANCH"
+          git add package.json package-lock.json
+          git commit -m "chore: release v$VERSION"
+          git push origin "$BRANCH"
+
+  build:
+    needs: bump
+    if: github.actor == 'adelbeke'
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: mac
+          - os: windows-latest
+            platform: win
+          - os: ubuntu-latest
+            platform: linux
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.branch }}
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm }
+      - run: npm install
+      - run: npx electron-vite build
+      - run: npx electron-builder --${{ matrix.platform }}
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.platform }}
+          path: release/**/*
+          retention-days: 1
+
+  release:
+    needs: [bump, build]
+    if: github.actor == 'adelbeke'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push tag
+        run: |
+          git config user.email "${{ secrets.GIT_USER_EMAIL }}"
+          git config user.name "${{ secrets.GIT_USER_NAME }}"
+          git tag "v${{ needs.bump.outputs.version }}"
+          git push origin "v${{ needs.bump.outputs.version }}"
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: artifacts
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.bump.outputs.version }}
+          name: v${{ needs.bump.outputs.version }}
+          generate_release_notes: true
+          files: artifacts/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pr:
+    needs: [bump, release]
+    if: github.actor == 'adelbeke'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create PR
+        run: |
+          gh pr create \
+            --title "chore: release v${{ needs.bump.outputs.version }}" \
+            --body "Merge version bump for v${{ needs.bump.outputs.version }} (released)." \
+            --base main \
+            --head "${{ needs.bump.outputs.branch }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,15 @@
+appId: com.dbkable.donna
+productName: Donna
+directories:
+  output: release
+files:
+  - out/**/*
+mac:
+  target:
+    - target: dmg
+      arch: [x64, arm64]
+  category: public.app-category.developer-tools
+win:
+  target: nsis
+linux:
+  target: AppImage


### PR DESCRIPTION
## Summary
- Add `electron-builder.yml` (dmg/nsis/AppImage targets)
- Add `.github/workflows/release.yml` (bump → build matrix → release → PR)

## Flow
`workflow_dispatch (patch|minor|major)` → branch `release/vX.Y.Z` → parallel builds (mac/win/linux) → GitHub Release with artifacts → PR back to main