### PR TITLE
feat: add copy-to-clipboard button for branch name

### DIFF
--- a/src/components/BranchList/BranchList.tsx
+++ b/src/components/BranchList/BranchList.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { usePRStore } from '../../store/prStore'
 import { useBranchStore } from '../../store/branchStore'
 import { usePullRequests } from '../../hooks/useGitHubPRs'
+import { CopyWithFeedback } from '../shared/CopyWithFeedback'
 import type { Worktree } from '../../types/worktree'
 import type { PullRequest } from '../../types/github'
 
@@ -27,6 +28,7 @@ function BranchCard({
           {repo}
         </span>
         <span className="text-sm font-medium text-[var(--color-text-primary)] font-mono">{branch}</span>
+        <CopyWithFeedback text={branch} label="Copy branch name" />
         {worktree && (
           <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-[var(--color-accent-subtle)] text-[var(--color-accent)]">
             worktree

--- a/src/components/shared/CopyWithFeedback.tsx
+++ b/src/components/shared/CopyWithFeedback.tsx
@@ -1,0 +1,43 @@
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+
+const FEEDBACK_DURATION_DEFAULT_DELAY = 3000
+// Matches Tailwind's default transition-opacity duration
+const TOOLTIP_TRANSITION_MS = 150
+
+export function CopyWithFeedback({
+  text,
+  label,
+  feedbackDuration = FEEDBACK_DURATION_DEFAULT_DELAY,
+}: {
+  text: string
+  label: string
+  feedbackDuration?: number
+}) {
+  const [copied, setCopied] = useState(false)
+  const [showCopied, setShowCopied] = useState(false)
+
+  function handleCopy() {
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    setShowCopied(true)
+    setTimeout(() => {
+      setCopied(false)
+      setTimeout(() => setShowCopied(false), TOOLTIP_TRANSITION_MS)
+    }, feedbackDuration)
+  }
+
+  return (
+    <div className="relative group">
+      <button
+        onClick={handleCopy}
+        className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer"
+      >
+        {showCopied ? <Check size={13} className="text-green-500" /> : <Copy size={13} />}
+      </button>
+      <span className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none transition-opacity ${copied ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
+        {showCopied ? 'Copied!' : label}
+      </span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a copy icon button next to branch names in the Branches view
- Clicking it copies the branch name to the clipboard
- Shows a GitHub-style tooltip with "Copied!" feedback: icon swaps to a checkmark, tooltip text changes, then the tooltip fades out before the text resets (avoids a visual glitch on reset)

## New component

`src/components/shared/CopyWithFeedback.tsx` — reusable component that takes `text`, `label`, and optional `feedbackDuration` (defaults to 3s).

## Test plan

- [x] Click the copy icon next to a branch name, paste somewhere to confirm the branch name was copied
- [x] Hover over the icon to see the "Copy branch name" tooltip
- [x] After clicking, confirm the icon becomes a checkmark and tooltip reads "Copied!"
- [x] After 3s, confirm tooltip fades out cleanly without the text flickering back

## Preview

https://github.com/user-attachments/assets/0db8bd27-de54-4a54-88c7-901f4494d04d

Feedbacks are welcome.
🤖 Generated with [Claude Code](https://claude.com/claude-code)