### PR TITLE
feat: add light theme with CSS variables and toggle

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+export function useTheme() {
+  const [theme, setTheme] = useState<'dark' | 'light'>(
+    () => (localStorage.getItem('theme') as 'dark' | 'light') ?? 'dark'
+  )
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme === 'light' ? 'light' : ''
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  return { theme, toggle: () => setTheme(t => t === 'dark' ? 'light' : 'dark') }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -26,3 +26,26 @@
 html, body {
   background-color: var(--color-surface);
 }
+
+[data-theme="light"] {
+  --color-surface: #ffffff;
+  --color-surface-raised: #f6f8fa;
+  --color-surface-overlay: #eaeef2;
+  --color-border: #d0d7de;
+  --color-border-subtle: #eaeef2;
+  --color-text-primary: #1f2328;
+  --color-text-secondary: #57606a;
+  --color-text-muted: #5c6370;
+  --color-accent: #0969da;
+  --color-accent-subtle: #ddf4ff;
+  --color-success: #1a7f37;
+  --color-success-subtle: #dafbe1;
+  --color-warning: #9a6700;
+  --color-warning-subtle: #fff8c5;
+  --color-danger: #cf222e;
+  --color-danger-subtle: #ffebe9;
+  --color-priority: #8250df;
+  --color-priority-subtle: #fbefff;
+  --shadow-card: 0 1px 3px 0 rgba(0,0,0,0.1);
+  --shadow-card-hover: 0 4px 12px 0 rgba(0,0,0,0.15);
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
-import { LogOut, Search, X } from 'lucide-react'
+import { LogOut, Moon, Search, Sun, X } from 'lucide-react'
 import { useAuthStore } from '../store/authStore'
 import { usePRStore } from '../store/prStore'
+import { useTheme } from '../hooks/useTheme'
 import { IS_ELECTRON } from '../lib/electron'
 import Filters from '../components/Filters/Filters'
 import PRList from '../components/PRList/PRList'
@@ -37,11 +38,12 @@ export default function DashboardPage() {
   const { filters, setFilters, view, setView } = usePRStore()
   const { data: latestVersion } = useUpdateCheck()
   const showBanner = latestVersion && isNewer(latestVersion, __APP_VERSION__)
+  const { theme, toggle } = useTheme()
 
   return (
     <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)] flex flex-col">
       {/* Top navbar */}
-      <header className="sticky top-0 z-10 border-b border-[var(--color-border)] bg-[var(--color-surface-raised)]/90 backdrop-blur-sm shadow-[0_1px_8px_0_rgba(0,0,0,0.4)] px-6 py-3">
+      <header className="sticky top-0 z-10 border-b border-[var(--color-border)] bg-[var(--color-surface-raised)]/90 backdrop-blur-sm px-6 py-3">
         <div className="max-w-6xl mx-auto flex items-center justify-between gap-4">
           <div className="flex items-center gap-1.5 shrink-0">
             <h1 className="text-sm font-semibold text-[var(--color-text-primary)] tracking-tight">
@@ -91,6 +93,13 @@ export default function DashboardPage() {
               <span className="text-xs text-[var(--color-text-secondary)]">
                 {user.login}
               </span>
+              <button
+                onClick={toggle}
+                title="Toggle theme"
+                className="p-1.5 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
+              >
+                {theme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
+              </button>
               {!IS_ELECTRON && (
                 <button
                   onClick={logout}


### PR DESCRIPTION
## What

Adds a light theme to the dashboard via CSS custom properties, a `useTheme` hook, and a Sun/Moon toggle button in the header.

## Why

Dark-only UI is limiting. Light theme improves usability in bright environments. Colors are sourced from GitHub Primer's light palette for consistency.

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes