### PR TITLE
refactor: extract ButtonWithTooltip and unify copy feedback across components

### DIFF
--- a/src/components/BranchList/BranchList.tsx
+++ b/src/components/BranchList/BranchList.tsx
@@ -66,23 +66,23 @@ function BranchCard({
       </div>
       <div className="flex gap-2 items-center">
         {worktree && (
-          <button
-            onClick={() => navigator.clipboard.writeText(`cd ${worktree.path}`)}
-            title={`Copy: cd ${worktree.path}`}
-            className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-[var(--color-border-subtle)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border)] transition-colors cursor-pointer font-mono"
+          <CopyWithFeedback
+            text={`cd ${worktree.path}`}
+            label="Copy cd command"
+            buttonClassName="flex items-center gap-1 text-xs px-2 py-1 rounded border border-[var(--color-border-subtle)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border)] transition-colors cursor-pointer font-mono"
           >
             <Copy size={11} />
             cd {shortPath}
-          </button>
+          </CopyWithFeedback>
         )}
-        <button
-          onClick={() => navigator.clipboard.writeText(`git switch ${branch}`)}
-          title={`Copy: git switch ${branch}`}
-          className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-[var(--color-border-subtle)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border)] transition-colors cursor-pointer font-mono"
+        <CopyWithFeedback
+          text={`git switch ${branch}`}
+          label="Copy git switch command"
+          buttonClassName="flex items-center gap-1 text-xs px-2 py-1 rounded border border-[var(--color-border-subtle)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border)] transition-colors cursor-pointer font-mono"
         >
           <Copy size={11} />
           git switch {branch}
-        </button>
+        </CopyWithFeedback>
       </div>
     </div>
   )

--- a/src/components/PRCard/PRCard.tsx
+++ b/src/components/PRCard/PRCard.tsx
@@ -6,14 +6,15 @@ import {
   AlertCircle,
   Star,
   ExternalLink,
+  Link2,
   FileCode,
   EyeOff,
   Eye,
   CheckCircle,
   XCircle,
   Clock,
-  Link2,
 } from 'lucide-react'
+import { CopyWithFeedback } from '../shared/CopyWithFeedback'
 import type { PullRequest, ReviewState, CheckRollupState } from '../../types/github'
 import { usePRStore } from '../../store/prStore'
 import { useAuthStore } from '../../store/authStore'
@@ -102,8 +103,7 @@ const reviewBadge: Record<
 
 function PRCard({ pr, isAuthored = false }: Props) {
   const [checksOpen, setChecksOpen] = useState(false)
-  const [copied, setCopied] = useState(false)
-  const togglePriority = usePRStore((s) => s.togglePriority)
+    const togglePriority = usePRStore((s) => s.togglePriority)
   const toggleHide = usePRStore((s) => s.toggleHide)
   const priorityIds = usePRStore((s) => s.priorityIds)
   const viewerLogin = useAuthStore((s) => s.user?.login ?? '')
@@ -272,17 +272,12 @@ function PRCard({ pr, isAuthored = false }: Props) {
             <Star size={14} fill={isPriority ? 'currentColor' : 'none'} />
           </button>
 
-          <button
-            onClick={() => {
-              navigator.clipboard.writeText(pr.url)
-              setCopied(true)
-              setTimeout(() => setCopied(false), 1500)
-            }}
-            title="Copy PR link"
-            className="p-1.5 rounded text-[var(--color-text-muted)] opacity-0 group-hover:opacity-100 hover:text-[var(--color-accent)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
-          >
-            {copied ? <Check size={14} /> : <Link2 size={14} />}
-          </button>
+          <CopyWithFeedback
+            text={pr.url}
+            label="Copy PR link"
+            icon={<Link2 size={14} />}
+            buttonClassName="p-1.5 rounded text-[var(--color-text-muted)] opacity-0 group-hover:opacity-100 hover:text-[var(--color-accent)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+          />
 
           <a
             href={pr.url}

--- a/src/components/PRCard/PRCard.tsx
+++ b/src/components/PRCard/PRCard.tsx
@@ -103,7 +103,7 @@ const reviewBadge: Record<
 
 function PRCard({ pr, isAuthored = false }: Props) {
   const [checksOpen, setChecksOpen] = useState(false)
-    const togglePriority = usePRStore((s) => s.togglePriority)
+  const togglePriority = usePRStore((s) => s.togglePriority)
   const toggleHide = usePRStore((s) => s.toggleHide)
   const priorityIds = usePRStore((s) => s.priorityIds)
   const viewerLogin = useAuthStore((s) => s.user?.login ?? '')

--- a/src/components/shared/CopyWithFeedback.tsx
+++ b/src/components/shared/CopyWithFeedback.tsx
@@ -1,46 +1,53 @@
-import {Check, Copy} from 'lucide-react'
-import {useState} from 'react'
-import type {ReactNode} from 'react'
-import {ButtonWithTooltip} from "../ui/ButtonWithTooltip.tsx";
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+import type { ReactNode } from 'react'
+import { ButtonWithTooltip } from '../ui/ButtonWithTooltip.tsx'
 
 const FEEDBACK_DURATION_DEFAULT_DELAY = 3000
 // Matches Tailwind's default transition-opacity duration
 const TOOLTIP_TRANSITION_MS = 150
 
 export function CopyWithFeedback({
-                                     text,
-                                     label,
-                                     feedbackDuration = FEEDBACK_DURATION_DEFAULT_DELAY,
-                                     icon,
-                                     children,
-                                     buttonClassName,
-                                 }: {
-    text: string
-    label: string
-    feedbackDuration?: number
-    icon?: ReactNode
-    children?: ReactNode
-    buttonClassName?: string
+  text,
+  label,
+  feedbackDuration = FEEDBACK_DURATION_DEFAULT_DELAY,
+  icon,
+  children,
+  buttonClassName,
+}: {
+  text: string
+  label: string
+  feedbackDuration?: number
+  icon?: ReactNode
+  children?: ReactNode
+  buttonClassName?: string
 }) {
-    const [copied, setCopied] = useState(false)
-    const [showCopied, setShowCopied] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [showCopied, setShowCopied] = useState(false)
 
-    function handleCopy() {
-        navigator.clipboard.writeText(text)
-        setCopied(true)
-        setShowCopied(true)
-        setTimeout(() => {
-            setCopied(false)
-            setTimeout(() => setShowCopied(false), TOOLTIP_TRANSITION_MS)
-        }, feedbackDuration)
-    }
+  function handleCopy() {
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    setShowCopied(true)
+    setTimeout(() => {
+      setCopied(false)
+      setTimeout(() => setShowCopied(false), TOOLTIP_TRANSITION_MS)
+    }, feedbackDuration)
+  }
 
-    return (
-        <ButtonWithTooltip label={showCopied ? 'Copied!' : label}
-                           onClick={handleCopy}
-                           tooltipClassName={copied ? 'opacity-100' : 'opacity-0 group-hover/tooltip:opacity-100'}
-                           buttonClassName={buttonClassName}>
-            {children ?? (showCopied ? <Check size={13} className="text-green-500"/> : (icon ?? <Copy size={13}/>))}
-        </ButtonWithTooltip>
-    )
+  return (
+    <ButtonWithTooltip
+      label={showCopied ? 'Copied!' : label}
+      onClick={handleCopy}
+      tooltipClassName={copied ? 'opacity-100' : 'opacity-0 group-hover/tooltip:opacity-100'}
+      buttonClassName={buttonClassName}
+    >
+      {children ??
+        (showCopied ? (
+          <Check size={13} className="text-green-500" />
+        ) : (
+          (icon ?? <Copy size={13} />)
+        ))}
+    </ButtonWithTooltip>
+  )
 }

--- a/src/components/shared/CopyWithFeedback.tsx
+++ b/src/components/shared/CopyWithFeedback.tsx
@@ -1,45 +1,46 @@
-import { Check, Copy } from 'lucide-react'
-import { useState } from 'react'
+import {Check, Copy} from 'lucide-react'
+import {useState} from 'react'
+import type {ReactNode} from 'react'
+import {ButtonWithTooltip} from "../ui/ButtonWithTooltip.tsx";
 
 const FEEDBACK_DURATION_DEFAULT_DELAY = 3000
 // Matches Tailwind's default transition-opacity duration
 const TOOLTIP_TRANSITION_MS = 150
 
 export function CopyWithFeedback({
-  text,
-  label,
-  feedbackDuration = FEEDBACK_DURATION_DEFAULT_DELAY,
-}: {
-  text: string
-  label: string
-  feedbackDuration?: number
+                                     text,
+                                     label,
+                                     feedbackDuration = FEEDBACK_DURATION_DEFAULT_DELAY,
+                                     icon,
+                                     children,
+                                     buttonClassName,
+                                 }: {
+    text: string
+    label: string
+    feedbackDuration?: number
+    icon?: ReactNode
+    children?: ReactNode
+    buttonClassName?: string
 }) {
-  const [copied, setCopied] = useState(false)
-  const [showCopied, setShowCopied] = useState(false)
+    const [copied, setCopied] = useState(false)
+    const [showCopied, setShowCopied] = useState(false)
 
-  function handleCopy() {
-    navigator.clipboard.writeText(text)
-    setCopied(true)
-    setShowCopied(true)
-    setTimeout(() => {
-      setCopied(false)
-      setTimeout(() => setShowCopied(false), TOOLTIP_TRANSITION_MS)
-    }, feedbackDuration)
-  }
+    function handleCopy() {
+        navigator.clipboard.writeText(text)
+        setCopied(true)
+        setShowCopied(true)
+        setTimeout(() => {
+            setCopied(false)
+            setTimeout(() => setShowCopied(false), TOOLTIP_TRANSITION_MS)
+        }, feedbackDuration)
+    }
 
-  return (
-    <div className="relative group">
-      <button
-        onClick={handleCopy}
-        className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer"
-      >
-        {showCopied ? <Check size={13} className="text-green-500" /> : <Copy size={13} />}
-      </button>
-      <span
-        className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none transition-opacity ${copied ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
-      >
-        {showCopied ? 'Copied!' : label}
-      </span>
-    </div>
-  )
+    return (
+        <ButtonWithTooltip label={showCopied ? 'Copied!' : label}
+                           onClick={handleCopy}
+                           tooltipClassName={copied ? 'opacity-100' : 'opacity-0 group-hover/tooltip:opacity-100'}
+                           buttonClassName={buttonClassName}>
+            {children ?? (showCopied ? <Check size={13} className="text-green-500"/> : (icon ?? <Copy size={13}/>))}
+        </ButtonWithTooltip>
+    )
 }

--- a/src/components/ui/ButtonWithTooltip.tsx
+++ b/src/components/ui/ButtonWithTooltip.tsx
@@ -1,0 +1,24 @@
+import type {PropsWithChildren} from "react";
+
+type Props = PropsWithChildren & {
+    label: string
+    onClick: () => void
+    tooltipClassName?: string
+    buttonClassName?: string
+}
+
+export function ButtonWithTooltip({ children, label, tooltipClassName, onClick, buttonClassName}: Props) {
+    return (
+        <div className="relative group/tooltip">
+            <button
+                onClick={onClick}
+                className={buttonClassName ?? "text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer"}
+            >
+                {children}
+            </button>
+            <span
+                className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none transition-opacity ${tooltipClassName}`}>
+        {label}
+      </span>
+        </div>)
+}

--- a/src/components/ui/ButtonWithTooltip.tsx
+++ b/src/components/ui/ButtonWithTooltip.tsx
@@ -1,24 +1,35 @@
-import type {PropsWithChildren} from "react";
+import type { PropsWithChildren } from 'react'
 
 type Props = PropsWithChildren & {
-    label: string
-    onClick: () => void
-    tooltipClassName?: string
-    buttonClassName?: string
+  label: string
+  onClick: () => void
+  tooltipClassName?: string
+  buttonClassName?: string
 }
 
-export function ButtonWithTooltip({ children, label, tooltipClassName, onClick, buttonClassName}: Props) {
-    return (
-        <div className="relative group/tooltip">
-            <button
-                onClick={onClick}
-                className={buttonClassName ?? "text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer"}
-            >
-                {children}
-            </button>
-            <span
-                className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none transition-opacity ${tooltipClassName}`}>
+export function ButtonWithTooltip({
+  children,
+  label,
+  tooltipClassName,
+  onClick,
+  buttonClassName,
+}: Props) {
+  return (
+    <div className="relative group/tooltip">
+      <button
+        onClick={onClick}
+        className={
+          buttonClassName ??
+          'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer'
+        }
+      >
+        {children}
+      </button>
+      <span
+        className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none transition-opacity ${tooltipClassName}`}
+      >
         {label}
       </span>
-        </div>)
+    </div>
+  )
 }


### PR DESCRIPTION
## What

Extract `ButtonWithTooltip` as a shared UI primitive and extend `CopyWithFeedback` to cover all copy interactions in the app — replacing ad-hoc clipboard buttons in `BranchList` and `PRCard`.

## Why

Three components had their own clipboard + feedback logic. `CopyWithFeedback` existed but wasn't used consistently, and `PRCard` still had inline state management for copy feedback. The tooltip also triggered on parent card hover due to an unnamed `group` conflict.

## Changes

- `ButtonWithTooltip`: new shared primitive extracted from `CopyWithFeedback`, adds `buttonClassName` prop and uses `group/tooltip` named group to avoid tooltip leaking on parent hover
- `CopyWithFeedback`: adds `icon` prop (replaces default `Copy` icon but still switches to `Check`) and `children` prop (static button content for text-style buttons like `git switch`/`cd`)
- `BranchList`: `cd` and `git switch` buttons now use `CopyWithFeedback` with children + buttonClassName
- `PRCard`: inline copy state replaced with `CopyWithFeedback` using `icon={<Link2 />}`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [ ] `npm run build` passes

---
_This pull request was created with AI assistance._