### PR TITLE
fix: fix OTA update banner race condition and UX

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -194,11 +194,13 @@ ipcMain.handle('update:is-downloaded', () => updateDownloaded)
 app.whenReady().then(() => {
   createWindow()
   if (app.isPackaged) {
-    autoUpdater.checkForUpdates()
+    // ponytail: error listener required — Node throws on unhandled 'error' events
+    autoUpdater.on('error', (err) => console.error('[updater]', err.message))
     autoUpdater.on('update-downloaded', () => {
       updateDownloaded = true
       BrowserWindow.getAllWindows().forEach((w) => w.webContents.send('update:downloaded'))
     })
+    autoUpdater.checkForUpdates()?.catch((err) => console.error('[updater]', err.message))
   }
 })
 app.on('window-all-closed', () => {

--- a/src/features/updates/components/UpdateBanner/UpdateBanner.tsx
+++ b/src/features/updates/components/UpdateBanner/UpdateBanner.tsx
@@ -10,28 +10,17 @@ export function UpdateBanner({ version }: { version: string }) {
     window.electronAPI?.updater?.onUpdateDownloaded(() => setDownloaded(true))
   }, [])
 
-  if (dismissed) return null
+  if (!downloaded || dismissed) return null
   return (
     <div className="flex items-center justify-between px-4 py-2 text-xs bg-[var(--color-accent)] text-white">
       <span>Version {version} is available.</span>
       <span className="flex items-center gap-3">
-        {downloaded ? (
-          <button
-            className="underline cursor-pointer"
-            onClick={() => window.electronAPI?.updater?.installUpdate()}
-          >
-            Restart to install
-          </button>
-        ) : (
-          <a
-            href="https://github.com/adelbeke/donna/releases/latest"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Download
-          </a>
-        )}
+        <button
+          className="underline cursor-pointer"
+          onClick={() => window.electronAPI?.updater?.installUpdate()}
+        >
+          Restart to install
+        </button>
         <button onClick={() => setDismissed(true)}>✕</button>
       </span>
     </div>


### PR DESCRIPTION
## What

- Register `update-downloaded` listener **before** calling `checkForUpdates()` — fixes a race condition where the event could be missed if electron-updater fires synchronously on a cached download
- Hide the update banner until the update is fully downloaded — it now only ever shows "Restart to install", never "Download"
- Add error handler on `autoUpdater` to prevent Node from throwing on unhandled `error` events

## Why

The banner was permanently stuck on "Download" because the `update-downloaded` listener was registered after `checkForUpdates()` was called. Node.js `EventEmitter` fires synchronously, so if the event was emitted before the listener was attached, it was silently dropped.

The "Download" → "Restart to install" two-step UX was also confusing — no need to show the banner at all until the update is ready.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes