### PR TITLE
refactor: split App into AppContainer/WebContainer with FeaturesContext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,9 @@ electron/            Electron main + preload (Node side; the only place that she
   main.ts            ipcMain handlers: gh:graphql/rest/installed, branches/worktrees list, dialog, updater
   preload.ts         contextBridge → window.electronAPI (typed in src/types/electron.d.ts)
 src/
-  App.tsx            QueryClient setup, Electron-vs-web auth gating, top-level routing
+  App.tsx            QueryClient setup + container switch (IS_NATIVE → AppContainer or WebContainer)
+  AppContainer.tsx   Electron entry: gh CLI auth probe, error screen, mounts DashboardPage
+  WebContainer.tsx   Web entry: PAT gate, mounts AuthPage or DashboardPage
   main.tsx           React entry
   index.css          Tailwind v4 @theme tokens + [data-theme="light"] overrides
   pages/             AuthPage (web PAT entry), DashboardPage (navbar + view switch)
@@ -59,23 +61,25 @@ src/
                      useTheme, useUpdateCheck
   store/             Zustand stores: authStore, prStore, branchStore
   lib/               github.ts (clients + GraphQL queries), prUtils.ts & prFilters.ts (pure,
-                     well-tested), timeAgo.ts, electron.ts (IS_ELECTRON)
+                     well-tested), timeAgo.ts, electron.ts (IS_NATIVE), features.ts (FeaturesContext)
   types/             github.ts (API shapes), worktree.ts, electron.d.ts (window global)
 ```
 
 `src/config.ts` is empty. `src/hooks/useBranches.ts`, `useRepos.ts`, `useRecentRepos.ts` exist but are **not wired into any view** (the live Branches tab uses local git via IPC, not these GraphQL/REST hooks) — treat them as dormant, not load-bearing.
 
-## The Electron-vs-web abstraction
+## The native-vs-web abstraction
 
-The renderer never branches on platform ad hoc. It goes through two seams:
+The renderer never branches on platform ad hoc. It goes through three seams:
 
-1. **`IS_ELECTRON`** (`src/lib/electron.ts`) — just `!!window.electronAPI`. The `electronAPI` object is injected by `electron/preload.ts` via `contextBridge` and is absent in the browser. Use this to gate Electron-only UI (the Branches tab, the OTA banner, hiding the PAT privacy note / logout button).
+1. **`AppContainer` / `WebContainer`** — the top-level split. `App.tsx` uses `IS_NATIVE` exactly once to choose which container to render. All platform-specific bootstrap logic (auth flow, error screens) lives in these two files and nowhere else.
 
-2. **`createClient(token)` / `restFetch(url, token)`** (`src/lib/github.ts`) — the transport seam. In Electron they call `window.electronAPI.gh.graphql/.rest`, which IPCs to `electron/main.ts` and shells out to `gh api`. In the browser they hit `api.github.com` directly with the PAT. **Data hooks stay platform-agnostic by always going through these functions** — never call `fetch` to GitHub or read `window.electronAPI` directly from a hook/component.
+2. **`FeaturesContext`** (`src/lib/features.ts`) — a static React context (never updated after mount) that carries the set of gated `Feature` values. `AppContainer` provides `new Set(['branches'])`; `WebContainer` leaves the default empty Set. Components read it via `useFeatures()` — **never import `IS_NATIVE` inside a component**, use `features.has('branches')` instead. To add a new gated feature: add it to the `Feature` union type and set it in `AppContainer`.
+
+3. **`createClient(token)` / `restFetch(url, token)`** (`src/lib/github.ts`) — the transport seam. In Electron they call `window.electronAPI.gh.graphql/.rest`, which IPCs to `electron/main.ts` and shells out to `gh api`. In the browser they hit `api.github.com` directly with the PAT. **Data hooks stay platform-agnostic by always going through these functions** — never call `fetch` to GitHub or read `window.electronAPI` directly from a hook/component.
 
 Anything that touches the local filesystem (list branches, list worktrees, directory picker) is Electron-only and lives as an `ipcMain.handle` in `electron/main.ts`, exposed through `preload.ts`, typed in `src/types/electron.d.ts`. These shell out to local `git`. `main.ts` augments `PATH` with Homebrew dirs so the bundled `.app` can find `gh`/`git`.
 
-Auth flow differs by mode (`src/App.tsx`): web shows `AuthPage` until a PAT is set; Electron auto-probes `gh` on launch, sets a sentinel token `'gh-cli'`, and shows an error screen with a Retry button if `gh` is missing or not logged in.
+Auth flow differs by container: `WebContainer` shows `AuthPage` until a PAT is set; `AppContainer` auto-probes `gh` on launch, sets a sentinel token `'gh-cli'`, and shows an error screen with a Retry button if `gh` is missing or not logged in.
 
 ## State management
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,9 @@
-import { useEffect, useState, useCallback } from 'react'
 import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-query'
-import { Terminal } from 'lucide-react'
 import { useAuthStore } from './store/authStore'
-import { isAuthError, VIEWER_QUERY } from './lib/github'
-import { IS_ELECTRON } from './lib/electron'
-import AuthPage from './pages/AuthPage'
-import DashboardPage from './pages/DashboardPage'
-import type { GitHubUser } from './types/github'
+import { isAuthError } from './lib/github'
+import { IS_NATIVE } from './lib/electron'
+import { AppContainer } from './AppContainer'
+import { WebContainer } from './WebContainer'
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -22,73 +19,10 @@ const queryClient = new QueryClient({
   },
 })
 
-function ElectronAuthError({ message, onRetry }: { message: string; onRetry: () => void }) {
-  return (
-    <div className="min-h-screen bg-[var(--color-surface)] flex flex-col items-center justify-center gap-4 p-8">
-      <Terminal size={32} className="text-[var(--color-text-muted)]" />
-      <p className="text-sm text-[var(--color-text-primary)] text-center max-w-xs">{message}</p>
-      <button
-        onClick={onRetry}
-        className="text-xs px-3 py-1.5 rounded bg-[var(--color-accent)] text-white cursor-pointer"
-      >
-        Retry
-      </button>
-    </div>
-  )
-}
-
-async function tryElectronAuth(
-  setToken: (t: string) => void,
-  setUser: (u: GitHubUser) => void
-): Promise<string | null> {
-  const installed = await window.electronAPI!.gh.isInstalled()
-  if (!installed) return 'gh CLI not found. Install it at cli.github.com then relaunch.'
-  try {
-    const res = await window.electronAPI!.gh.graphql(VIEWER_QUERY, {})
-    const viewer = (res.data as { viewer: GitHubUser }).viewer
-    setToken('gh-cli')
-    setUser(viewer)
-    return null
-  } catch {
-    return 'Not authenticated. Run `gh auth login` in your terminal then click Retry.'
-  }
-}
-
-function AppContent() {
-  const { token, setToken, setUser } = useAuthStore()
-  const [ghChecking, setGhChecking] = useState(() => IS_ELECTRON && !token)
-  const [ghError, setGhError] = useState<string | null>(null)
-
-  const runElectronAuth = useCallback(() => {
-    setGhError(null)
-    setGhChecking(true)
-    tryElectronAuth(setToken, setUser)
-      .then(setGhError)
-      .finally(() => setGhChecking(false))
-  }, [setToken, setUser])
-
-  useEffect(() => {
-    if (!IS_ELECTRON || token) return
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    runElectronAuth()
-    // ponytail: run once; token excluded so re-auth on next open uses cached token
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  if (ghChecking) return null
-
-  if (IS_ELECTRON) {
-    if (ghError) return <ElectronAuthError message={ghError} onRetry={runElectronAuth} />
-    return <DashboardPage />
-  }
-
-  return token ? <DashboardPage /> : <AuthPage />
-}
-
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <AppContent />
+      {IS_NATIVE ? <AppContainer /> : <WebContainer />}
     </QueryClientProvider>
   )
 }

--- a/src/AppContainer.tsx
+++ b/src/AppContainer.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState, useCallback } from 'react'
+import { Terminal } from 'lucide-react'
+import { useAuthStore } from './store/authStore'
+import { VIEWER_QUERY } from './lib/github'
+import DashboardPage from './pages/DashboardPage'
+import { FeaturesContext, type Feature } from './lib/features'
+import type { GitHubUser } from './types/github'
+
+const APP_FEATURES = new Set<Feature>(['branches'])
+
+async function tryNativeAuth(
+  setToken: (t: string) => void,
+  setUser: (u: GitHubUser) => void
+): Promise<string | null> {
+  const installed = await window.electronAPI!.gh.isInstalled()
+  if (!installed) return 'gh CLI not found. Install it at cli.github.com then relaunch.'
+  try {
+    const res = await window.electronAPI!.gh.graphql(VIEWER_QUERY, {})
+    const viewer = (res.data as { viewer: GitHubUser }).viewer
+    setToken('gh-cli')
+    setUser(viewer)
+    return null
+  } catch {
+    return 'Not authenticated. Run `gh auth login` in your terminal then click Retry.'
+  }
+}
+
+function AppAuthError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="min-h-screen bg-[var(--color-surface)] flex flex-col items-center justify-center gap-4 p-8">
+      <Terminal size={32} className="text-[var(--color-text-muted)]" />
+      <p className="text-sm text-[var(--color-text-primary)] text-center max-w-xs">{message}</p>
+      <button
+        onClick={onRetry}
+        className="text-xs px-3 py-1.5 rounded bg-[var(--color-accent)] text-white cursor-pointer"
+      >
+        Retry
+      </button>
+    </div>
+  )
+}
+
+export function AppContainer() {
+  const { token, setToken, setUser } = useAuthStore()
+  const [checking, setChecking] = useState(!token)
+  const [error, setError] = useState<string | null>(null)
+
+  const runAuth = useCallback(() => {
+    setError(null)
+    setChecking(true)
+    tryNativeAuth(setToken, setUser)
+      .then(setError)
+      .finally(() => setChecking(false))
+  }, [setToken, setUser])
+
+  useEffect(() => {
+    if (token) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    runAuth()
+  }, [runAuth, token])
+
+  if (checking) return null
+  if (error) return <AppAuthError message={error} onRetry={runAuth} />
+  return (
+    <FeaturesContext.Provider value={APP_FEATURES}>
+      <DashboardPage />
+    </FeaturesContext.Provider>
+  )
+}

--- a/src/WebContainer.tsx
+++ b/src/WebContainer.tsx
@@ -1,0 +1,8 @@
+import { useAuthStore } from './store/authStore'
+import AuthPage from './pages/AuthPage'
+import DashboardPage from './pages/DashboardPage'
+
+export function WebContainer() {
+  const token = useAuthStore((s) => s.token)
+  return token ? <DashboardPage /> : <AuthPage />
+}

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Lock, X } from 'lucide-react'
 import { usePRStore, type PRSection } from '../../store/prStore'
 import { usePullRequests } from '../../hooks/useGitHubPRs'
-import { IS_ELECTRON } from '../../lib/electron'
+import { useFeatures } from '../../lib/features'
 
 const SECTIONS: { id: PRSection; label: string }[] = [
   { id: 'review-requested', label: 'Review requested' },
@@ -15,6 +15,7 @@ export default function Filters() {
   const addHiddenAuthor = usePRStore((s) => s.addHiddenAuthor)
   const removeHiddenAuthor = usePRStore((s) => s.removeHiddenAuthor)
   const { repos = [], hasNextPage, truncated, loadedCount, totalCount } = usePullRequests()
+  const features = useFeatures()
   const [mutedInput, setMutedInput] = useState('')
 
   function toggleRepo(repo: string) {
@@ -151,7 +152,7 @@ export default function Filters() {
         )}
       </div>
 
-      {!IS_ELECTRON && (
+      {!features.has('branches') && (
         <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center cursor-default">
           <Lock size={16} className="text-[var(--color-text-muted)]" />
           <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">

--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -1,1 +1,1 @@
-export const IS_ELECTRON = !!window.electronAPI
+export const IS_NATIVE = !!window.electronAPI

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from 'react'
+
+export type Feature = 'branches'
+
+const FeaturesContext = createContext<Set<Feature>>(new Set())
+
+export const useFeatures = () => useContext(FeaturesContext)
+export { FeaturesContext }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -3,7 +3,7 @@ import { LogOut, Moon, Search, Sun, X } from 'lucide-react'
 import { useAuthStore } from '../store/authStore'
 import { usePRStore } from '../store/prStore'
 import { useTheme } from '../hooks/useTheme'
-import { IS_ELECTRON } from '../lib/electron'
+import { useFeatures } from '../lib/features'
 import Filters from '../components/Filters/Filters'
 import PRList from '../components/PRList/PRList'
 import BranchList from '../components/BranchList/BranchList'
@@ -54,6 +54,7 @@ export default function DashboardPage() {
   const { data: latestVersion } = useUpdateCheck()
   const showBanner = latestVersion && isNewer(latestVersion, __APP_VERSION__)
   const { theme, toggle } = useTheme()
+  const features = useFeatures()
 
   return (
     <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)] flex flex-col">
@@ -67,7 +68,7 @@ export default function DashboardPage() {
           </div>
 
           <div className="flex items-center gap-1 shrink-0">
-            {(['prs', ...(IS_ELECTRON ? ['branches' as const] : [])] as const).map((v) => (
+            {(['prs', ...(features.has('branches') ? ['branches' as const] : [])] as const).map((v) => (
               <button
                 key={v}
                 onClick={() => setView(v)}
@@ -116,7 +117,7 @@ export default function DashboardPage() {
               >
                 {theme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
               </button>
-              {!IS_ELECTRON && (
+              {!features.has('branches') && (
                 <button
                   onClick={logout}
                   title="Disconnect"

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -68,20 +68,22 @@ export default function DashboardPage() {
           </div>
 
           <div className="flex items-center gap-1 shrink-0">
-            {(['prs', ...(features.has('branches') ? ['branches' as const] : [])] as const).map((v) => (
-              <button
-                key={v}
-                onClick={() => setView(v)}
-                className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
+            {(['prs', ...(features.has('branches') ? ['branches' as const] : [])] as const).map(
+              (v) => (
+                <button
+                  key={v}
+                  onClick={() => setView(v)}
+                  className={`text-xs px-3 py-1.5 rounded-md font-medium transition-colors cursor-pointer
                     ${
                       view === v
                         ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
                         : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)]'
                     }`}
-              >
-                {v === 'prs' ? 'Pull Requests' : 'Branches'}
-              </button>
-            ))}
+                >
+                  {v === 'prs' ? 'Pull Requests' : 'Branches'}
+                </button>
+              )
+            )}
           </div>
 
           <div className="relative flex-1 max-w-sm mx-auto">


### PR DESCRIPTION
## What

Split `App.tsx` into two platform-specific containers and introduce a static `FeaturesContext` to gate platform-only features without leaking `IS_NATIVE` into components.

## Why

Foundation for a feature-folder architecture (upcoming `stashes`, `reflog`, etc.). Components should be platform-agnostic — only containers decide what's available.

Key changes:
- `AppContainer.tsx` — Electron auth probe, error screen, provides `FeaturesContext` with `['branches']`
- `WebContainer.tsx` — PAT gate, no features override (empty Set by default)
- `App.tsx` — reduced to `QueryClient` setup + one `IS_NATIVE` branch to pick the container
- `IS_ELECTRON` → `IS_NATIVE` in `src/lib/electron.ts`
- `FeaturesContext` + `useFeatures()` in `src/lib/features.ts` — static context, never updated post-mount
- Components use `features.has('branches')` instead of importing `IS_NATIVE` directly
- `CLAUDE.md` updated to document the three-seam abstraction

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes