### PR TITLE
chore: add prettier with CI auto-format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,46 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
       - run: npm install
-      - run: npm run lint
-      - run: npm run test:run
-      - run: npm run build
+
+      - name: Format
+        id: format
+        run: |
+          npm run format
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet; then
+            git add -A
+            git commit -m "style: auto-format with prettier"
+            git push origin HEAD:${{ github.head_ref || github.ref_name }}
+            echo "formatted=true" >> $GITHUB_OUTPUT
+          else
+            echo "formatted=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Lint
+        if: steps.format.outputs.formatted == 'false'
+        run: npm run lint
+
+      - name: Test
+        if: steps.format.outputs.formatted == 'false'
+        run: npm run test:run
+
+      - name: Build
+        if: steps.format.outputs.formatted == 'false'
+        run: npm run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist/
+out/
+node_modules/
+*.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 dist/
 out/
 node_modules/
+package-lock.json
 *.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "semi": false
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,12 +7,9 @@ import path from 'node:path'
 const execFileAsync = promisify(execFile)
 
 // ponytail: augment PATH so macOS .app bundles find gh via Homebrew/nix paths
-const GH_PATH = [
-  '/opt/homebrew/bin',
-  '/usr/local/bin',
-  '/usr/bin',
-  process.env.PATH,
-].filter(Boolean).join(':')
+const GH_PATH = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', process.env.PATH]
+  .filter(Boolean)
+  .join(':')
 
 function runGh(args: string[], stdinData?: string): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -59,24 +56,46 @@ function gitError(e: unknown): Error {
 
 ipcMain.handle('worktrees:list', async (_e, repoPath: string) => {
   try {
-    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'worktree', 'list', '--porcelain'])
+    const { stdout } = await execFileAsync('git', [
+      '-C',
+      repoPath,
+      'worktree',
+      'list',
+      '--porcelain',
+    ])
     const worktrees = parseWorktrees(stdout)
-    return await Promise.all(worktrees.map(async (wt) => {
-      try {
-        const { stdout: status } = await execFileAsync('git', ['-C', wt.path, 'status', '--porcelain'])
-        return { ...wt, isDirty: status.trim().length > 0 }
-      } catch {
-        return { ...wt, isDirty: false }
-      }
-    }))
-  } catch (e) { throw gitError(e) }
+    return await Promise.all(
+      worktrees.map(async (wt) => {
+        try {
+          const { stdout: status } = await execFileAsync('git', [
+            '-C',
+            wt.path,
+            'status',
+            '--porcelain',
+          ])
+          return { ...wt, isDirty: status.trim().length > 0 }
+        } catch {
+          return { ...wt, isDirty: false }
+        }
+      })
+    )
+  } catch (e) {
+    throw gitError(e)
+  }
 })
 
 ipcMain.handle('branches:list', async (_e, repoPath: string) => {
   try {
-    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'branch', '--format=%(refname:short)'])
+    const { stdout } = await execFileAsync('git', [
+      '-C',
+      repoPath,
+      'branch',
+      '--format=%(refname:short)',
+    ])
     return stdout.trim().split('\n').filter(Boolean)
-  } catch (e) { throw gitError(e) }
+  } catch (e) {
+    throw gitError(e)
+  }
 })
 
 ipcMain.handle('dialog:open', async () => {
@@ -145,7 +164,7 @@ app.whenReady().then(() => {
     autoUpdater.checkForUpdates()
     autoUpdater.on('update-downloaded', () => {
       updateDownloaded = true
-      BrowserWindow.getAllWindows().forEach(w => w.webContents.send('update:downloaded'))
+      BrowserWindow.getAllWindows().forEach((w) => w.webContents.send('update:downloaded'))
     })
   }
 })

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
+import eslintConfigPrettier from 'eslint-config-prettier'
 
 export default defineConfig([
   globalIgnores(['dist']),
@@ -14,6 +15,7 @@ export default defineConfig([
       tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
+      eslintConfigPrettier,
     ],
     languageOptions: {
       globals: globals.browser,

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,11 +33,13 @@
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
         "eslint": "^10.5.0",
+        "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.6.0",
         "graphql": "^17.0.1",
         "jsdom": "^29.1.1",
+        "prettier": "^3.5.3",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.61.1",
         "vite": "^8.1.0",
@@ -857,422 +859,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4954,6 +4540,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
@@ -7066,6 +6668,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -482,7 +481,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -531,7 +529,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -821,6 +818,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -842,6 +840,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -849,6 +848,27 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1869,7 +1889,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2082,7 +2101,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2093,7 +2111,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2153,7 +2170,6 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -2517,7 +2533,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2983,7 +2998,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3312,7 +3326,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3564,7 +3579,6 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -4281,6 +4295,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4301,6 +4316,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -4316,6 +4332,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4326,6 +4343,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -4486,7 +4504,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -5172,7 +5189,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.1.tgz",
       "integrity": "sha512-8eWbg5Zcv/8o20nzEjHUGPTj20MLFJjc5kagbIPxbaeGxvFwpitJhemEC/k17n5+UD4M/9ea5rTuce78mELujQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
       }
@@ -6162,6 +6178,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -6550,7 +6567,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6639,6 +6655,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -6656,6 +6673,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -6813,7 +6831,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6823,7 +6840,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6956,6 +6972,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7356,6 +7373,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -7573,7 +7591,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7721,7 +7738,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8122,7 +8138,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "build:web": "tsc -b && vite build",
     "build:electron": "electron-vite build && electron-builder",
     "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run"
@@ -68,6 +70,8 @@
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "eslint": "^10.5.0",
+    "eslint-config-prettier": "^10.1.5",
+    "prettier": "^3.5.3",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,6 @@ const queryClient = new QueryClient({
   },
 })
 
-
 function ElectronAuthError({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
     <div className="min-h-screen bg-[var(--color-surface)] flex flex-col items-center justify-center gap-4 p-8">
@@ -40,7 +39,7 @@ function ElectronAuthError({ message, onRetry }: { message: string; onRetry: () 
 
 async function tryElectronAuth(
   setToken: (t: string) => void,
-  setUser: (u: GitHubUser) => void,
+  setUser: (u: GitHubUser) => void
 ): Promise<string | null> {
   const installed = await window.electronAPI!.gh.isInstalled()
   if (!installed) return 'gh CLI not found. Install it at cli.github.com then relaunch.'
@@ -72,8 +71,8 @@ function AppContent() {
     if (!IS_ELECTRON || token) return
     // eslint-disable-next-line react-hooks/set-state-in-effect
     runElectronAuth()
-  // ponytail: run once; token excluded so re-auth on next open uses cached token
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // ponytail: run once; token excluded so re-auth on next open uses cached token
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   if (ghChecking) return null

--- a/src/components/BranchList/BranchList.tsx
+++ b/src/components/BranchList/BranchList.tsx
@@ -29,12 +29,17 @@ function BranchCard({
     <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-4 py-3 space-y-2">
       <div className="flex items-center gap-2 flex-wrap">
         <span
-          style={{ backgroundColor: `hsla(${hue}, 65%, 50%, 0.18)`, color: `hsl(${hue}, 70%, 65%)` }}
+          style={{
+            backgroundColor: `hsla(${hue}, 65%, 50%, 0.18)`,
+            color: `hsl(${hue}, 70%, 65%)`,
+          }}
           className="text-[10px] font-medium px-1.5 py-0.5 rounded"
         >
           {repo}
         </span>
-        <span className="text-sm font-medium text-[var(--color-text-primary)] font-mono">{branch}</span>
+        <span className="text-sm font-medium text-[var(--color-text-primary)] font-mono">
+          {branch}
+        </span>
         <CopyWithFeedback text={branch} label="Copy branch name" />
         {worktree && (
           <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-[var(--color-accent-subtle)] text-[var(--color-accent)]">
@@ -42,7 +47,10 @@ function BranchCard({
           </span>
         )}
         {worktree?.isDirty && (
-          <span title="Uncommitted changes" className="w-2 h-2 rounded-full bg-yellow-400 inline-block" />
+          <span
+            title="Uncommitted changes"
+            className="w-2 h-2 rounded-full bg-yellow-400 inline-block"
+          />
         )}
         {pr && (
           <a
@@ -120,7 +128,8 @@ export default function BranchList() {
     worktreeQueries.forEach((q) => q.refetch())
   }
 
-  const isFetching = branchQueries.some((q) => q.isFetching) || worktreeQueries.some((q) => q.isFetching)
+  const isFetching =
+    branchQueries.some((q) => q.isFetching) || worktreeQueries.some((q) => q.isFetching)
 
   if (localPaths.length === 0) {
     return (
@@ -140,16 +149,36 @@ export default function BranchList() {
   type FlatItem =
     | { key: string; loading: true; repoLabel: string }
     | { key: string; error: string; repoLabel: string }
-    | { key: string; branch: string; repoLabel: string; hue: number; worktree?: Worktree; pr?: PullRequest }
+    | {
+        key: string
+        branch: string
+        repoLabel: string
+        hue: number
+        worktree?: Worktree
+        pr?: PullRequest
+      }
 
   const flatBranches: FlatItem[] = []
   for (let i = 0; i < localPaths.length; i++) {
     const localPath = localPaths[i]
     const repoLabel = localPath.split('/').pop() ?? localPath
-    const { data: branches, isLoading: bLoading, isError: bError, error: bErrObj } = branchQueries[i]
-    const { data: worktrees, isLoading: wLoading, isError: wError, error: wErrObj } = worktreeQueries[i]
+    const {
+      data: branches,
+      isLoading: bLoading,
+      isError: bError,
+      error: bErrObj,
+    } = branchQueries[i]
+    const {
+      data: worktrees,
+      isLoading: wLoading,
+      isError: wError,
+      error: wErrObj,
+    } = worktreeQueries[i]
 
-    if (bLoading || wLoading) { flatBranches.push({ key: localPath, loading: true, repoLabel }); continue }
+    if (bLoading || wLoading) {
+      flatBranches.push({ key: localPath, loading: true, repoLabel })
+      continue
+    }
     if (bError || wError) {
       const errMsg = ((bErrObj || wErrObj) as Error)?.message ?? 'Failed to load.'
       flatBranches.push({ key: localPath, error: errMsg, repoLabel })
@@ -202,8 +231,12 @@ export default function BranchList() {
               onClick={() => removeLocalPath(p)}
               title={`Remove ${label}`}
               style={{ color }}
-              onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--color-danger)' }}
-              onMouseLeave={(e) => { e.currentTarget.style.color = color }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = 'var(--color-danger)'
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = color
+              }}
               className="flex items-center gap-1 text-xs transition-colors cursor-pointer"
             >
               <X size={12} />
@@ -216,10 +249,18 @@ export default function BranchList() {
       <div className="space-y-2">
         {flatBranches.map((item) => {
           if ('loading' in item) {
-            return <p key={item.key} className="text-xs text-[var(--color-text-muted)]">Loading {item.repoLabel}…</p>
+            return (
+              <p key={item.key} className="text-xs text-[var(--color-text-muted)]">
+                Loading {item.repoLabel}…
+              </p>
+            )
           }
           if ('error' in item) {
-            return <p key={item.key} className="text-xs text-[var(--color-danger)]">{item.repoLabel}: {item.error}</p>
+            return (
+              <p key={item.key} className="text-xs text-[var(--color-danger)]">
+                {item.repoLabel}: {item.error}
+              </p>
+            )
           }
           return (
             <BranchCard

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -80,9 +80,10 @@ export default function Filters() {
                 <label
                   key={repo}
                   className={`flex items-center gap-2 px-1 py-1 rounded cursor-pointer group
-                    ${selected
-                      ? 'bg-[var(--color-accent-subtle)]'
-                      : 'hover:bg-[var(--color-surface-overlay)]'
+                    ${
+                      selected
+                        ? 'bg-[var(--color-accent-subtle)]'
+                        : 'hover:bg-[var(--color-surface-overlay)]'
                     }`}
                 >
                   <input
@@ -91,10 +92,12 @@ export default function Filters() {
                     onChange={() => toggleRepo(repo)}
                     className="accent-[var(--color-accent)] cursor-pointer"
                   />
-                  <span className={`text-xs truncate
-                    ${selected
-                      ? 'text-[var(--color-text-primary)] font-medium'
-                      : 'text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]'
+                  <span
+                    className={`text-xs truncate
+                    ${
+                      selected
+                        ? 'text-[var(--color-text-primary)] font-medium'
+                        : 'text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]'
                     }`}
                   >
                     {repo.split('/')[1]}
@@ -106,11 +109,13 @@ export default function Filters() {
         </div>
       )}
 
-      {(filters.repos.length > 0 || filters.showDrafts || filters.showHidden) && hasNextPage && !truncated && (
-        <p className="text-xs text-[var(--color-warning)]">
-          ⚠ Filters apply to {loadedCount} of ~{totalCount} PRs
-        </p>
-      )}
+      {(filters.repos.length > 0 || filters.showDrafts || filters.showHidden) &&
+        hasNextPage &&
+        !truncated && (
+          <p className="text-xs text-[var(--color-warning)]">
+            ⚠ Filters apply to {loadedCount} of ~{totalCount} PRs
+          </p>
+        )}
 
       {/* Muted authors — free-form pattern input */}
       <div>

--- a/src/components/PRCard/ChecksPanel.tsx
+++ b/src/components/PRCard/ChecksPanel.tsx
@@ -31,8 +31,10 @@ function CheckIcon({ check }: { check: CheckRunContext | StatusContextItem }) {
   }
 
   const { state } = check
-  if (state === 'SUCCESS') return <CheckCircle size={12} className="text-[var(--color-success)] shrink-0" />
-  if (state === 'ERROR' || state === 'FAILURE') return <XCircle size={12} className="text-[var(--color-danger)] shrink-0" />
+  if (state === 'SUCCESS')
+    return <CheckCircle size={12} className="text-[var(--color-success)] shrink-0" />
+  if (state === 'ERROR' || state === 'FAILURE')
+    return <XCircle size={12} className="text-[var(--color-danger)] shrink-0" />
   return <Clock size={12} className="text-[var(--color-warning)] shrink-0" />
 }
 
@@ -68,7 +70,9 @@ export default function ChecksPanel({ checks, rollupState, onClose, isLoading }:
               className="flex items-center gap-2 px-3 py-1.5 hover:bg-[var(--color-surface-overlay)]"
             >
               <CheckIcon check={check} />
-              <span className="text-xs text-[var(--color-text-secondary)] flex-1 truncate">{name}</span>
+              <span className="text-xs text-[var(--color-text-secondary)] flex-1 truncate">
+                {name}
+              </span>
               {url && (
                 <a
                   href={url}
@@ -86,7 +90,9 @@ export default function ChecksPanel({ checks, rollupState, onClose, isLoading }:
       {(rollupState === 'PENDING' || rollupState === 'EXPECTED') && (
         <div className="flex items-center gap-2 px-3 py-1.5 border-t border-[var(--color-border)]">
           <Clock size={12} className="text-[var(--color-warning)] shrink-0" />
-          <span className="text-xs text-[var(--color-text-muted)]">Some checks may still be pending or not yet shown</span>
+          <span className="text-xs text-[var(--color-text-muted)]">
+            Some checks may still be pending or not yet shown
+          </span>
         </div>
       )}
     </div>

--- a/src/components/PRCard/PRCard.test.tsx
+++ b/src/components/PRCard/PRCard.test.tsx
@@ -30,10 +30,18 @@ const pr: PullRequest = {
 }
 
 beforeEach(() => {
-  usePRStore.setState({ priorityIds: [], hiddenIds: [], filters: {
-    section: 'review-requested', repos: [], hiddenAuthors: [],
-    showDrafts: false, showHidden: false, search: '',
-  }})
+  usePRStore.setState({
+    priorityIds: [],
+    hiddenIds: [],
+    filters: {
+      section: 'review-requested',
+      repos: [],
+      hiddenAuthors: [],
+      showDrafts: false,
+      showHidden: false,
+      search: '',
+    },
+  })
 })
 
 describe('PRCard', () => {
@@ -93,14 +101,16 @@ describe('PRCard', () => {
       return {
         ...pr,
         commits: {
-          nodes: [{
-            commit: {
-              statusCheckRollup: {
-                state,
-                contexts: { nodes: [greenCheck] },
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  state,
+                  contexts: { nodes: [greenCheck] },
+                },
               },
             },
-          }],
+          ],
         },
       }
     }
@@ -109,21 +119,27 @@ describe('PRCard', () => {
       const user = userEvent.setup()
       render(<PRCard pr={makePrWithRollup('EXPECTED')} />)
       await user.click(screen.getByText('Checks pending'))
-      expect(screen.getByText('Some checks may still be pending or not yet shown')).toBeInTheDocument()
+      expect(
+        screen.getByText('Some checks may still be pending or not yet shown')
+      ).toBeInTheDocument()
     })
 
     it('GIVEN rollup PENDING with all-green contexts WHEN checks opened THEN footer note appears', async () => {
       const user = userEvent.setup()
       render(<PRCard pr={makePrWithRollup('PENDING')} />)
       await user.click(screen.getByText('Checks pending'))
-      expect(screen.getByText('Some checks may still be pending or not yet shown')).toBeInTheDocument()
+      expect(
+        screen.getByText('Some checks may still be pending or not yet shown')
+      ).toBeInTheDocument()
     })
 
     it('GIVEN rollup SUCCESS WHEN checks opened THEN no footer note', async () => {
       const user = userEvent.setup()
       render(<PRCard pr={makePrWithRollup('SUCCESS')} />)
       await user.click(screen.getByText('Checks pass'))
-      expect(screen.queryByText('Some checks may still be pending or not yet shown')).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('Some checks may still be pending or not yet shown')
+      ).not.toBeInTheDocument()
     })
   })
 
@@ -164,11 +180,13 @@ describe('PRCard', () => {
       return {
         ...pr,
         commits: {
-          nodes: [{
-            commit: {
-              statusCheckRollup: { state, contexts: { nodes: [] } },
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: { state, contexts: { nodes: [] } },
+              },
             },
-          }],
+          ],
         },
       }
     }

--- a/src/components/PRCard/PRCard.tsx
+++ b/src/components/PRCard/PRCard.tsx
@@ -1,5 +1,19 @@
 import { useState, type ReactElement } from 'react'
-import { GitMerge, MessageSquare, Check, AlertCircle, Star, ExternalLink, FileCode, EyeOff, Eye, CheckCircle, XCircle, Clock, Link2 } from 'lucide-react'
+import {
+  GitMerge,
+  MessageSquare,
+  Check,
+  AlertCircle,
+  Star,
+  ExternalLink,
+  FileCode,
+  EyeOff,
+  Eye,
+  CheckCircle,
+  XCircle,
+  Clock,
+  Link2,
+} from 'lucide-react'
 import type { PullRequest, ReviewState, CheckRollupState } from '../../types/github'
 import { usePRStore } from '../../store/prStore'
 import { useAuthStore } from '../../store/authStore'
@@ -14,12 +28,40 @@ interface Props {
   isAuthored?: boolean
 }
 
-const ciStateBadge: Record<CheckRollupState, { label: string; color: string; bg: string; icon: ReactElement }> = {
-  SUCCESS:  { label: 'Checks pass',    color: 'text-[var(--color-success)]',  bg: 'bg-[var(--color-success-subtle)]',  icon: <CheckCircle size={11} /> },
-  FAILURE:  { label: 'Checks failed',  color: 'text-[var(--color-danger)]',   bg: 'bg-[var(--color-danger-subtle)]',   icon: <XCircle size={11} /> },
-  ERROR:    { label: 'Checks error',   color: 'text-[var(--color-danger)]',   bg: 'bg-[var(--color-danger-subtle)]',   icon: <XCircle size={11} /> },
-  PENDING:  { label: 'Checks pending', color: 'text-[var(--color-warning)]',  bg: 'bg-[var(--color-warning-subtle)]',  icon: <Clock size={11} /> },
-  EXPECTED: { label: 'Checks pending', color: 'text-[var(--color-warning)]',  bg: 'bg-[var(--color-warning-subtle)]',  icon: <Clock size={11} /> },
+const ciStateBadge: Record<
+  CheckRollupState,
+  { label: string; color: string; bg: string; icon: ReactElement }
+> = {
+  SUCCESS: {
+    label: 'Checks pass',
+    color: 'text-[var(--color-success)]',
+    bg: 'bg-[var(--color-success-subtle)]',
+    icon: <CheckCircle size={11} />,
+  },
+  FAILURE: {
+    label: 'Checks failed',
+    color: 'text-[var(--color-danger)]',
+    bg: 'bg-[var(--color-danger-subtle)]',
+    icon: <XCircle size={11} />,
+  },
+  ERROR: {
+    label: 'Checks error',
+    color: 'text-[var(--color-danger)]',
+    bg: 'bg-[var(--color-danger-subtle)]',
+    icon: <XCircle size={11} />,
+  },
+  PENDING: {
+    label: 'Checks pending',
+    color: 'text-[var(--color-warning)]',
+    bg: 'bg-[var(--color-warning-subtle)]',
+    icon: <Clock size={11} />,
+  },
+  EXPECTED: {
+    label: 'Checks pending',
+    color: 'text-[var(--color-warning)]',
+    bg: 'bg-[var(--color-warning-subtle)]',
+    icon: <Clock size={11} />,
+  },
 }
 
 const reviewBadge: Record<
@@ -57,7 +99,6 @@ const reviewBadge: Record<
     icon: <MessageSquare size={11} />,
   },
 }
-
 
 function PRCard({ pr, isAuthored = false }: Props) {
   const [checksOpen, setChecksOpen] = useState(false)
@@ -136,8 +177,7 @@ function PRCard({ pr, isAuthored = false }: Props) {
 
               {/* Diff size */}
               <span className="text-xs font-mono">
-                <span className="text-[var(--color-success)]">+{pr.additions}</span>
-                {' '}
+                <span className="text-[var(--color-success)]">+{pr.additions}</span>{' '}
                 <span className="text-[var(--color-danger)]">-{pr.deletions}</span>
               </span>
 
@@ -176,7 +216,12 @@ function PRCard({ pr, isAuthored = false }: Props) {
                     {ciBadge.label}
                   </button>
                   {checksOpen && (
-                    <ChecksPanel checks={checks} isLoading={checksLoading} rollupState={checkState} onClose={() => setChecksOpen(false)} />
+                    <ChecksPanel
+                      checks={checks}
+                      isLoading={checksLoading}
+                      rollupState={checkState}
+                      onClose={() => setChecksOpen(false)}
+                    />
                   )}
                 </div>
               )}
@@ -188,7 +233,6 @@ function PRCard({ pr, isAuthored = false }: Props) {
                   Conflict
                 </span>
               )}
-
             </div>
 
             {/* Reviewer avatars (authored section only) */}

--- a/src/components/PRList/PRList.test.tsx
+++ b/src/components/PRList/PRList.test.tsx
@@ -91,14 +91,26 @@ describe('PRList', () => {
 
   it('GIVEN priorityPRs THEN shows Top priority heading', () => {
     const p = makePR('1', 'Priority PR')
-    mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: [], priorityPRs: [p], totalCount: 1, loadedCount: 1 } as never)
+    mockUsePullRequests.mockReturnValue({
+      ...defaultQuery,
+      data: [],
+      priorityPRs: [p],
+      totalCount: 1,
+      loadedCount: 1,
+    } as never)
     render(<PRList />)
     expect(screen.getByText('Top priority')).toBeInTheDocument()
   })
 
   it('GIVEN no priorityPRs THEN Top priority heading absent', () => {
     const p = makePR('1', 'Regular PR')
-    mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: [p], priorityPRs: [], totalCount: 1, loadedCount: 1 } as never)
+    mockUsePullRequests.mockReturnValue({
+      ...defaultQuery,
+      data: [p],
+      priorityPRs: [],
+      totalCount: 1,
+      loadedCount: 1,
+    } as never)
     render(<PRList />)
     expect(screen.queryByText('Top priority')).not.toBeInTheDocument()
   })
@@ -106,14 +118,26 @@ describe('PRList', () => {
   it('GIVEN regular + priority PRs THEN count badge shows combined total', () => {
     const r = makePR('1', 'Regular')
     const p = makePR('2', 'Priority')
-    mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: [r], priorityPRs: [p], totalCount: 2, loadedCount: 2 } as never)
+    mockUsePullRequests.mockReturnValue({
+      ...defaultQuery,
+      data: [r],
+      priorityPRs: [p],
+      totalCount: 2,
+      loadedCount: 2,
+    } as never)
     render(<PRList />)
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
   it('GIVEN truncated THEN shows of {totalCount}', () => {
     const prs = [makePR('1', 'PR')]
-    mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: prs, priorityPRs: [], totalCount: 500, loadedCount: 1 } as never)
+    mockUsePullRequests.mockReturnValue({
+      ...defaultQuery,
+      data: prs,
+      priorityPRs: [],
+      totalCount: 500,
+      loadedCount: 1,
+    } as never)
     render(<PRList />)
     expect(screen.getByText(/of 500/)).toBeInTheDocument()
   })
@@ -121,7 +145,14 @@ describe('PRList', () => {
   describe('pagination CTAs', () => {
     it('GIVEN hasNextPage and no active filters THEN shows "Load more" only', () => {
       const prs = [makePR('1', 'PR')]
-      mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: prs, priorityPRs: [], hasNextPage: true, totalCount: 100, loadedCount: 50 } as never)
+      mockUsePullRequests.mockReturnValue({
+        ...defaultQuery,
+        data: prs,
+        priorityPRs: [],
+        hasNextPage: true,
+        totalCount: 100,
+        loadedCount: 50,
+      } as never)
       render(<PRList />)
       expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument()
       expect(screen.queryByRole('button', { name: 'Load all' })).not.toBeInTheDocument()
@@ -130,7 +161,12 @@ describe('PRList', () => {
 
     it('GIVEN hasNextPage=false THEN no pagination CTAs', () => {
       const prs = [makePR('1', 'PR')]
-      mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: prs, priorityPRs: [], hasNextPage: false } as never)
+      mockUsePullRequests.mockReturnValue({
+        ...defaultQuery,
+        data: prs,
+        priorityPRs: [],
+        hasNextPage: false,
+      } as never)
       render(<PRList />)
       expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: 'Load all' })).not.toBeInTheDocument()
@@ -139,7 +175,15 @@ describe('PRList', () => {
     it('GIVEN "Load more" clicked THEN fetchNextPage is called', () => {
       const fetchNextPage = vi.fn()
       const prs = [makePR('1', 'PR')]
-      mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: prs, priorityPRs: [], hasNextPage: true, fetchNextPage, totalCount: 100, loadedCount: 50 } as never)
+      mockUsePullRequests.mockReturnValue({
+        ...defaultQuery,
+        data: prs,
+        priorityPRs: [],
+        hasNextPage: true,
+        fetchNextPage,
+        totalCount: 100,
+        loadedCount: 50,
+      } as never)
       render(<PRList />)
       fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
       expect(fetchNextPage).toHaveBeenCalledOnce()
@@ -148,7 +192,14 @@ describe('PRList', () => {
     it('GIVEN hasNextPage and active filter THEN shows "Load all" button', () => {
       mockStoreFilters({ repos: ['org/repo'] })
       const prs = [makePR('1', 'PR')]
-      mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: prs, priorityPRs: [], hasNextPage: true, totalCount: 100, loadedCount: 50 } as never)
+      mockUsePullRequests.mockReturnValue({
+        ...defaultQuery,
+        data: prs,
+        priorityPRs: [],
+        hasNextPage: true,
+        totalCount: 100,
+        loadedCount: 50,
+      } as never)
       render(<PRList />)
       expect(screen.getByRole('button', { name: 'Load all' })).toBeInTheDocument()
     })

--- a/src/components/PRList/PRList.tsx
+++ b/src/components/PRList/PRList.tsx
@@ -12,7 +12,19 @@ const sectionLabels: Record<string, string> = {
 }
 
 export default function PRList() {
-  const { data: prs = [], priorityPRs = [], isLoading, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage, refetch, error, totalCount, truncated } = usePullRequests()
+  const {
+    data: prs = [],
+    priorityPRs = [],
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+    refetch,
+    error,
+    totalCount,
+    truncated,
+  } = usePullRequests()
   const filters = usePRStore((s) => s.filters)
   const section = filters.section
   const loadAllRef = useRef(false)
@@ -109,7 +121,9 @@ export default function PRList() {
 
       {!isLoading && !error && priorityPRs.length > 0 && (
         <div className="mb-4">
-          <p className="text-sm font-semibold text-[var(--color-text-primary)] mb-2">Top priority</p>
+          <p className="text-sm font-semibold text-[var(--color-text-primary)] mb-2">
+            Top priority
+          </p>
           <div className="space-y-2">
             {priorityPRs.map((pr) => (
               <PRCard key={pr.id} pr={pr} isAuthored={section === 'authored'} />
@@ -138,7 +152,10 @@ export default function PRList() {
             </button>
             {hasActiveFilters && (
               <button
-                onClick={() => { loadAllRef.current = true; fetchNextPage() }}
+                onClick={() => {
+                  loadAllRef.current = true
+                  fetchNextPage()
+                }}
                 disabled={isFetchingNextPage}
                 className="text-xs px-3 py-1.5 rounded border border-[var(--color-accent)] text-[var(--color-accent)] hover:bg-[var(--color-accent-subtle)] transition-colors cursor-pointer disabled:opacity-40"
               >

--- a/src/components/PRList/VisibilityToggles.tsx
+++ b/src/components/PRList/VisibilityToggles.tsx
@@ -10,9 +10,10 @@ export default function VisibilityToggles() {
         onClick={() => setFilters({ showDrafts: !filters.showDrafts })}
         title={filters.showDrafts ? 'Hide drafts' : 'Show drafts'}
         className={`text-xs px-2 py-0.5 rounded transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none
-          ${filters.showDrafts
-            ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
-            : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)]'
+          ${
+            filters.showDrafts
+              ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
+              : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)]'
           }`}
       >
         Drafts
@@ -21,9 +22,10 @@ export default function VisibilityToggles() {
         onClick={() => setFilters({ showHidden: !filters.showHidden })}
         title={filters.showHidden ? 'Hide hidden PRs' : 'Show hidden PRs'}
         className={`text-xs px-2 py-0.5 rounded transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none
-          ${filters.showHidden
-            ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
-            : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)]'
+          ${
+            filters.showHidden
+              ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
+              : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)]'
           }`}
       >
         Hidden{hiddenIds.length > 0 && ` (${hiddenIds.length})`}

--- a/src/components/shared/CopyWithFeedback.tsx
+++ b/src/components/shared/CopyWithFeedback.tsx
@@ -35,7 +35,9 @@ export function CopyWithFeedback({
       >
         {showCopied ? <Check size={13} className="text-green-500" /> : <Copy size={13} />}
       </button>
-      <span className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none transition-opacity ${copied ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
+      <span
+        className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none transition-opacity ${copied ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
+      >
         {showCopied ? 'Copied!' : label}
       </span>
     </div>

--- a/src/hooks/useBranches.test.tsx
+++ b/src/hooks/useBranches.test.tsx
@@ -42,7 +42,9 @@ function makePage(nodes: ReturnType<typeof makeNode>[], hasNextPage: boolean, en
 }
 
 beforeEach(() => {
-  vi.mocked(createClient).mockReturnValue({ request: mockRequest } as unknown as ReturnType<typeof createClient>)
+  vi.mocked(createClient).mockReturnValue({ request: mockRequest } as unknown as ReturnType<
+    typeof createClient
+  >)
   vi.mocked(useAuthStore).mockImplementation((selector) =>
     selector({ token: 'tok', user: { login: 'alice' } } as never)
   )
@@ -51,7 +53,9 @@ beforeEach(() => {
 
 describe('useBranches', () => {
   it('GIVEN single page WHEN fetching THEN returns mapped branches', async () => {
-    mockRequest.mockResolvedValueOnce(makePage([makeNode('feat-x', 'alice', '2024-01-01T00:00:00Z')], false))
+    mockRequest.mockResolvedValueOnce(
+      makePage([makeNode('feat-x', 'alice', '2024-01-01T00:00:00Z')], false)
+    )
 
     const { result } = renderHook(() => useBranches(['org/repo']), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
@@ -63,20 +67,28 @@ describe('useBranches', () => {
 
   it('GIVEN two pages WHEN fetching THEN paginates with cursor and accumulates nodes', async () => {
     mockRequest
-      .mockResolvedValueOnce(makePage([makeNode('feat-a', 'alice', '2024-01-02T00:00:00Z')], true, 'cursor1'))
+      .mockResolvedValueOnce(
+        makePage([makeNode('feat-a', 'alice', '2024-01-02T00:00:00Z')], true, 'cursor1')
+      )
       .mockResolvedValueOnce(makePage([makeNode('feat-b', 'alice', '2024-01-01T00:00:00Z')], false))
 
     const { result } = renderHook(() => useBranches(['org/repo']), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(mockRequest).toHaveBeenCalledTimes(2)
-    expect(mockRequest).toHaveBeenNthCalledWith(2, expect.anything(), expect.objectContaining({ cursor: 'cursor1' }))
+    expect(mockRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({ cursor: 'cursor1' })
+    )
     expect(result.current.data!.map((b) => b.name)).toEqual(['feat-a', 'feat-b'])
   })
 
   it('GIVEN always hasNextPage WHEN fetching THEN caps at 10 pages and warns', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    mockRequest.mockResolvedValue(makePage([makeNode('feat-x', 'alice', '2024-01-01T00:00:00Z')], true, 'cursor'))
+    mockRequest.mockResolvedValue(
+      makePage([makeNode('feat-x', 'alice', '2024-01-01T00:00:00Z')], true, 'cursor')
+    )
 
     const { result } = renderHook(() => useBranches(['org/repo']), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
@@ -88,10 +100,16 @@ describe('useBranches', () => {
 
   it('GIVEN branches from two repos WHEN fetching THEN sorts by date descending', async () => {
     mockRequest
-      .mockResolvedValueOnce(makePage([makeNode('feat-old', 'alice', '2024-01-01T00:00:00Z')], false))
-      .mockResolvedValueOnce(makePage([makeNode('feat-new', 'alice', '2024-06-01T00:00:00Z')], false))
+      .mockResolvedValueOnce(
+        makePage([makeNode('feat-old', 'alice', '2024-01-01T00:00:00Z')], false)
+      )
+      .mockResolvedValueOnce(
+        makePage([makeNode('feat-new', 'alice', '2024-06-01T00:00:00Z')], false)
+      )
 
-    const { result } = renderHook(() => useBranches(['org/repo1', 'org/repo2']), { wrapper: makeWrapper() })
+    const { result } = renderHook(() => useBranches(['org/repo1', 'org/repo2']), {
+      wrapper: makeWrapper(),
+    })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(result.current.data!.map((b) => b.name)).toEqual(['feat-new', 'feat-old'])
@@ -114,7 +132,11 @@ describe('mapBranchNodes', () => {
     const nodes = [
       makeNode('main', 'alice', '2024-01-01T00:00:00Z'),
       makeNode('feature-x', 'bob', '2024-01-02T00:00:00Z'),
-      makeNode('feature-y', 'alice', '2024-01-03T00:00:00Z', { number: 42, state: 'OPEN', url: 'https://github.com/org/repo/pull/42' }),
+      makeNode('feature-y', 'alice', '2024-01-03T00:00:00Z', {
+        number: 42,
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/42',
+      }),
     ]
 
     const actual = mapBranchNodes(nodes, 'org/repo', 'alice')

--- a/src/hooks/useBranches.ts
+++ b/src/hooks/useBranches.ts
@@ -3,7 +3,14 @@ import { useAuthStore } from '../store/authStore'
 import { createClient, BRANCHES_QUERY } from '../lib/github'
 import type { Branch } from '../types/github'
 
-const DEFAULT_BRANCHES = new Set(['main', 'master', 'develop', 'development', 'staging', 'production'])
+const DEFAULT_BRANCHES = new Set([
+  'main',
+  'master',
+  'develop',
+  'development',
+  'staging',
+  'production',
+])
 
 interface BranchNode {
   name: string
@@ -35,12 +42,14 @@ export function mapBranchNodes(
       const authorLogin = n.target.author?.user?.login
       return !login || authorLogin === login
     })
-    .map((n): Branch => ({
-      name: n.name,
-      repo,
-      lastCommitDate: n.target!.committedDate!,
-      linkedPr: n.associatedPullRequests.nodes[0],
-    }))
+    .map(
+      (n): Branch => ({
+        name: n.name,
+        repo,
+        lastCommitDate: n.target!.committedDate!,
+        linkedPr: n.associatedPullRequests.nodes[0],
+      })
+    )
 }
 
 export function useBranches(repos: string[]) {
@@ -61,7 +70,11 @@ export function useBranches(repos: string[]) {
           let cursor: string | undefined
 
           for (let page = 0; page < 10; page++) {
-            const data = await client.request<BranchesResult>(BRANCHES_QUERY, { owner, name, cursor })
+            const data = await client.request<BranchesResult>(BRANCHES_QUERY, {
+              owner,
+              name,
+              cursor,
+            })
             const { nodes: chunk, pageInfo } = data.repository.refs
             nodes.push(...chunk)
             if (!pageInfo.hasNextPage) break

--- a/src/hooks/useGitHubPRs.test.ts
+++ b/src/hooks/useGitHubPRs.test.ts
@@ -43,7 +43,11 @@ describe('deriveMyReviewState', () => {
   it('GIVEN mix of null and real author WHEN filtering THEN returns real author state', () => {
     const pr = makePRWithReviews([
       { state: 'COMMENTED', submittedAt: '2024-01-01T00:00:00Z', author: null },
-      { state: 'APPROVED', submittedAt: '2024-01-02T00:00:00Z', author: { login: 'user', avatarUrl: '' } },
+      {
+        state: 'APPROVED',
+        submittedAt: '2024-01-02T00:00:00Z',
+        author: { login: 'user', avatarUrl: '' },
+      },
     ])
     const actual = deriveMyReviewState(pr, 'user')
     expect(actual).toBe('APPROVED')
@@ -56,8 +60,16 @@ describe('deriveMyReviewState', () => {
 
   it('GIVEN multiple reviews by same user THEN returns most recent', () => {
     const pr = makePRWithReviews([
-      { state: 'COMMENTED', submittedAt: '2024-01-01T00:00:00Z', author: { login: 'user', avatarUrl: '' } },
-      { state: 'APPROVED', submittedAt: '2024-01-03T00:00:00Z', author: { login: 'user', avatarUrl: '' } },
+      {
+        state: 'COMMENTED',
+        submittedAt: '2024-01-01T00:00:00Z',
+        author: { login: 'user', avatarUrl: '' },
+      },
+      {
+        state: 'APPROVED',
+        submittedAt: '2024-01-03T00:00:00Z',
+        author: { login: 'user', avatarUrl: '' },
+      },
     ])
     expect(deriveMyReviewState(pr, 'user')).toBe('APPROVED')
   })

--- a/src/hooks/useGitHubPRs.ts
+++ b/src/hooks/useGitHubPRs.ts
@@ -43,28 +43,30 @@ export function usePullRequests() {
     },
     getNextPageParam: (lastPage, pages) => {
       if (pages.length >= MAX_PAGES) return undefined
-      return lastPage.search.pageInfo.hasNextPage
-        ? lastPage.search.pageInfo.endCursor
-        : undefined
+      return lastPage.search.pageInfo.hasNextPage ? lastPage.search.pageInfo.endCursor : undefined
     },
   })
 
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = query
 
   const allNodes = useMemo(
-    () => (query.data?.pages ?? [])
-      .flatMap((p) => p.search.nodes)
-      .map((pr) => ({
-        ...pr,
-        myReviewState: deriveMyReviewState(pr, user!.login),
-        isTopPriority: priorityIds.includes(pr.id),
-        isHidden: hiddenIds.includes(pr.id),
-      })),
+    () =>
+      (query.data?.pages ?? [])
+        .flatMap((p) => p.search.nodes)
+        .map((pr) => ({
+          ...pr,
+          myReviewState: deriveMyReviewState(pr, user!.login),
+          isTopPriority: priorityIds.includes(pr.id),
+          isHidden: hiddenIds.includes(pr.id),
+        })),
     [query.data, user, priorityIds, hiddenIds]
   )
 
   const filtered = useMemo(() => applyFilters(allNodes, filters), [allNodes, filters])
-  const { priorityPRs, regular } = useMemo(() => sortAndPartition(filtered, priorityIds), [filtered, priorityIds])
+  const { priorityPRs, regular } = useMemo(
+    () => sortAndPartition(filtered, priorityIds),
+    [filtered, priorityIds]
+  )
 
   const repos = useMemo(
     () => [...new Set(allNodes.map((pr) => pr.repository.nameWithOwner))].sort(),
@@ -77,5 +79,17 @@ export function usePullRequests() {
   const hitPageCap = (query.data?.pages.length ?? 0) >= MAX_PAGES
   const truncated = hitPageCap && !!lastPage?.search.pageInfo.hasNextPage
 
-  return { ...query, data: regular, priorityPRs, allPRs: allNodes, repos, totalCount, loadedCount, truncated, hasNextPage, isFetchingNextPage, fetchNextPage }
+  return {
+    ...query,
+    data: regular,
+    priorityPRs,
+    allPRs: allNodes,
+    repos,
+    totalCount,
+    loadedCount,
+    truncated,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  }
 }

--- a/src/hooks/useRecentRepos.test.tsx
+++ b/src/hooks/useRecentRepos.test.tsx
@@ -30,7 +30,9 @@ beforeEach(() => {
 describe('useRecentRepos', () => {
   it('GIVEN events with duplicate repos WHEN fetching THEN deduplicates', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify(makeEvents(['org/repo-a', 'org/repo-b', 'org/repo-a'])), { status: 200 })
+      new Response(JSON.stringify(makeEvents(['org/repo-a', 'org/repo-b', 'org/repo-a'])), {
+        status: 200,
+      })
     )
 
     const { result } = renderHook(() => useRecentRepos(), { wrapper: makeWrapper() })

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -10,5 +10,5 @@ export function useTheme() {
     localStorage.setItem('theme', theme)
   }, [theme])
 
-  return { theme, toggle: () => setTheme(t => t === 'dark' ? 'light' : 'dark') }
+  return { theme, toggle: () => setTheme((t) => (t === 'dark' ? 'light' : 'dark')) }
 }

--- a/src/hooks/useUpdateCheck.test.tsx
+++ b/src/hooks/useUpdateCheck.test.tsx
@@ -33,7 +33,14 @@ describe('UpdateBanner', () => {
 
   it('calls onDismiss when ✕ is clicked', () => {
     let dismissed = false
-    render(<UpdateBanner version="v1.2.3" onDismiss={() => { dismissed = true }} />)
+    render(
+      <UpdateBanner
+        version="v1.2.3"
+        onDismiss={() => {
+          dismissed = true
+        }}
+      />
+    )
     fireEvent.click(screen.getByText('✕'))
     expect(dismissed).toBe(true)
   })

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
   --color-surface: #0d1117;
@@ -19,15 +19,16 @@
   --color-danger-subtle: #3d1010;
   --color-priority: #bf91f3;
   --color-priority-subtle: #2d1f4e;
-  --shadow-card: 0 1px 3px 0 rgba(0,0,0,0.3);
-  --shadow-card-hover: 0 4px 12px 0 rgba(0,0,0,0.4);
+  --shadow-card: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
+  --shadow-card-hover: 0 4px 12px 0 rgba(0, 0, 0, 0.4);
 }
 
-html, body {
+html,
+body {
   background-color: var(--color-surface);
 }
 
-[data-theme="light"] {
+[data-theme='light'] {
   --color-surface: #ffffff;
   --color-surface-raised: #f6f8fa;
   --color-surface-overlay: #eaeef2;
@@ -46,6 +47,6 @@ html, body {
   --color-danger-subtle: #ffebe9;
   --color-priority: #8250df;
   --color-priority-subtle: #fbefff;
-  --shadow-card: 0 1px 3px 0 rgba(0,0,0,0.1);
-  --shadow-card-hover: 0 4px 12px 0 rgba(0,0,0,0.15);
+  --shadow-card: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  --shadow-card-hover: 0 4px 12px 0 rgba(0, 0, 0, 0.15);
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -28,7 +28,10 @@ type GQLClient = { request: <T>(query: string, variables?: Record<string, unknow
 function createElectronClient(): GQLClient {
   return {
     request: async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
-      const result = await window.electronAPI!.gh.graphql(query, variables ?? {}) as { data: T; errors?: { message: string }[] }
+      const result = (await window.electronAPI!.gh.graphql(query, variables ?? {})) as {
+        data: T
+        errors?: { message: string }[]
+      }
       if (result.errors?.length) throw new Error(result.errors[0].message)
       return result.data
     },
@@ -147,8 +150,17 @@ export const PR_CHECK_CONTEXTS_QUERY = /* GraphQL */ `
                 contexts(first: 100) {
                   nodes {
                     __typename
-                    ... on CheckRun { name status conclusion detailsUrl }
-                    ... on StatusContext { context state targetUrl }
+                    ... on CheckRun {
+                      name
+                      status
+                      conclusion
+                      detailsUrl
+                    }
+                    ... on StatusContext {
+                      context
+                      state
+                      targetUrl
+                    }
                   }
                 }
               }
@@ -163,18 +175,35 @@ export const PR_CHECK_CONTEXTS_QUERY = /* GraphQL */ `
 export const BRANCHES_QUERY = /* GraphQL */ `
   query GetBranches($owner: String!, $name: String!, $cursor: String) {
     repository(owner: $owner, name: $name) {
-      refs(refPrefix: "refs/heads/", first: 100, after: $cursor,
-           orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
-        pageInfo { hasNextPage endCursor }
+      refs(
+        refPrefix: "refs/heads/"
+        first: 100
+        after: $cursor
+        orderBy: { field: TAG_COMMIT_DATE, direction: DESC }
+      ) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
         nodes {
           name
           target {
             ... on Commit {
               committedDate
-              author { user { login } }
+              author {
+                user {
+                  login
+                }
+              }
             }
           }
-          associatedPullRequests(first: 1) { nodes { number state url } }
+          associatedPullRequests(first: 1) {
+            nodes {
+              number
+              state
+              url
+            }
+          }
         }
       }
     }

--- a/src/lib/prUtils.test.ts
+++ b/src/lib/prUtils.test.ts
@@ -63,11 +63,13 @@ describe('deriveCheckState', () => {
   it('GIVEN PR with SUCCESS rollup WHEN called THEN returns SUCCESS', () => {
     const pr = makePR({
       commits: {
-        nodes: [{
-          commit: {
-            statusCheckRollup: { state: 'SUCCESS', contexts: { nodes: [] } },
+        nodes: [
+          {
+            commit: {
+              statusCheckRollup: { state: 'SUCCESS', contexts: { nodes: [] } },
+            },
           },
-        }],
+        ],
       },
     })
     expect(deriveCheckState(pr)).toBe('SUCCESS')
@@ -76,11 +78,13 @@ describe('deriveCheckState', () => {
   it('GIVEN PR with FAILURE rollup WHEN called THEN returns FAILURE', () => {
     const pr = makePR({
       commits: {
-        nodes: [{
-          commit: {
-            statusCheckRollup: { state: 'FAILURE', contexts: { nodes: [] } },
+        nodes: [
+          {
+            commit: {
+              statusCheckRollup: { state: 'FAILURE', contexts: { nodes: [] } },
+            },
           },
-        }],
+        ],
       },
     })
     expect(deriveCheckState(pr)).toBe('FAILURE')
@@ -101,8 +105,16 @@ describe('deriveReviewerSummary', () => {
     const pr = makePR({
       reviews: {
         nodes: [
-          { state: 'COMMENTED', author: { login: 'bob', avatarUrl: 'https://example.com/bob.png' }, submittedAt: '2024-01-01T09:00:00Z' },
-          { state: 'APPROVED', author: { login: 'bob', avatarUrl: 'https://example.com/bob.png' }, submittedAt: '2024-01-01T10:00:00Z' },
+          {
+            state: 'COMMENTED',
+            author: { login: 'bob', avatarUrl: 'https://example.com/bob.png' },
+            submittedAt: '2024-01-01T09:00:00Z',
+          },
+          {
+            state: 'APPROVED',
+            author: { login: 'bob', avatarUrl: 'https://example.com/bob.png' },
+            submittedAt: '2024-01-01T10:00:00Z',
+          },
         ],
       },
     })
@@ -116,7 +128,11 @@ describe('deriveReviewerSummary', () => {
     const pr = makePR({
       reviews: {
         nodes: [
-          { state: 'APPROVED', author: { login: 'author', avatarUrl: 'https://example.com/author.png' }, submittedAt: '2024-01-01T10:00:00Z' },
+          {
+            state: 'APPROVED',
+            author: { login: 'author', avatarUrl: 'https://example.com/author.png' },
+            submittedAt: '2024-01-01T10:00:00Z',
+          },
         ],
       },
     })
@@ -128,7 +144,11 @@ describe('deriveReviewerSummary', () => {
     const pr = makePR({
       reviews: {
         nodes: [
-          { state: 'DISMISSED', author: { login: 'carol', avatarUrl: 'https://example.com/carol.png' }, submittedAt: '2024-01-01T10:00:00Z' },
+          {
+            state: 'DISMISSED',
+            author: { login: 'carol', avatarUrl: 'https://example.com/carol.png' },
+            submittedAt: '2024-01-01T10:00:00Z',
+          },
         ],
       },
     })
@@ -143,7 +163,11 @@ describe('deriveReviewerSummary', () => {
     const pr = makePR({
       reviews: {
         nodes: [
-          { state: 'PENDING', author: { login: 'dave', avatarUrl: 'https://example.com/dave.png' }, submittedAt: '2024-01-01T10:00:00Z' },
+          {
+            state: 'PENDING',
+            author: { login: 'dave', avatarUrl: 'https://example.com/dave.png' },
+            submittedAt: '2024-01-01T10:00:00Z',
+          },
         ],
       },
     })
@@ -156,7 +180,13 @@ describe('deriveReviewerSummary', () => {
     const pr = makePR({
       reviewRequests: {
         nodes: [
-          { requestedReviewer: { __typename: 'User', login: 'eve', avatarUrl: 'https://example.com/eve.png' } },
+          {
+            requestedReviewer: {
+              __typename: 'User',
+              login: 'eve',
+              avatarUrl: 'https://example.com/eve.png',
+            },
+          },
         ],
       },
     })
@@ -169,12 +199,22 @@ describe('deriveReviewerSummary', () => {
     const pr = makePR({
       reviews: {
         nodes: [
-          { state: 'APPROVED', author: { login: 'frank', avatarUrl: 'https://example.com/frank.png' }, submittedAt: '2024-01-01T10:00:00Z' },
+          {
+            state: 'APPROVED',
+            author: { login: 'frank', avatarUrl: 'https://example.com/frank.png' },
+            submittedAt: '2024-01-01T10:00:00Z',
+          },
         ],
       },
       reviewRequests: {
         nodes: [
-          { requestedReviewer: { __typename: 'User', login: 'frank', avatarUrl: 'https://example.com/frank.png' } },
+          {
+            requestedReviewer: {
+              __typename: 'User',
+              login: 'frank',
+              avatarUrl: 'https://example.com/frank.png',
+            },
+          },
         ],
       },
     })
@@ -187,12 +227,22 @@ describe('deriveReviewerSummary', () => {
     const pr = makePR({
       reviews: {
         nodes: [
-          { state: 'DISMISSED', author: { login: 'grace', avatarUrl: 'https://example.com/grace.png' }, submittedAt: '2024-01-01T10:00:00Z' },
+          {
+            state: 'DISMISSED',
+            author: { login: 'grace', avatarUrl: 'https://example.com/grace.png' },
+            submittedAt: '2024-01-01T10:00:00Z',
+          },
         ],
       },
       reviewRequests: {
         nodes: [
-          { requestedReviewer: { __typename: 'User', login: 'grace', avatarUrl: 'https://example.com/grace.png' } },
+          {
+            requestedReviewer: {
+              __typename: 'User',
+              login: 'grace',
+              avatarUrl: 'https://example.com/grace.png',
+            },
+          },
         ],
       },
     })

--- a/src/lib/prUtils.ts
+++ b/src/lib/prUtils.ts
@@ -41,7 +41,12 @@ export function deriveReviewerSummary(pr: PullRequest, authorLogin: string): Rev
     .sort((a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime())
 
   const seen = new Set<string>()
-  const buckets: ReviewerSummary = { approved: [], changesRequested: [], commented: [], pending: [] }
+  const buckets: ReviewerSummary = {
+    approved: [],
+    changesRequested: [],
+    commented: [],
+    pending: [],
+  }
 
   for (const review of sorted) {
     if (!review.author || seen.has(review.author.login)) continue
@@ -70,7 +75,7 @@ export function deriveCheckState(pr: PullRequest): CheckRollupState | null {
 
 export function sortAndPartition(
   prs: PullRequest[],
-  priorityIds: string[],
+  priorityIds: string[]
 ): { regular: PullRequest[]; priorityPRs: PullRequest[] } {
   const byDate = [...prs].sort(
     (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,5 +6,5 @@ import App from './App.tsx'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 )

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -37,78 +37,80 @@ export default function AuthPage() {
   return (
     <div className="min-h-screen bg-[var(--color-surface)] flex flex-col">
       <div className="flex-1 flex items-center justify-center p-4">
-      <div className="w-full max-w-md">
-        {/* Logo / title */}
-        <div className="mb-8 text-center">
-          <h1 className="text-2xl font-semibold text-[var(--color-text-primary)] tracking-tight">
-            Donna
-          </h1>
-          <p className="mt-2 text-sm text-[var(--color-text-secondary)]">
-            The GitHub PR inbox you actually want to open.
-          </p>
-        </div>
-
-        <div className="bg-[var(--color-surface-raised)] border border-[var(--color-border)] rounded-lg p-6 space-y-4">
-          <div className="space-y-1.5">
-            <label
-              htmlFor="token"
-              className="block text-xs font-medium text-[var(--color-text-secondary)] uppercase tracking-wider"
-            >
-              Personal Access Token
-            </label>
-            <input
-              id="token"
-              type="password"
-              value={token}
-              onChange={(e) => setToken(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleConnect()}
-              placeholder="github_pat_..."
-              className="w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded-md px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-colors"
-            />
+        <div className="w-full max-w-md">
+          {/* Logo / title */}
+          <div className="mb-8 text-center">
+            <h1 className="text-2xl font-semibold text-[var(--color-text-primary)] tracking-tight">
+              Donna
+            </h1>
+            <p className="mt-2 text-sm text-[var(--color-text-secondary)]">
+              The GitHub PR inbox you actually want to open.
+            </p>
           </div>
 
-          {(error || (sessionExpired && !error)) && (
-            <p className="text-xs text-[var(--color-danger)] bg-[var(--color-danger-subtle)] border border-[var(--color-danger)] rounded px-3 py-2">
-              {error ?? 'Your session expired or the token was revoked. Please reconnect with a valid token.'}
-            </p>
-          )}
+          <div className="bg-[var(--color-surface-raised)] border border-[var(--color-border)] rounded-lg p-6 space-y-4">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="token"
+                className="block text-xs font-medium text-[var(--color-text-secondary)] uppercase tracking-wider"
+              >
+                Personal Access Token
+              </label>
+              <input
+                id="token"
+                type="password"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleConnect()}
+                placeholder="github_pat_..."
+                className="w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded-md px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-colors"
+              />
+            </div>
 
-          <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center">
-            <Lock size={16} className="text-[var(--color-text-muted)]" />
-            <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
-              Your GitHub token is never transmitted or shared. It only lives in your localStorage.{' '}
+            {(error || (sessionExpired && !error)) && (
+              <p className="text-xs text-[var(--color-danger)] bg-[var(--color-danger-subtle)] border border-[var(--color-danger)] rounded px-3 py-2">
+                {error ??
+                  'Your session expired or the token was revoked. Please reconnect with a valid token.'}
+              </p>
+            )}
+
+            <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center">
+              <Lock size={16} className="text-[var(--color-text-muted)]" />
+              <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+                Your GitHub token is never transmitted or shared. It only lives in your
+                localStorage.{' '}
+                <a
+                  href="https://github.com/settings/tokens/new?scopes=repo,read:org"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--color-accent)] hover:underline"
+                >
+                  Generate one →
+                </a>
+              </p>
+            </div>
+
+            <button
+              onClick={handleConnect}
+              disabled={loading || !token.trim()}
+              className="w-full bg-[var(--color-accent)] hover:opacity-90 disabled:opacity-40 text-white text-sm font-medium py-2 rounded-md transition-opacity cursor-pointer disabled:cursor-not-allowed"
+            >
+              {loading ? 'Connecting…' : 'Connect'}
+            </button>
+            <p className="text-xs text-[var(--color-text-muted)] text-center">
+              Using an organization with SSO?{' '}
               <a
-                href="https://github.com/settings/tokens/new?scopes=repo,read:org"
+                href="https://github.com/settings/tokens"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-[var(--color-accent)] hover:underline"
               >
-                Generate one →
-              </a>
+                Authorize the token for SSO
+              </a>{' '}
+              after generating it.
             </p>
           </div>
-
-          <button
-            onClick={handleConnect}
-            disabled={loading || !token.trim()}
-            className="w-full bg-[var(--color-accent)] hover:opacity-90 disabled:opacity-40 text-white text-sm font-medium py-2 rounded-md transition-opacity cursor-pointer disabled:cursor-not-allowed"
-          >
-            {loading ? 'Connecting…' : 'Connect'}
-          </button>
-          <p className="text-xs text-[var(--color-text-muted)] text-center">
-            Using an organization with SSO?{' '}
-            <a
-              href="https://github.com/settings/tokens"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--color-accent)] hover:underline"
-            >
-              Authorize the token for SSO
-            </a>{' '}
-            after generating it.
-          </p>
         </div>
-      </div>
       </div>
       <Footer />
     </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -25,10 +25,23 @@ function UpdateBanner({ version }: { version: string }) {
     <div className="flex items-center justify-between px-4 py-2 text-xs bg-[var(--color-accent)] text-white">
       <span>Version {version} is available.</span>
       <span className="flex items-center gap-3">
-        {downloaded
-          ? <button className="underline cursor-pointer" onClick={() => window.electronAPI?.updater?.installUpdate()}>Restart to install</button>
-          : <a href="https://github.com/adelbeke/donna/releases/latest" target="_blank" rel="noopener noreferrer" className="underline">Download</a>
-        }
+        {downloaded ? (
+          <button
+            className="underline cursor-pointer"
+            onClick={() => window.electronAPI?.updater?.installUpdate()}
+          >
+            Restart to install
+          </button>
+        ) : (
+          <a
+            href="https://github.com/adelbeke/donna/releases/latest"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Download
+          </a>
+        )}
         <button onClick={() => setDismissed(true)}>✕</button>
       </span>
     </div>
@@ -54,20 +67,27 @@ export default function DashboardPage() {
           </div>
 
           <div className="flex items-center gap-1 shrink-0">
-              {(['prs', ...(IS_ELECTRON ? ['branches' as const] : [])] as const).map((v) => (
-                <button key={v} onClick={() => setView(v)}
-                  className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
-                    ${view === v
-                      ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
-                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)]'
-                    }`}>
-                  {v === 'prs' ? 'Pull Requests' : 'Branches'}
-                </button>
-              ))}
-            </div>
+            {(['prs', ...(IS_ELECTRON ? ['branches' as const] : [])] as const).map((v) => (
+              <button
+                key={v}
+                onClick={() => setView(v)}
+                className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
+                    ${
+                      view === v
+                        ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
+                        : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)]'
+                    }`}
+              >
+                {v === 'prs' ? 'Pull Requests' : 'Branches'}
+              </button>
+            ))}
+          </div>
 
           <div className="relative flex-1 max-w-sm mx-auto">
-            <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]" />
+            <Search
+              size={13}
+              className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]"
+            />
             <input
               type="text"
               value={filters.search}
@@ -87,14 +107,8 @@ export default function DashboardPage() {
 
           {user && (
             <div className="flex items-center gap-3 shrink-0">
-              <img
-                src={user.avatarUrl}
-                alt={user.login}
-                className="w-6 h-6 rounded-full"
-              />
-              <span className="text-xs text-[var(--color-text-secondary)]">
-                {user.login}
-              </span>
+              <img src={user.avatarUrl} alt={user.login} className="w-6 h-6 rounded-full" />
+              <span className="text-xs text-[var(--color-text-secondary)]">{user.login}</span>
               <button
                 onClick={toggle}
                 title="Toggle theme"
@@ -120,15 +134,14 @@ export default function DashboardPage() {
 
       {/* Main layout */}
       <main className="flex-1 max-w-6xl mx-auto px-6 py-8 w-full">
-        {view === 'branches'
-          ? <BranchList />
-          : (
-            <div className="flex gap-8">
-              <Filters />
-              <PRList />
-            </div>
-          )
-        }
+        {view === 'branches' ? (
+          <BranchList />
+        ) : (
+          <div className="flex gap-8">
+            <Filters />
+            <PRList />
+          </div>
+        )}
       </main>
       <Footer />
     </div>

--- a/src/store/branchStore.ts
+++ b/src/store/branchStore.ts
@@ -12,7 +12,8 @@ export const useBranchStore = create<BranchStore>()(
     (set) => ({
       localPaths: [],
       addLocalPath: (path) => set((state) => ({ localPaths: [...state.localPaths, path] })),
-      removeLocalPath: (path) => set((state) => ({ localPaths: state.localPaths.filter((p) => p !== path) })),
+      removeLocalPath: (path) =>
+        set((state) => ({ localPaths: state.localPaths.filter((p) => p !== path) })),
     }),
     { name: 'branch-dashboard-state' }
   )

--- a/src/store/prStore.ts
+++ b/src/store/prStore.ts
@@ -5,8 +5,8 @@ export type PRSection = 'review-requested' | 'authored' | 'mentioned'
 
 export interface PRFilters {
   section: PRSection
-  repos: string[]          // empty = all
-  hiddenAuthors: string[]  // empty = all
+  repos: string[] // empty = all
+  hiddenAuthors: string[] // empty = all
   showDrafts: boolean
   showHidden: boolean
   search: string
@@ -43,8 +43,7 @@ export const usePRStore = create<PRStore>()(
       priorityIds: [],
       hiddenIds: [],
       setView: (v) => set((state) => ({ view: v, filters: { ...state.filters, search: '' } })),
-      setFilters: (partial) =>
-        set((state) => ({ filters: { ...state.filters, ...partial } })),
+      setFilters: (partial) => set((state) => ({ filters: { ...state.filters, ...partial } })),
       togglePriority: (id) =>
         set((state) => ({
           priorityIds: state.priorityIds.includes(id)
@@ -61,7 +60,12 @@ export const usePRStore = create<PRStore>()(
         set((state) => {
           const normalized = pattern.toLowerCase()
           if (state.filters.hiddenAuthors.includes(normalized)) return state
-          return { filters: { ...state.filters, hiddenAuthors: [...state.filters.hiddenAuthors, normalized] } }
+          return {
+            filters: {
+              ...state.filters,
+              hiddenAuthors: [...state.filters.hiddenAuthors, normalized],
+            },
+          }
         }),
       removeHiddenAuthor: (pattern) =>
         set((state) => ({

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -4,7 +4,10 @@ interface Window {
   electronAPI?: {
     gh: {
       isInstalled: () => Promise<boolean>
-      graphql: (query: string, variables: Record<string, unknown>) => Promise<{ data: unknown; errors?: { message: string }[] }>
+      graphql: (
+        query: string,
+        variables: Record<string, unknown>
+      ) => Promise<{ data: unknown; errors?: { message: string }[] }>
       rest: (path: string) => Promise<unknown>
     }
     branches: {

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -2,8 +2,16 @@ export type ReviewState = 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'PEND
 export type MergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
 export type CheckRollupState = 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED'
 export type CheckRunConclusion =
-  | 'ACTION_REQUIRED' | 'CANCELLED' | 'FAILURE' | 'NEUTRAL'
-  | 'SKIPPED' | 'STALE' | 'SUCCESS' | 'TIMED_OUT' | 'STARTUP_FAILURE' | null
+  | 'ACTION_REQUIRED'
+  | 'CANCELLED'
+  | 'FAILURE'
+  | 'NEUTRAL'
+  | 'SKIPPED'
+  | 'STALE'
+  | 'SUCCESS'
+  | 'TIMED_OUT'
+  | 'STARTUP_FAILURE'
+  | null
 
 export interface CheckRunContext {
   __typename: 'CheckRun'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,10 +7,7 @@ import pkg from './package.json'
 export default defineConfig({
   base: '/donna/',
   server: { port: 5173 },
-  plugins: [
-    react(),
-    tailwindcss(),
-  ],
+  plugins: [react(), tailwindcss()],
   define: { __APP_VERSION__: JSON.stringify(pkg.version) },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## What

Add Prettier for consistent code formatting across the project.

## Why

No formatter existed — diffs were polluted by style inconsistencies across editors. Prettier + `eslint-config-prettier` ensures a single canonical style with zero ESLint conflicts.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes