### PR TITLE
fix: use main as target_commitish for release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           tag_name: v${{ needs.bump.outputs.version }}
           name: v${{ needs.bump.outputs.version }}
           generate_release_notes: true
+          target_commitish: main
           files: artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `generate_release_notes: true` without `target_commitish` was generating notes against the release branch commit (not `main`), causing GitHub to dump the full PR history on every release
- Adding `target_commitish: main` makes GitHub correctly scope the notes to PRs merged since the previous tag

## Test plan
- [ ] Next release should only include PRs merged since the previous tag