### PR TITLE
feat: hide token privacy note in Electron

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-qu
 import { Terminal } from 'lucide-react'
 import { useAuthStore } from './store/authStore'
 import { isAuthError, VIEWER_QUERY } from './lib/github'
+import { isElectron } from './lib/electron'
 import AuthPage from './pages/AuthPage'
 import DashboardPage from './pages/DashboardPage'
 import type { GitHubUser } from './types/github'
@@ -35,8 +36,6 @@ function ElectronAuthError({ message, onRetry }: { message: string; onRetry: () 
     </div>
   )
 }
-
-const isElectron = !!window.electronAPI
 
 async function tryElectronAuth(
   setToken: (t: string) => void,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-qu
 import { Terminal } from 'lucide-react'
 import { useAuthStore } from './store/authStore'
 import { isAuthError, VIEWER_QUERY } from './lib/github'
-import { isElectron } from './lib/electron'
+import { IS_ELECTRON } from './lib/electron'
 import AuthPage from './pages/AuthPage'
 import DashboardPage from './pages/DashboardPage'
 import type { GitHubUser } from './types/github'
@@ -56,7 +56,7 @@ async function tryElectronAuth(
 
 function AppContent() {
   const { token, setToken, setUser } = useAuthStore()
-  const [ghChecking, setGhChecking] = useState(() => isElectron && !token)
+  const [ghChecking, setGhChecking] = useState(() => IS_ELECTRON && !token)
   const [ghError, setGhError] = useState<string | null>(null)
 
   const runElectronAuth = useCallback(() => {
@@ -68,7 +68,7 @@ function AppContent() {
   }, [setToken, setUser])
 
   useEffect(() => {
-    if (!isElectron || token) return
+    if (!IS_ELECTRON || token) return
     // eslint-disable-next-line react-hooks/set-state-in-effect
     runElectronAuth()
   // ponytail: run once; token excluded so re-auth on next open uses cached token
@@ -77,7 +77,7 @@ function AppContent() {
 
   if (ghChecking) return null
 
-  if (isElectron) {
+  if (IS_ELECTRON) {
     if (ghError) return <ElectronAuthError message={ghError} onRetry={runElectronAuth} />
     return <DashboardPage />
   }

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Lock, X } from 'lucide-react'
 import { usePRStore, type PRSection } from '../../store/prStore'
 import { usePullRequests } from '../../hooks/useGitHubPRs'
-import { isElectron } from '../../lib/electron'
+import { IS_ELECTRON } from '../../lib/electron'
 
 const SECTIONS: { id: PRSection; label: string }[] = [
   { id: 'review-requested', label: 'Review requested' },
@@ -146,7 +146,7 @@ export default function Filters() {
         )}
       </div>
 
-      {!isElectron && (
+      {!IS_ELECTRON && (
         <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center cursor-default">
           <Lock size={16} className="text-[var(--color-text-muted)]" />
           <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -3,6 +3,8 @@ import { Lock, X } from 'lucide-react'
 import { usePRStore, type PRSection } from '../../store/prStore'
 import { usePullRequests } from '../../hooks/useGitHubPRs'
 
+const isElectron = !!window.electronAPI
+
 const SECTIONS: { id: PRSection; label: string }[] = [
   { id: 'review-requested', label: 'Review requested' },
   { id: 'authored', label: 'My PRs' },
@@ -145,12 +147,14 @@ export default function Filters() {
         )}
       </div>
 
-      <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center cursor-default">
-        <Lock size={16} className="text-[var(--color-text-muted)]" />
-        <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
-          Your GitHub token is never transmitted or shared. It only lives in your localStorage.
-        </p>
-      </div>
+      {!isElectron && (
+        <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center cursor-default">
+          <Lock size={16} className="text-[var(--color-text-muted)]" />
+          <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+            Your GitHub token is never transmitted or shared. It only lives in your localStorage.
+          </p>
+        </div>
+      )}
     </aside>
   )
 }

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react'
 import { Lock, X } from 'lucide-react'
 import { usePRStore, type PRSection } from '../../store/prStore'
 import { usePullRequests } from '../../hooks/useGitHubPRs'
-
-const isElectron = !!window.electronAPI
+import { isElectron } from '../../lib/electron'
 
 const SECTIONS: { id: PRSection; label: string }[] = [
   { id: 'review-requested', label: 'Review requested' },

--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -1,1 +1,1 @@
-export const isElectron = !!window.electronAPI
+export const IS_ELECTRON = !!window.electronAPI

--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -1,0 +1,1 @@
+export const isElectron = !!window.electronAPI

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { LogOut, Search, X } from 'lucide-react'
 import { useAuthStore } from '../store/authStore'
 import { usePRStore } from '../store/prStore'
+import { isElectron } from '../lib/electron'
 import Filters from '../components/Filters/Filters'
 import PRList from '../components/PRList/PRList'
 import BranchList from '../components/BranchList/BranchList'
@@ -22,7 +23,7 @@ export default function DashboardPage() {
           </div>
 
           <div className="flex items-center gap-1 shrink-0">
-              {(['prs', ...(window.electronAPI ? ['branches' as const] : [])] as const).map((v) => (
+              {(['prs', ...(isElectron ? ['branches' as const] : [])] as const).map((v) => (
                 <button key={v} onClick={() => setView(v)}
                   className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
                     ${view === v
@@ -63,7 +64,7 @@ export default function DashboardPage() {
               <span className="text-xs text-[var(--color-text-secondary)]">
                 {user.login}
               </span>
-              {!window.electronAPI && (
+              {!isElectron && (
                 <button
                   onClick={logout}
                   title="Disconnect"

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { LogOut, Search, X } from 'lucide-react'
 import { useAuthStore } from '../store/authStore'
 import { usePRStore } from '../store/prStore'
-import { isElectron } from '../lib/electron'
+import { IS_ELECTRON } from '../lib/electron'
 import Filters from '../components/Filters/Filters'
 import PRList from '../components/PRList/PRList'
 import BranchList from '../components/BranchList/BranchList'
@@ -23,7 +23,7 @@ export default function DashboardPage() {
           </div>
 
           <div className="flex items-center gap-1 shrink-0">
-              {(['prs', ...(isElectron ? ['branches' as const] : [])] as const).map((v) => (
+              {(['prs', ...(IS_ELECTRON ? ['branches' as const] : [])] as const).map((v) => (
                 <button key={v} onClick={() => setView(v)}
                   className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
                     ${view === v
@@ -64,7 +64,7 @@ export default function DashboardPage() {
               <span className="text-xs text-[var(--color-text-secondary)]">
                 {user.login}
               </span>
-              {!isElectron && (
+              {!IS_ELECTRON && (
                 <button
                   onClick={logout}
                   title="Disconnect"


### PR DESCRIPTION
## Summary

- Hides the "token lives in localStorage" privacy note in the Filters panel when running as Electron
- Irrelevant in Electron since auth is handled via `gh` CLI, no token is entered

## Test plan

- [ ] `npm run dev:electron` → open Filters panel → privacy note should be gone
- [ ] `npm run dev` (web) → open Filters panel → privacy note should still be visible