### PR TITLE
ci: mac-only release, fix notarization env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: release-mac
-          path: release/**/*
+          path: |
+            release/*.dmg
+            release/*.blockmap
           retention-days: 1
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,17 +44,7 @@ jobs:
     if: github.actor == 'adelbeke'
     permissions:
       contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            platform: mac
-          - os: windows-latest
-            platform: win
-          - os: ubuntu-latest
-            platform: linux
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,16 +53,16 @@ jobs:
         with: { node-version: 20, cache: npm }
       - run: npm install
       - run: npx electron-vite build
-      - run: npx electron-builder --${{ matrix.platform }}
+      - run: npx electron-builder --mac
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       - uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.platform }}
+          name: release-mac
           path: release/**/*
           retention-days: 1
 
@@ -95,7 +85,7 @@ jobs:
           git push origin "v${{ needs.bump.outputs.version }}"
       - uses: actions/download-artifact@v4
         with:
-          pattern: release-*
+          pattern: release-mac
           merge-multiple: true
           path: artifacts
       - uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         with: { node-version: 20, cache: npm }
       - run: npm install
       - run: npx electron-vite build
-      - run: npx electron-builder --mac
+      - run: npx electron-builder --mac --publish never
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  cleanup:
+    needs: [bump, build, release]
+    if: failure() && needs.bump.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete release branch
+        run: git push origin --delete "${{ needs.bump.outputs.branch }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   pr:
     needs: [bump, release]
     if: github.actor == 'adelbeke'

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,7 +9,3 @@ mac:
     - target: dmg
       arch: [x64, arm64]
   category: public.app-category.developer-tools
-win:
-  target: nsis
-linux:
-  target: AppImage


### PR DESCRIPTION
## What

Remove Linux and Windows from the release matrix, keep Mac only. Fix Mac notarization failure by mapping `APPLE_ID_PASSWORD` secret to the correct `APPLE_APP_SPECIFIC_PASSWORD` env var that electron-builder actually reads.

## Why

- Linux build was failing: `GH_TOKEN` not set (electron-builder trying to publish)
- Mac build was failing: `APPLE_APP_SPECIFIC_PASSWORD` env var missing for notarization
- Linux/Windows not needed for now

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes

---
_This pull request was created with AI assistance._