### PR TITLE
fix: use electron-vite dev for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "dev": "vite",
     "dev:web": "vite",
-    "dev:electron": "electron .",
+    "dev:electron": "electron-vite dev",
     "build": "tsc -b && vite build",
     "build:web": "tsc -b && vite build",
     "build:electron": "electron-vite build && electron-builder",


### PR DESCRIPTION
## Summary

`npm run dev:electron` was broken: `electron .` looks for `out/main/index.js` which only exists after `electron-vite build`. Switching to `electron-vite dev` builds and watches on the fly.

No impact on the release pipeline (`build:electron` is unchanged).

## Test plan

- [ ] `npm run dev:electron` starts without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)