### PR TITLE
fix: open external links in system browser

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron'
 import { spawn, execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
@@ -117,6 +117,11 @@ function createWindow() {
       preload: path.join(__dirname, '../preload/index.js'),
       contextIsolation: true,
     },
+  })
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url)
+    return { action: 'deny' }
   })
 
   if (!app.isPackaged) {


### PR DESCRIPTION
## Summary

Links clicked in the app were opening inside Electron instead of the system browser. Fixes it via `shell.openExternal`.

## Test plan

- [ ] Click an external link in the app → opens in system browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)