### PR TITLE
fix: fetch full git history in release job to fix empty changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           ref: ${{ needs.bump.outputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
       - name: Create and push tag
         run: |
           git config user.email "${{ secrets.GIT_USER_EMAIL }}"


### PR DESCRIPTION
## What

Add `fetch-depth: 0` to the `checkout` step in the `release` job.

## Why

The release job used a shallow clone (default `fetch-depth: 1`), so previous tags were never fetched. `PREV_TAG` resolved to an empty string, causing `git log "..HEAD"` to return nothing — empty changelog in every release.

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes

---
_This pull request was created with AI assistance._