### PR TITLE
feat: update available banner and version in footer

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import pkg from './package.json'
 
 export default defineConfig({
   main: {
@@ -19,5 +20,6 @@ export default defineConfig({
     root: '.',
     plugins: [react(), tailwindcss()],
     build: { rollupOptions: { input: 'index.html' } },
+    define: { __APP_VERSION__: JSON.stringify(pkg.version) },
   },
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const queryClient = new QueryClient({
   },
 })
 
+
 function ElectronAuthError({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
     <div className="min-h-screen bg-[var(--color-surface)] flex flex-col items-center justify-center gap-4 p-8">

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -18,6 +18,8 @@ export default function Footer() {
       >
         Buy me a coffee
       </a>
+      <span className="mx-2">—</span>
+      <span>v{__APP_VERSION__}</span>
     </footer>
   )
 }

--- a/src/hooks/useUpdateCheck.test.tsx
+++ b/src/hooks/useUpdateCheck.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
-import React from 'react'
 import { isNewer } from './useUpdateCheck'
 
 describe('isNewer', () => {

--- a/src/hooks/useUpdateCheck.test.tsx
+++ b/src/hooks/useUpdateCheck.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { isNewer } from './useUpdateCheck'
+
+describe('isNewer', () => {
+  it('returns true when latest is ahead', () => {
+    expect(isNewer('v0.2.0', '0.1.0')).toBe(true)
+    expect(isNewer('v0.1.1', '0.1.0')).toBe(true)
+    expect(isNewer('v1.0.0', '0.9.9')).toBe(true)
+  })
+
+  it('returns false when current is same or ahead', () => {
+    expect(isNewer('v0.1.0', '0.1.0')).toBe(false)
+    expect(isNewer('v0.1.0', '0.2.0')).toBe(false)
+  })
+})
+
+// Inline minimal banner to avoid importing App-level deps
+function UpdateBanner({ version, onDismiss }: { version: string; onDismiss: () => void }) {
+  return (
+    <div>
+      <span>Version {version} is available.</span>
+      <button onClick={onDismiss}>✕</button>
+    </div>
+  )
+}
+
+describe('UpdateBanner', () => {
+  it('renders the version', () => {
+    render(<UpdateBanner version="v1.2.3" onDismiss={() => {}} />)
+    expect(screen.getByText('Version v1.2.3 is available.')).toBeInTheDocument()
+  })
+
+  it('calls onDismiss when ✕ is clicked', () => {
+    let dismissed = false
+    render(<UpdateBanner version="v1.2.3" onDismiss={() => { dismissed = true }} />)
+    fireEvent.click(screen.getByText('✕'))
+    expect(dismissed).toBe(true)
+  })
+})

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+
+export function isNewer(latest: string, current: string) {
+  const a = latest.replace(/^v/, '').split('.').map(Number)
+  const b = current.replace(/^v/, '').split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return true
+    if (a[i] < b[i]) return false
+  }
+  return false
+}
+
+export function useUpdateCheck() {
+  return useQuery({
+    queryKey: ['update-check'],
+    queryFn: async () => {
+      try {
+        const data = await window.electronAPI!.gh.rest('repos/adelbeke/donna/releases/latest')
+        return (data as { tag_name: string }).tag_name
+      } catch {
+        return null
+      }
+    },
+    staleTime: 60 * 60 * 1000,
+    enabled: !!window.electronAPI,
+  })
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { LogOut, Search, X } from 'lucide-react'
 import { useAuthStore } from '../store/authStore'
 import { usePRStore } from '../store/prStore'
@@ -5,10 +6,27 @@ import Filters from '../components/Filters/Filters'
 import PRList from '../components/PRList/PRList'
 import BranchList from '../components/BranchList/BranchList'
 import Footer from '../components/Footer/Footer'
+import { useUpdateCheck, isNewer } from '../hooks/useUpdateCheck'
+
+function UpdateBanner({ version }: { version: string }) {
+  const [dismissed, setDismissed] = useState(false)
+  if (dismissed) return null
+  return (
+    <div className="flex items-center justify-between px-4 py-2 text-xs bg-[var(--color-accent)] text-white">
+      <span>Version {version} is available.</span>
+      <span className="flex items-center gap-3">
+        <a href="https://github.com/adelbeke/donna/releases/latest" target="_blank" rel="noopener noreferrer" className="underline">Download</a>
+        <button onClick={() => setDismissed(true)}>✕</button>
+      </span>
+    </div>
+  )
+}
 
 export default function DashboardPage() {
   const { user, logout } = useAuthStore()
   const { filters, setFilters, view, setView } = usePRStore()
+  const { data: latestVersion } = useUpdateCheck()
+  const showBanner = latestVersion && isNewer(latestVersion, __APP_VERSION__)
 
   return (
     <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)] flex flex-col">
@@ -76,6 +94,8 @@ export default function DashboardPage() {
           )}
         </div>
       </header>
+
+      {showBanner && <UpdateBanner version={latestVersion} />}
 
       {/* Main layout */}
       <main className="flex-1 max-w-6xl mx-auto px-6 py-8 w-full">

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,4 +1,5 @@
 // Global augmentation — no imports/exports so TypeScript treats this as a script
+declare const __APP_VERSION__: string
 interface Window {
   electronAPI?: {
     gh: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import pkg from './package.json'
 
 export default defineConfig({
   base: '/donna/',
@@ -10,6 +11,7 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  define: { __APP_VERSION__: JSON.stringify(pkg.version) },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary

- Adds a dismissable banner below the header when a newer GitHub release is available
- Uses `gh` CLI for the release check (authenticated — no rate-limit issues)
- Injects `__APP_VERSION__` at build time via Vite `define` in both web and Electron configs
- Displays current version (`vX.Y.Z`) in the footer

## Test plan

- [ ] `npm run dev:electron` → banner appears below header when a newer release exists
- [ ] Clicking ✕ dismisses the banner (reappears on next launch until updated)
- [ ] Clicking Download opens the releases page in the system browser
- [ ] Footer shows correct version in both web and Electron