### PR TITLE
fix: include PR numbers and GitHub authors in release changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,17 +95,21 @@ jobs:
           path: artifacts
       - name: Generate changelog
         id: changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PREV_TAG=$(git tag --sort=-v:refname | grep -v "^v${{ needs.bump.outputs.version }}$" | head -1)
           echo "Previous tag: $PREV_TAG"
 
           get_entries() {
             local prefix="$1"
-            git log --pretty=format:"%s" "${PREV_TAG}..HEAD" \
+            git log --pretty=format:"%s|%H" "${PREV_TAG}..HEAD" \
               | grep "^${prefix}:" \
-              | sed "s/^${prefix}: //" \
-              | sed 's/ (#[0-9]*)//' \
-              | sed 's/^/- /'
+              | while IFS='|' read -r subject sha; do
+                  CLEAN=$(echo "$subject" | sed "s/^${prefix}: //")
+                  AUTHOR=$(gh api "/repos/$GITHUB_REPOSITORY/commits/$sha" --jq '.author.login // .commit.author.name' 2>/dev/null)
+                  echo "- $CLEAN @$AUTHOR"
+                done
           }
 
           FEATURES=$(get_entries "feat")


### PR DESCRIPTION
## What

Rework the changelog generator in the `release` job to preserve PR numbers and resolve contributor GitHub logins.

## Why

The previous script stripped `(#42)` references via `sed` and never captured author info — releases showed bare bullet points with no traceability.

## How

- `git log` now outputs `%s|%H` (subject + SHA)
- For each commit, `gh api /repos/$GITHUB_REPOSITORY/commits/$sha` resolves the GitHub login
- Format: `- feat description (#42) @username`
- Added `GH_TOKEN` env on the step so `gh api` is authenticated

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes

---
_This pull request was created with AI assistance._