### PR TITLE
fix: prevent OTA banner from missing update-downloaded event on mount

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -135,12 +135,16 @@ function createWindow() {
 }
 
 ipcMain.handle('update:install', () => autoUpdater.quitAndInstall())
+// ponytail: flag so the banner can catch updates downloaded before it mounts
+let updateDownloaded = false
+ipcMain.handle('update:is-downloaded', () => updateDownloaded)
 
 app.whenReady().then(() => {
   createWindow()
   if (app.isPackaged) {
     autoUpdater.checkForUpdates()
     autoUpdater.on('update-downloaded', () => {
+      updateDownloaded = true
       BrowserWindow.getAllWindows().forEach(w => w.webContents.send('update:downloaded'))
     })
   }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -19,5 +19,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   updater: {
     onUpdateDownloaded: (cb: () => void) => ipcRenderer.on('update:downloaded', cb),
     installUpdate: (): Promise<void> => ipcRenderer.invoke('update:install'),
+    isUpdateDownloaded: (): Promise<boolean> => ipcRenderer.invoke('update:is-downloaded'),
   },
 })

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -15,6 +15,8 @@ function UpdateBanner({ version }: { version: string }) {
   const [downloaded, setDownloaded] = useState(false)
 
   useEffect(() => {
+    // Check if update was already downloaded before this banner mounted (race condition)
+    window.electronAPI?.updater?.isUpdateDownloaded().then(setDownloaded)
     window.electronAPI?.updater?.onUpdateDownloaded(() => setDownloaded(true))
   }, [])
 
@@ -24,7 +26,7 @@ function UpdateBanner({ version }: { version: string }) {
       <span>Version {version} is available.</span>
       <span className="flex items-center gap-3">
         {downloaded
-          ? <button className="underline" onClick={() => window.electronAPI?.updater?.installUpdate()}>Restart to install</button>
+          ? <button className="underline cursor-pointer" onClick={() => window.electronAPI?.updater?.installUpdate()}>Restart to install</button>
           : <a href="https://github.com/adelbeke/donna/releases/latest" target="_blank" rel="noopener noreferrer" className="underline">Download</a>
         }
         <button onClick={() => setDismissed(true)}>✕</button>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -19,6 +19,7 @@ interface Window {
     updater: {
       onUpdateDownloaded: (cb: () => void) => void
       installUpdate: () => Promise<void>
+      isUpdateDownloaded: () => Promise<boolean>
     }
   }
 }


### PR DESCRIPTION
## Summary

- `autoUpdater` can download and fire `update:downloaded` IPC before `UpdateBanner` mounts (it waits for a REST call to complete), causing the event to be missed and the banner to show "Download" instead of "Restart to install"
- Fix: persist a `updateDownloaded` flag in the main process + expose `update:is-downloaded` IPC handler so the banner can poll current state on mount
- Also adds `cursor-pointer` on the "Restart to install" button

Fixes #63

## Test plan

- [ ] Build and install a release; verify the banner shows "Restart to install" when a newer version is available and has been downloaded

## Preview

<img width="1272" height="126" alt="Screenshot 2026-06-25 at 19 14 55" src="https://github.com/user-attachments/assets/84c08461-050e-4505-bae8-02dd7f180ab8" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)