### PR TITLE
feat: add branch deletion from the branches tab

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -98,6 +98,36 @@ ipcMain.handle('branches:list', async (_e, repoPath: string) => {
   }
 })
 
+ipcMain.handle('branches:switchToDefault', async (_e, repoPath: string) => {
+  try {
+    await execFileAsync('git', ['-C', repoPath, 'switch', 'main'])
+  } catch {
+    try {
+      await execFileAsync('git', ['-C', repoPath, 'switch', 'master'])
+    } catch (e) {
+      throw gitError(e)
+    }
+  }
+})
+
+ipcMain.handle('branches:delete', async (_e, repoPath: string, branch: string) => {
+  try {
+    await execFileAsync('git', ['-C', repoPath, 'branch', '-d', branch])
+  } catch (e) {
+    throw gitError(e)
+  }
+})
+
+ipcMain.handle('worktrees:remove', async (_e, repoPath: string, worktreePath: string, force: boolean) => {
+  try {
+    const args = ['-C', repoPath, 'worktree', 'remove', worktreePath]
+    if (force) args.splice(4, 0, '--force')
+    await execFileAsync('git', args)
+  } catch (e) {
+    throw gitError(e)
+  }
+})
+
 ipcMain.handle('dialog:open', async () => {
   const { canceled, filePaths } = await dialog.showOpenDialog({ properties: ['openDirectory'] })
   return canceled ? null : filePaths[0]

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -118,15 +118,18 @@ ipcMain.handle('branches:delete', async (_e, repoPath: string, branch: string) =
   }
 })
 
-ipcMain.handle('worktrees:remove', async (_e, repoPath: string, worktreePath: string, force: boolean) => {
-  try {
-    const args = ['-C', repoPath, 'worktree', 'remove', worktreePath]
-    if (force) args.splice(4, 0, '--force')
-    await execFileAsync('git', args)
-  } catch (e) {
-    throw gitError(e)
+ipcMain.handle(
+  'worktrees:remove',
+  async (_e, repoPath: string, worktreePath: string, force: boolean) => {
+    try {
+      const args = ['-C', repoPath, 'worktree', 'remove', worktreePath]
+      if (force) args.splice(4, 0, '--force')
+      await execFileAsync('git', args)
+    } catch (e) {
+      throw gitError(e)
+    }
   }
-})
+)
 
 ipcMain.handle('dialog:open', async () => {
   const { canceled, filePaths } = await dialog.showOpenDialog({ properties: ['openDirectory'] })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -9,9 +9,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   branches: {
     list: (repoPath: string): Promise<string[]> => ipcRenderer.invoke('branches:list', repoPath),
+    delete: (repoPath: string, branch: string): Promise<void> =>
+      ipcRenderer.invoke('branches:delete', repoPath, branch),
+    switchToDefault: (repoPath: string): Promise<void> =>
+      ipcRenderer.invoke('branches:switchToDefault', repoPath),
   },
   worktrees: {
     list: (repoPath: string): Promise<unknown[]> => ipcRenderer.invoke('worktrees:list', repoPath),
+    remove: (repoPath: string, worktreePath: string, force: boolean): Promise<void> =>
+      ipcRenderer.invoke('worktrees:remove', repoPath, worktreePath, force),
   },
   dialog: {
     openDirectory: (): Promise<string | null> => ipcRenderer.invoke('dialog:open'),

--- a/src/components/BranchList/BranchList.test.tsx
+++ b/src/components/BranchList/BranchList.test.tsx
@@ -111,7 +111,13 @@ describe('BranchCard — current branch', () => {
 })
 
 describe('BranchCard — worktree branch', () => {
-  const worktree = { path: '/repos/my-repo-wt', branch: 'feat/my-feature', commit: 'abc123', isMain: false, isDirty: false }
+  const worktree = {
+    path: '/repos/my-repo-wt',
+    branch: 'feat/my-feature',
+    commit: 'abc123',
+    isMain: false,
+    isDirty: false,
+  }
 
   it('WHEN more-actions clicked THEN shows Remove worktree, not Delete branch', async () => {
     const user = userEvent.setup()

--- a/src/components/BranchList/BranchList.test.tsx
+++ b/src/components/BranchList/BranchList.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BranchCard } from './BranchList'
+
+const mockDelete = vi.fn().mockResolvedValue(undefined)
+const mockSwitchToDefault = vi.fn().mockResolvedValue(undefined)
+const mockRemove = vi.fn().mockResolvedValue(undefined)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(window, 'confirm').mockReturnValue(true)
+  Object.defineProperty(window, 'electronAPI', {
+    value: {
+      branches: { delete: mockDelete, switchToDefault: mockSwitchToDefault },
+      worktrees: { remove: mockRemove },
+    },
+    writable: true,
+    configurable: true,
+  })
+})
+
+function card(overrides: Partial<Parameters<typeof BranchCard>[0]> = {}) {
+  const onDeleted = vi.fn()
+  render(
+    <BranchCard
+      branch="feat/my-feature"
+      repo="my-repo"
+      repoPath="/repos/my-repo"
+      hue={210}
+      isCurrentBranch={false}
+      onDeleted={onDeleted}
+      {...overrides}
+    />
+  )
+  return { onDeleted }
+}
+
+describe('BranchCard — protected branches', () => {
+  it('GIVEN branch is main WHEN rendered THEN no more-actions button', () => {
+    card({ branch: 'main' })
+    expect(screen.queryByTitle('More actions')).not.toBeInTheDocument()
+  })
+
+  it('GIVEN branch is master WHEN rendered THEN no more-actions button', () => {
+    card({ branch: 'master' })
+    expect(screen.queryByTitle('More actions')).not.toBeInTheDocument()
+  })
+})
+
+describe('BranchCard — regular branch', () => {
+  it('WHEN rendered THEN more-actions button is visible', () => {
+    card()
+    expect(screen.getByTitle('More actions')).toBeInTheDocument()
+  })
+
+  it('WHEN more-actions clicked THEN shows Delete branch option', async () => {
+    const user = userEvent.setup()
+    card()
+    await user.click(screen.getByTitle('More actions'))
+    expect(screen.getByText('Delete branch')).toBeInTheDocument()
+  })
+
+  it('GIVEN user confirms WHEN Delete branch clicked THEN calls branches.delete', async () => {
+    const user = userEvent.setup()
+    const { onDeleted } = card()
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Delete branch'))
+    expect(mockDelete).toHaveBeenCalledWith('/repos/my-repo', 'feat/my-feature')
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled())
+  })
+
+  it('GIVEN user cancels WHEN Delete branch clicked THEN does not call branches.delete', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = userEvent.setup()
+    card()
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Delete branch'))
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it('GIVEN delete fails WHEN Delete branch clicked THEN shows error inline', async () => {
+    mockDelete.mockRejectedValueOnce(new Error('branch not fully merged'))
+    const user = userEvent.setup()
+    card()
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Delete branch'))
+    await waitFor(() => expect(screen.getByText('branch not fully merged')).toBeInTheDocument())
+  })
+})
+
+describe('BranchCard — current branch', () => {
+  it('WHEN more-actions clicked THEN confirm message mentions switching to main', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = userEvent.setup()
+    card({ isCurrentBranch: true })
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Delete branch'))
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('switch to main'))
+  })
+
+  it('GIVEN user confirms WHEN Delete branch clicked THEN calls switchToDefault then delete', async () => {
+    const user = userEvent.setup()
+    const { onDeleted } = card({ isCurrentBranch: true })
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Delete branch'))
+    expect(mockSwitchToDefault).toHaveBeenCalledWith('/repos/my-repo')
+    expect(mockDelete).toHaveBeenCalledWith('/repos/my-repo', 'feat/my-feature')
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled())
+  })
+})
+
+describe('BranchCard — worktree branch', () => {
+  const worktree = { path: '/repos/my-repo-wt', branch: 'feat/my-feature', commit: 'abc123', isMain: false, isDirty: false }
+
+  it('WHEN more-actions clicked THEN shows Remove worktree, not Delete branch', async () => {
+    const user = userEvent.setup()
+    card({ worktree })
+    await user.click(screen.getByTitle('More actions'))
+    expect(screen.getByText('Remove worktree')).toBeInTheDocument()
+    expect(screen.queryByText('Delete branch')).not.toBeInTheDocument()
+  })
+
+  it('GIVEN user confirms WHEN Remove worktree clicked THEN calls worktrees.remove with force=false', async () => {
+    const user = userEvent.setup()
+    const { onDeleted } = card({ worktree })
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Remove worktree'))
+    expect(mockRemove).toHaveBeenCalledWith('/repos/my-repo', '/repos/my-repo-wt', false)
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled())
+  })
+
+  it('GIVEN dirty worktree WHEN more-actions clicked THEN confirm message warns about lost changes', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = userEvent.setup()
+    card({ worktree: { ...worktree, isDirty: true } })
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Remove worktree'))
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('uncommitted changes'))
+  })
+
+  it('GIVEN dirty worktree WHEN user confirms THEN calls worktrees.remove with force=true', async () => {
+    const user = userEvent.setup()
+    const { onDeleted } = card({ worktree: { ...worktree, isDirty: true } })
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Remove worktree'))
+    expect(mockRemove).toHaveBeenCalledWith('/repos/my-repo', '/repos/my-repo-wt', true)
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled())
+  })
+})

--- a/src/components/BranchList/BranchList.tsx
+++ b/src/components/BranchList/BranchList.tsx
@@ -103,44 +103,44 @@ export function BranchCard({
               <ExternalLink size={10} />
             </a>
           )}
-          {!isProtected && <div className="relative">
-            <button
-              onClick={() => setIsMenuOpen((v) => !v)}
-              title="More actions"
-              className="p-1 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
-            >
-              <MoreVertical size={14} />
-            </button>
-            {isMenuOpen && (
-              <>
-                <div className="fixed inset-0 z-10" onClick={() => setIsMenuOpen(false)} />
-                <div className="absolute right-0 top-full z-20 mt-1 min-w-[160px] rounded-md border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg py-1">
-                  {worktree ? (
-                    <button
-                      onClick={removeWorktree}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--color-danger)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
-                    >
-                      <Trash2 size={12} />
-                      Remove worktree
-                    </button>
-                  ) : (
-                    <button
-                      onClick={deleteBranch}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--color-danger)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
-                    >
-                      <Trash2 size={12} />
-                      Delete branch
-                    </button>
-                  )}
-                </div>
-              </>
-            )}
-          </div>}
+          {!isProtected && (
+            <div className="relative">
+              <button
+                onClick={() => setIsMenuOpen((v) => !v)}
+                title="More actions"
+                className="p-1 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
+              >
+                <MoreVertical size={14} />
+              </button>
+              {isMenuOpen && (
+                <>
+                  <div className="fixed inset-0 z-10" onClick={() => setIsMenuOpen(false)} />
+                  <div className="absolute right-0 top-full z-20 mt-1 min-w-[160px] rounded-md border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg py-1">
+                    {worktree ? (
+                      <button
+                        onClick={removeWorktree}
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--color-danger)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
+                      >
+                        <Trash2 size={12} />
+                        Remove worktree
+                      </button>
+                    ) : (
+                      <button
+                        onClick={deleteBranch}
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--color-danger)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
+                      >
+                        <Trash2 size={12} />
+                        Delete branch
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
-      {deleteError && (
-        <p className="text-xs text-[var(--color-danger)]">{deleteError}</p>
-      )}
+      {deleteError && <p className="text-xs text-[var(--color-danger)]">{deleteError}</p>}
       <div className="flex gap-2 items-center">
         {worktree && (
           <CopyWithFeedback

--- a/src/components/BranchList/BranchList.tsx
+++ b/src/components/BranchList/BranchList.tsx
@@ -1,6 +1,6 @@
 import { useQueries } from '@tanstack/react-query'
-import { Copy, ExternalLink, FolderPlus, RefreshCw, X } from 'lucide-react'
-import { useMemo } from 'react'
+import { Copy, ExternalLink, FolderPlus, MoreVertical, RefreshCw, Trash2, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import { usePRStore } from '../../store/prStore'
 import { useBranchStore } from '../../store/branchStore'
 import { usePullRequests } from '../../hooks/useGitHubPRs'
@@ -10,20 +10,59 @@ import type { PullRequest } from '../../types/github'
 
 const REPO_HUES = [210, 140, 30, 280, 180, 60, 320, 260]
 
-function BranchCard({
+export function BranchCard({
   branch,
   repo,
+  repoPath,
   hue,
+  isCurrentBranch,
   worktree,
   pr,
+  onDeleted,
 }: {
   branch: string
   repo: string
+  repoPath: string
   hue: number
+  isCurrentBranch: boolean
   worktree?: Worktree
   pr?: PullRequest
+  onDeleted: () => void
 }) {
   const shortPath = worktree?.path.replace(/^\/Users\/[^/]+/, '~')
+  const isProtected = branch === 'main' || branch === 'master'
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  async function deleteBranch() {
+    const message = isCurrentBranch
+      ? `Delete branch "${branch}"?\n\nYou're currently on this branch — git will switch to main first.`
+      : `Delete branch "${branch}"?\nThe branch must be fully merged.`
+    if (!window.confirm(message)) return
+    setIsMenuOpen(false)
+    try {
+      if (isCurrentBranch) await window.electronAPI!.branches.switchToDefault(repoPath)
+      await window.electronAPI!.branches.delete(repoPath, branch)
+      onDeleted()
+    } catch (e) {
+      setDeleteError((e as Error).message)
+    }
+  }
+
+  async function removeWorktree() {
+    const wt = worktree!
+    const message = wt.isDirty
+      ? `⚠️ "${branch}" has uncommitted changes.\n\nRemoving this worktree will permanently delete those changes.\n\nAre you sure?`
+      : `Remove worktree at "${wt.path}"?`
+    if (!window.confirm(message)) return
+    setIsMenuOpen(false)
+    try {
+      await window.electronAPI!.worktrees.remove(repoPath, wt.path, wt.isDirty)
+      onDeleted()
+    } catch (e) {
+      setDeleteError((e as Error).message)
+    }
+  }
 
   return (
     <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-4 py-3 space-y-2">
@@ -52,18 +91,56 @@ function BranchCard({
             className="w-2 h-2 rounded-full bg-yellow-400 inline-block"
           />
         )}
-        {pr && (
-          <a
-            href={pr.url}
-            target="_blank"
-            rel="noreferrer"
-            className="ml-auto flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-[var(--color-border-subtle)] text-[var(--color-accent)] hover:border-[var(--color-accent)] transition-colors font-mono"
-          >
-            #{pr.number}
-            <ExternalLink size={10} />
-          </a>
-        )}
+        <div className="ml-auto flex items-center gap-1">
+          {pr && (
+            <a
+              href={pr.url}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-[var(--color-border-subtle)] text-[var(--color-accent)] hover:border-[var(--color-accent)] transition-colors font-mono"
+            >
+              #{pr.number}
+              <ExternalLink size={10} />
+            </a>
+          )}
+          {!isProtected && <div className="relative">
+            <button
+              onClick={() => setIsMenuOpen((v) => !v)}
+              title="More actions"
+              className="p-1 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
+            >
+              <MoreVertical size={14} />
+            </button>
+            {isMenuOpen && (
+              <>
+                <div className="fixed inset-0 z-10" onClick={() => setIsMenuOpen(false)} />
+                <div className="absolute right-0 top-full z-20 mt-1 min-w-[160px] rounded-md border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg py-1">
+                  {worktree ? (
+                    <button
+                      onClick={removeWorktree}
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--color-danger)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
+                    >
+                      <Trash2 size={12} />
+                      Remove worktree
+                    </button>
+                  ) : (
+                    <button
+                      onClick={deleteBranch}
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--color-danger)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
+                    >
+                      <Trash2 size={12} />
+                      Delete branch
+                    </button>
+                  )}
+                </div>
+              </>
+            )}
+          </div>}
+        </div>
       </div>
+      {deleteError && (
+        <p className="text-xs text-[var(--color-danger)]">{deleteError}</p>
+      )}
       <div className="flex gap-2 items-center">
         {worktree && (
           <CopyWithFeedback
@@ -153,7 +230,9 @@ export default function BranchList() {
         key: string
         branch: string
         repoLabel: string
+        repoPath: string
         hue: number
+        isCurrentBranch: boolean
         worktree?: Worktree
         pr?: PullRequest
       }
@@ -189,6 +268,7 @@ export default function BranchList() {
     for (const wt of worktrees ?? []) {
       if (wt.branch && !wt.isMain) wtByBranch.set(wt.branch, wt)
     }
+    const mainBranch = (worktrees ?? []).find((wt) => wt.isMain)?.branch ?? ''
 
     for (const branch of (branches ?? []).filter(
       (b) => !filters.search || b.toLowerCase().includes(filters.search.toLowerCase())
@@ -197,7 +277,9 @@ export default function BranchList() {
         key: `${localPath}/${branch}`,
         branch,
         repoLabel,
+        repoPath: localPath,
         hue: REPO_HUES[i % REPO_HUES.length],
+        isCurrentBranch: branch === mainBranch,
         worktree: wtByBranch.get(branch),
         pr: prMap.get(`${repoLabel}/${branch}`),
       })
@@ -267,9 +349,12 @@ export default function BranchList() {
               key={item.key}
               branch={item.branch}
               repo={item.repoLabel}
+              repoPath={item.repoPath}
+              isCurrentBranch={item.isCurrentBranch}
               hue={item.hue}
               worktree={item.worktree}
               pr={item.pr}
+              onDeleted={refetchAll}
             />
           )
         })}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -12,9 +12,12 @@ interface Window {
     }
     branches: {
       list: (repoPath: string) => Promise<string[]>
+      delete: (repoPath: string, branch: string) => Promise<void>
+      switchToDefault: (repoPath: string) => Promise<void>
     }
     worktrees: {
       list: (repoPath: string) => Promise<import('./worktree').Worktree[]>
+      remove: (repoPath: string, worktreePath: string, force: boolean) => Promise<void>
     }
     dialog: {
       openDirectory: () => Promise<string | null>


### PR DESCRIPTION
## What

Adds a `⋮` context menu on each `BranchCard` in the Branches tab (Electron only) to delete a branch or remove a worktree.

## Why

Closes #65 — the Branches view was read-only; users had to go to the terminal to clean up stale branches or worktrees.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes (133 tests, 13 new)
- [x] `npm run build` passes

---
_This pull request was created with AI assistance._