### PR TITLE
feat: muted repository setting

### DIFF
--- a/src/features/branches/components/BranchDashboard/BranchDashboard.tsx
+++ b/src/features/branches/components/BranchDashboard/BranchDashboard.tsx
@@ -1,32 +1,18 @@
 import { BranchList } from '@/features/branches/components/BranchList/BranchList.tsx'
 import { SearchInput } from '@/shared/components/SearchInput/SearchInput.tsx'
-import { usePRStore } from '@/features/pull-requests/stores/prStore.ts'
+import { useBranchStore } from '@/features/branches/stores/branchStore.ts'
 import type { ChangeEvent } from 'react'
 
 export function BranchDashboard() {
-  // TODO: we should have a dedicated store for the search in the branches features
-  const { filters, setFilters } = usePRStore()
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setFilters({
-      search: event.target.value,
-    })
-  }
-
-  const handleClear = () => {
-    setFilters({
-      search: '',
-    })
-  }
-
+  const { branchSearch, setBranchSearch } = useBranchStore()
   return (
     <div className={'flex flex-col gap-8'}>
       <SearchInput
-        value={filters.search}
+        value={branchSearch}
         placeholder={'Filter by branch name…'}
-        displayClearButton={filters.search.length > 0}
-        onChange={handleChange}
-        onClear={handleClear}
+        displayClearButton={branchSearch.length > 0}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => setBranchSearch(event.target.value)}
+        onClear={() => setBranchSearch('')}
       />
       <BranchList />
     </div>

--- a/src/features/branches/components/BranchList/BranchList.tsx
+++ b/src/features/branches/components/BranchList/BranchList.tsx
@@ -1,7 +1,7 @@
 import { useQueries } from '@tanstack/react-query'
 import { FolderPlus, RefreshCw, X } from 'lucide-react'
 import { useMemo } from 'react'
-import { usePRStore, usePullRequests } from '@/features/pull-requests/exports'
+import { usePullRequests } from '@/features/pull-requests/exports'
 import { useBranchStore } from '../../stores/branchStore'
 import type { Worktree } from '../../types'
 import type { PullRequest } from '@/types/github'
@@ -11,7 +11,7 @@ const REPO_HUES = [210, 140, 30, 280, 180, 60, 320, 260]
 
 export function BranchList() {
   const { localPaths, addLocalPath, removeLocalPath } = useBranchStore()
-  const { filters } = usePRStore()
+  const { branchSearch } = useBranchStore()
   const { allPRs } = usePullRequests()
 
   const branchQueries = useQueries({
@@ -115,7 +115,7 @@ export function BranchList() {
     const mainBranch = (worktrees ?? []).find((wt) => wt.isMain)?.branch ?? ''
 
     for (const branch of (branches ?? []).filter(
-      (b) => !filters.search || b.toLowerCase().includes(filters.search.toLowerCase())
+      (b) => !branchSearch || b.toLowerCase().includes(branchSearch.toLowerCase())
     )) {
       flatBranches.push({
         key: `${localPath}/${branch}`,

--- a/src/features/branches/stores/branchStore.ts
+++ b/src/features/branches/stores/branchStore.ts
@@ -3,17 +3,21 @@ import { persist } from 'zustand/middleware'
 
 interface BranchStore {
   localPaths: string[]
+  branchSearch: string
   addLocalPath: (path: string) => void
   removeLocalPath: (path: string) => void
+  setBranchSearch: (s: string) => void
 }
 
 export const useBranchStore = create<BranchStore>()(
   persist(
     (set) => ({
       localPaths: [],
+      branchSearch: '',
       addLocalPath: (path) => set((state) => ({ localPaths: [...state.localPaths, path] })),
       removeLocalPath: (path) =>
         set((state) => ({ localPaths: state.localPaths.filter((p) => p !== path) })),
+      setBranchSearch: (s) => set({ branchSearch: s }),
     }),
     { name: 'branch-dashboard-state' }
   )

--- a/src/features/pull-requests/components/Filters/Filters.test.tsx
+++ b/src/features/pull-requests/components/Filters/Filters.test.tsx
@@ -1,86 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { Filters } from './Filters'
-import { usePullRequests } from '../../queries/useGitHubPRs'
-import { usePRStore, type PRFilters } from '../../stores/prStore'
+import { usePRStore } from '../../stores/prStore'
 
-vi.mock('../../queries/useGitHubPRs', () => ({ usePullRequests: vi.fn() }))
 vi.mock('../../stores/prStore', () => ({ usePRStore: vi.fn() }))
-const mockUsePullRequests = vi.mocked(usePullRequests)
 const mockUsePRStore = vi.mocked(usePRStore)
 
-const defaultQuery = {
-  isLoading: false,
-  isFetching: false,
-  hasNextPage: true,
-  truncated: false,
-  loadedCount: 50,
-  totalCount: 100,
-  repos: [],
-}
-
-function mockStore(filterOverrides: Partial<PRFilters> = {}) {
-  const state = {
-    filters: {
-      section: 'review-requested',
-      repos: [],
-      hiddenAuthors: [],
-      showDrafts: false,
-      showHidden: false,
-      search: '',
-      ...filterOverrides,
-    } as PRFilters,
-    priorityIds: [],
-    hiddenIds: [],
-    setFilters: vi.fn(),
-    resetFilters: vi.fn(),
-    toggleHide: vi.fn(),
-    togglePriority: vi.fn(),
-    addHiddenAuthor: vi.fn(),
-    removeHiddenAuthor: vi.fn(),
-    setView: vi.fn(),
-    view: 'prs' as const,
-  }
-  mockUsePRStore.mockImplementation((selector?: (s: typeof state) => unknown) =>
-    selector ? selector(state) : state
-  )
+function mockStore(section = 'review-requested', setSection = vi.fn()) {
+  mockUsePRStore.mockImplementation((selector?: (s: unknown) => unknown) => {
+    const state = { section, setSection }
+    return selector ? selector(state) : state
+  })
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockUsePullRequests.mockReturnValue(defaultQuery as never)
   mockStore()
 })
 
-describe('Filters — pagination warning', () => {
-  it('GIVEN only muted authors active THEN warning is absent', () => {
-    mockStore({ hiddenAuthors: ['renovate', 'dependabot'] })
+describe('Filters — section tabs', () => {
+  it('renders all three section tabs', () => {
     render(<Filters />)
-    expect(screen.queryByText(/Filters apply to/)).not.toBeInTheDocument()
+    expect(screen.getByText('Review requested')).toBeInTheDocument()
+    expect(screen.getByText('My PRs')).toBeInTheDocument()
+    expect(screen.getByText('Mentioned')).toBeInTheDocument()
   })
 
-  it('GIVEN repo filter selected THEN warning is present', () => {
-    mockStore({ repos: ['org/repo'] })
+  it('active section tab has accent styling', () => {
+    mockStore('authored')
     render(<Filters />)
-    expect(screen.getByText(/Filters apply to/)).toBeInTheDocument()
+    const activeBtn = screen.getByText('My PRs')
+    expect(activeBtn.className).toContain('text-[var(--color-accent)]')
   })
 
-  it('GIVEN showDrafts active THEN warning is present', () => {
-    mockStore({ showDrafts: true })
+  it('clicking a tab calls setSection', () => {
+    const setSection = vi.fn()
+    mockStore('review-requested', setSection)
     render(<Filters />)
-    expect(screen.getByText(/Filters apply to/)).toBeInTheDocument()
-  })
-
-  it('GIVEN showHidden active THEN warning is present', () => {
-    mockStore({ showHidden: true })
-    render(<Filters />)
-    expect(screen.getByText(/Filters apply to/)).toBeInTheDocument()
-  })
-
-  it('GIVEN no additive filters and no next page THEN warning is absent', () => {
-    mockUsePullRequests.mockReturnValue({ ...defaultQuery, hasNextPage: false } as never)
-    mockStore({ repos: ['org/repo'] })
-    render(<Filters />)
-    expect(screen.queryByText(/Filters apply to/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('My PRs'))
+    expect(setSection).toHaveBeenCalledWith('authored')
   })
 })

--- a/src/features/pull-requests/components/Filters/Filters.tsx
+++ b/src/features/pull-requests/components/Filters/Filters.tsx
@@ -1,8 +1,4 @@
-import { useState } from 'react'
-import { Lock, X } from 'lucide-react'
 import { usePRStore, type PRSection } from '../../stores/prStore'
-import { usePullRequests } from '../../queries/useGitHubPRs'
-import { useFeatures } from '@/shared/features'
 
 const SECTIONS: { id: PRSection; label: string }[] = [
   { id: 'review-requested', label: 'Review requested' },
@@ -11,42 +7,19 @@ const SECTIONS: { id: PRSection; label: string }[] = [
 ]
 
 export function Filters() {
-  const { filters, setFilters } = usePRStore()
-  const addHiddenAuthor = usePRStore((s) => s.addHiddenAuthor)
-  const removeHiddenAuthor = usePRStore((s) => s.removeHiddenAuthor)
-  const { repos = [], hasNextPage, truncated, loadedCount, totalCount } = usePullRequests()
-  const features = useFeatures()
-  const [mutedInput, setMutedInput] = useState('')
-
-  function toggleRepo(repo: string) {
-    setFilters({
-      repos: filters.repos.includes(repo)
-        ? filters.repos.filter((r) => r !== repo)
-        : [...filters.repos, repo],
-    })
-  }
-
-  function handleMutedKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter') {
-      const trimmed = mutedInput.trim()
-      if (trimmed) {
-        addHiddenAuthor(trimmed)
-        setMutedInput('')
-      }
-    }
-  }
+  const section = usePRStore((s) => s.section)
+  const setSection = usePRStore((s) => s.setSection)
 
   return (
-    <aside className="w-56 shrink-0 space-y-6">
-      {/* Section tabs */}
+    <aside className="w-56 shrink-0">
       <nav className="space-y-0.5">
         {SECTIONS.map((s) => (
           <button
             key={s.id}
-            onClick={() => setFilters({ section: s.id })}
+            onClick={() => setSection(s.id)}
             className={`w-full text-left text-sm px-3 py-1.5 rounded-md transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none
               ${
-                filters.section === s.id
+                section === s.id
                   ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)] font-medium'
                   : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)]'
               }`}
@@ -55,111 +28,6 @@ export function Filters() {
           </button>
         ))}
       </nav>
-
-      <div className="border-t border-[var(--color-border-subtle)]" />
-
-      {/* Repo filter — only shown if multiple repos */}
-      {repos.length > 1 && (
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider">
-              Repository{filters.repos.length > 0 && ` (${filters.repos.length})`}
-            </p>
-            {filters.repos.length > 0 && (
-              <button
-                onClick={() => setFilters({ repos: [] })}
-                className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-danger)] transition-colors cursor-pointer"
-              >
-                Clear
-              </button>
-            )}
-          </div>
-          <div className="space-y-0.5 max-h-48 overflow-y-auto">
-            {repos.map((repo) => {
-              const selected = filters.repos.includes(repo)
-              return (
-                <label
-                  key={repo}
-                  className={`flex items-center gap-2 px-1 py-1 rounded cursor-pointer group
-                    ${
-                      selected
-                        ? 'bg-[var(--color-accent-subtle)]'
-                        : 'hover:bg-[var(--color-surface-overlay)]'
-                    }`}
-                >
-                  <input
-                    type="checkbox"
-                    checked={selected}
-                    onChange={() => toggleRepo(repo)}
-                    className="accent-[var(--color-accent)] cursor-pointer"
-                  />
-                  <span
-                    className={`text-xs truncate
-                    ${
-                      selected
-                        ? 'text-[var(--color-text-primary)] font-medium'
-                        : 'text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]'
-                    }`}
-                  >
-                    {repo.split('/')[1]}
-                  </span>
-                </label>
-              )
-            })}
-          </div>
-        </div>
-      )}
-
-      {(filters.repos.length > 0 || filters.showDrafts || filters.showHidden) &&
-        hasNextPage &&
-        !truncated && (
-          <p className="text-xs text-[var(--color-warning)]">
-            ⚠ Filters apply to {loadedCount} of ~{totalCount} PRs
-          </p>
-        )}
-
-      {/* Muted authors — free-form pattern input */}
-      <div>
-        <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2">
-          Muted authors{filters.hiddenAuthors.length > 0 && ` (${filters.hiddenAuthors.length})`}
-        </p>
-        <input
-          type="text"
-          value={mutedInput}
-          onChange={(e) => setMutedInput(e.target.value)}
-          onKeyDown={handleMutedKeyDown}
-          placeholder="e.g. renovate, dependabot"
-          className="w-full text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] bg-[var(--color-surface)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
-        />
-        {filters.hiddenAuthors.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2">
-            {filters.hiddenAuthors.map((pattern) => (
-              <span
-                key={pattern}
-                className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-[var(--color-surface-overlay)] text-[var(--color-text-secondary)]"
-              >
-                {pattern}
-                <button
-                  onClick={() => removeHiddenAuthor(pattern)}
-                  className="text-[var(--color-text-muted)] hover:text-[var(--color-danger)] transition-colors cursor-pointer"
-                  aria-label={`Remove ${pattern}`}
-                >
-                  <X size={10} />
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {!features.has('branches') && (
-        <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-3 py-3 flex flex-col items-center gap-2 text-center cursor-default">
-          <Lock size={16} className="text-[var(--color-text-muted)]" />
-          <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
-            Your GitHub token is never transmitted or shared. It only lives in your localStorage.
-          </p>
-        </div>
-      )}
     </aside>
   )
 }

--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -30,18 +30,7 @@ const pr: PullRequest = {
 }
 
 beforeEach(() => {
-  usePRStore.setState({
-    priorityIds: [],
-    hiddenIds: [],
-    filters: {
-      section: 'review-requested',
-      repos: [],
-      hiddenAuthors: [],
-      showDrafts: false,
-      showHidden: false,
-      search: '',
-    },
-  })
+  usePRStore.setState({ priorityIds: [], hiddenIds: [] })
 })
 
 describe('PRCard', () => {

--- a/src/features/pull-requests/components/PRDashboard/PRDashboard.tsx
+++ b/src/features/pull-requests/components/PRDashboard/PRDashboard.tsx
@@ -3,31 +3,35 @@ import { usePRStore } from '@/features/pull-requests/stores/prStore.ts'
 import type { ChangeEvent } from 'react'
 import { Filters } from '@/features/pull-requests/components/Filters/Filters.tsx'
 import { PRList } from '@/features/pull-requests/components/PRList/PRList.tsx'
+import { SettingsModal } from '@/features/pull-requests/components/SettingsModal/SettingsModal.tsx'
 
 export function PRDashboard() {
-  const { filters, setFilters } = usePRStore()
+  const section = usePRStore((s) => s.section)
+  const viewFilters = usePRStore((s) => s.viewFilters)
+  const setViewFilters = usePRStore((s) => s.setViewFilters)
+
+  const search = viewFilters[section].search
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setFilters({
-      search: event.target.value,
-    })
+    setViewFilters(section, { search: event.target.value })
   }
 
   const handleClear = () => {
-    setFilters({
-      search: '',
-    })
+    setViewFilters(section, { search: '' })
   }
 
   return (
     <div className="flex-col flex gap-8">
-      <SearchInput
-        value={filters.search}
-        placeholder={'Filter by title…'}
-        displayClearButton={filters.search.length > 0}
-        onChange={handleChange}
-        onClear={handleClear}
-      />
+      <div className="flex items-center gap-2">
+        <SearchInput
+          value={search}
+          placeholder={'Filter by title…'}
+          displayClearButton={search.length > 0}
+          onChange={handleChange}
+          onClear={handleClear}
+        />
+        <SettingsModal />
+      </div>
       <div className="flex gap-8">
         <Filters />
         <PRList />

--- a/src/features/pull-requests/components/PRDashboard/PRDashboard.tsx
+++ b/src/features/pull-requests/components/PRDashboard/PRDashboard.tsx
@@ -1,7 +1,7 @@
 import { SearchInput } from '@/shared/components/SearchInput/SearchInput.tsx'
 import { usePRStore } from '@/features/pull-requests/stores/prStore.ts'
 import type { ChangeEvent } from 'react'
-import { Filters } from '@/features/pull-requests/components/Filters/Filters.tsx'
+import { PRSectionsTabs } from '@/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.tsx'
 import { PRList } from '@/features/pull-requests/components/PRList/PRList.tsx'
 import { SettingsModal } from '@/features/pull-requests/components/SettingsModal/SettingsModal.tsx'
 
@@ -33,7 +33,7 @@ export function PRDashboard() {
         <SettingsModal />
       </div>
       <div className="flex gap-8">
-        <Filters />
+        <PRSectionsTabs />
         <PRList />
       </div>
     </div>

--- a/src/features/pull-requests/components/PRList/PRList.test.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@/features/pull-requests/queries/useCheckContexts', () => ({
 }))
 
 import { usePullRequests } from '@/features/pull-requests/queries/useGitHubPRs'
-import { usePRStore, type PRFilters } from '@/features/pull-requests/stores/prStore'
+import { usePRStore } from '@/features/pull-requests/stores/prStore'
 const mockUsePullRequests = vi.mocked(usePullRequests)
 const mockUsePRStore = vi.mocked(usePRStore)
 
@@ -37,26 +37,28 @@ function makePR(id: string, title: string): PullRequest {
   }
 }
 
-function mockStoreFilters(filterOverrides: Record<string, unknown> = {}) {
+function mockStoreFilters(viewOverrides: Record<string, unknown> = {}) {
   mockUsePRStore.mockImplementation((selector) =>
     selector({
-      filters: {
-        section: 'review-requested',
-        repos: [],
-        hiddenAuthors: [],
-        showDrafts: false,
-        showHidden: false,
-        search: '',
-        ...filterOverrides,
-      } as PRFilters,
+      section: 'review-requested',
+      globalFilters: { hiddenAuthors: [], hiddenRepos: [], showHidden: false },
+      viewFilters: {
+        'review-requested': { repos: [], showDrafts: false, search: '', ...viewOverrides },
+        authored: { repos: [], showDrafts: false, search: '' },
+        mentioned: { repos: [], showDrafts: false, search: '' },
+      },
       priorityIds: [],
       hiddenIds: [],
-      setFilters: vi.fn(),
+      setSection: vi.fn(),
+      setGlobalFilters: vi.fn(),
+      setViewFilters: vi.fn(),
       resetFilters: vi.fn(),
       toggleHide: vi.fn(),
       togglePriority: vi.fn(),
       addHiddenAuthor: vi.fn(),
       removeHiddenAuthor: vi.fn(),
+      addHiddenRepo: vi.fn(),
+      removeHiddenRepo: vi.fn(),
       setView: vi.fn(),
       view: 'prs' as const,
     })
@@ -190,7 +192,7 @@ describe('PRList', () => {
     })
 
     it('GIVEN hasNextPage and active filter THEN shows "Load all" button', () => {
-      mockStoreFilters({ repos: ['org/repo'] })
+      mockStoreFilters({ repos: ['org/repo'] }) // viewOverrides for review-requested
       const prs = [makePR('1', 'PR')]
       mockUsePullRequests.mockReturnValue({
         ...defaultQuery,

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -24,17 +24,19 @@ export function PRList() {
     totalCount,
     truncated,
   } = usePullRequests()
-  const filters = usePRStore((s) => s.filters)
-  const section = filters.section
+  const section = usePRStore((s) => s.section)
+  const viewFilters = usePRStore((s) => s.viewFilters)
+  const globalFilters = usePRStore((s) => s.globalFilters)
+  const currentView = viewFilters[section]
   const loadAllRef = useRef(false)
 
   const handleRefetch = () => void refetch()
 
   const hasActiveFilters =
-    filters.repos.length > 0 ||
-    (filters.hiddenAuthors?.length ?? 0) > 0 ||
-    filters.showDrafts ||
-    filters.search.length > 0
+    currentView.repos.length > 0 ||
+    globalFilters.hiddenAuthors.length > 0 ||
+    currentView.showDrafts ||
+    currentView.search.length > 0
 
   useEffect(() => {
     if (loadAllRef.current && hasNextPage && !isFetchingNextPage) {

--- a/src/features/pull-requests/components/PRList/VisibilityToggles/VisibilityToggles.tsx
+++ b/src/features/pull-requests/components/PRList/VisibilityToggles/VisibilityToggles.tsx
@@ -1,17 +1,23 @@
 import { usePRStore } from '@/features/pull-requests/stores/prStore.ts'
 
 export function VisibilityToggles() {
-  const { filters, setFilters } = usePRStore()
+  const section = usePRStore((s) => s.section)
+  const globalFilters = usePRStore((s) => s.globalFilters)
+  const setGlobalFilters = usePRStore((s) => s.setGlobalFilters)
+  const viewFilters = usePRStore((s) => s.viewFilters)
+  const setViewFilters = usePRStore((s) => s.setViewFilters)
   const hiddenIds = usePRStore((s) => s.hiddenIds)
+
+  const showDrafts = viewFilters[section].showDrafts
 
   return (
     <div className="flex items-center gap-1">
       <button
-        onClick={() => setFilters({ showDrafts: !filters.showDrafts })}
-        title={filters.showDrafts ? 'Hide drafts' : 'Show drafts'}
+        onClick={() => setViewFilters(section, { showDrafts: !showDrafts })}
+        title={showDrafts ? 'Hide drafts' : 'Show drafts'}
         className={`text-xs px-2 py-0.5 rounded transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none
           ${
-            filters.showDrafts
+            showDrafts
               ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
               : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)]'
           }`}
@@ -19,11 +25,11 @@ export function VisibilityToggles() {
         Drafts
       </button>
       <button
-        onClick={() => setFilters({ showHidden: !filters.showHidden })}
-        title={filters.showHidden ? 'Hide hidden PRs' : 'Show hidden PRs'}
+        onClick={() => setGlobalFilters({ showHidden: !globalFilters.showHidden })}
+        title={globalFilters.showHidden ? 'Hide hidden PRs' : 'Show hidden PRs'}
         className={`text-xs px-2 py-0.5 rounded transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none
           ${
-            filters.showHidden
+            globalFilters.showHidden
               ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
               : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)]'
           }`}

--- a/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.test.tsx
+++ b/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.test.tsx
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { Filters } from './Filters'
+import { PRSectionsTabs } from './PRSectionsTabs'
 import { usePRStore } from '../../stores/prStore'
+import type { PRStore } from '../../stores/prStore'
 
 vi.mock('../../stores/prStore', () => ({ usePRStore: vi.fn() }))
 const mockUsePRStore = vi.mocked(usePRStore)
 
 function mockStore(section = 'review-requested', setSection = vi.fn()) {
-  mockUsePRStore.mockImplementation((selector?: (s: unknown) => unknown) => {
+  mockUsePRStore.mockImplementation((selector: (s: PRStore) => unknown) => {
     const state = { section, setSection }
-    return selector ? selector(state) : state
+    return selector(state as unknown as PRStore)
   })
 }
 
@@ -18,9 +19,9 @@ beforeEach(() => {
   mockStore()
 })
 
-describe('Filters — section tabs', () => {
+describe('PRSectionsTabs — section tabs', () => {
   it('renders all three section tabs', () => {
-    render(<Filters />)
+    render(<PRSectionsTabs />)
     expect(screen.getByText('Review requested')).toBeInTheDocument()
     expect(screen.getByText('My PRs')).toBeInTheDocument()
     expect(screen.getByText('Mentioned')).toBeInTheDocument()
@@ -28,7 +29,7 @@ describe('Filters — section tabs', () => {
 
   it('active section tab has accent styling', () => {
     mockStore('authored')
-    render(<Filters />)
+    render(<PRSectionsTabs />)
     const activeBtn = screen.getByText('My PRs')
     expect(activeBtn.className).toContain('text-[var(--color-accent)]')
   })
@@ -36,7 +37,7 @@ describe('Filters — section tabs', () => {
   it('clicking a tab calls setSection', () => {
     const setSection = vi.fn()
     mockStore('review-requested', setSection)
-    render(<Filters />)
+    render(<PRSectionsTabs />)
     fireEvent.click(screen.getByText('My PRs'))
     expect(setSection).toHaveBeenCalledWith('authored')
   })

--- a/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.tsx
+++ b/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.tsx
@@ -6,7 +6,7 @@ const SECTIONS: { id: PRSection; label: string }[] = [
   { id: 'mentioned', label: 'Mentioned' },
 ]
 
-export function Filters() {
+export function PRSectionsTabs() {
   const section = usePRStore((s) => s.section)
   const setSection = usePRStore((s) => s.setSection)
 

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -23,7 +23,9 @@ export function SettingsModal() {
 
   useEffect(() => {
     document.body.style.overflow = open ? 'hidden' : ''
-    return () => { document.body.style.overflow = '' }
+    return () => {
+      document.body.style.overflow = ''
+    }
   }, [open])
 
   const activeCount =
@@ -54,7 +56,8 @@ export function SettingsModal() {
       setHiddenRepoInput('')
       // drop any selected repos that are now globally hidden
       const remaining = currentView.repos.filter((r) => !r.includes(trimmed))
-      if (remaining.length !== currentView.repos.length) setViewFilters(section, { repos: remaining })
+      if (remaining.length !== currentView.repos.length)
+        setViewFilters(section, { repos: remaining })
     }
   }
 
@@ -108,28 +111,37 @@ export function SettingsModal() {
                     )}
                   </div>
                   <div className="space-y-0.5 max-h-48 overflow-y-auto">
-                    {repos.filter((r) => !globalFilters.hiddenRepos.some((h) => h.includes('/') ? r.toLowerCase() === h : r.toLowerCase().split('/')[0] === h)).map((repo) => {
-                      const selected = currentView.repos.includes(repo)
-                      return (
-                        <label
-                          key={repo}
-                          className={`flex items-center gap-2 px-1 py-1 rounded cursor-pointer group
-                            ${selected ? 'bg-[var(--color-accent-subtle)]' : 'hover:bg-[var(--color-surface-overlay)]'}`}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selected}
-                            onChange={() => toggleRepo(repo)}
-                            className="accent-[var(--color-accent)] cursor-pointer"
-                          />
-                          <span
-                            className={`text-xs truncate ${selected ? 'text-[var(--color-text-primary)] font-medium' : 'text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]'}`}
-                          >
-                            {repo.split('/')[1]}
-                          </span>
-                        </label>
+                    {repos
+                      .filter(
+                        (r) =>
+                          !globalFilters.hiddenRepos.some((h) =>
+                            h.includes('/')
+                              ? r.toLowerCase() === h
+                              : r.toLowerCase().split('/')[0] === h
+                          )
                       )
-                    })}
+                      .map((repo) => {
+                        const selected = currentView.repos.includes(repo)
+                        return (
+                          <label
+                            key={repo}
+                            className={`flex items-center gap-2 px-1 py-1 rounded cursor-pointer group
+                            ${selected ? 'bg-[var(--color-accent-subtle)]' : 'hover:bg-[var(--color-surface-overlay)]'}`}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={selected}
+                              onChange={() => toggleRepo(repo)}
+                              className="accent-[var(--color-accent)] cursor-pointer"
+                            />
+                            <span
+                              className={`text-xs truncate ${selected ? 'text-[var(--color-text-primary)] font-medium' : 'text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]'}`}
+                            >
+                              {repo.split('/')[1]}
+                            </span>
+                          </label>
+                        )
+                      })}
                   </div>
                 </div>
               )}

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -29,7 +29,10 @@ export function SettingsModal() {
   }, [open])
 
   const activeCount =
-    currentView.repos.length + globalFilters.hiddenAuthors.length + globalFilters.hiddenRepos.length
+    currentView.repos.length +
+    (section !== 'authored'
+      ? globalFilters.hiddenAuthors.length + globalFilters.hiddenRepos.length
+      : 0)
 
   function toggleRepo(repo: string) {
     setViewFilters(section, {

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -1,0 +1,222 @@
+import { useState, useEffect } from 'react'
+import { Settings, X } from 'lucide-react'
+import { usePRStore } from '../../stores/prStore'
+import { usePullRequests } from '../../queries/useGitHubPRs'
+import { ButtonWithTooltip } from '@/shared/components/ui/ButtonWithTooltip'
+
+export function SettingsModal() {
+  const [open, setOpen] = useState(false)
+  const [mutedInput, setMutedInput] = useState('')
+  const [hiddenRepoInput, setHiddenRepoInput] = useState('')
+
+  const section = usePRStore((s) => s.section)
+  const globalFilters = usePRStore((s) => s.globalFilters)
+  const viewFilters = usePRStore((s) => s.viewFilters)
+  const setViewFilters = usePRStore((s) => s.setViewFilters)
+  const addHiddenAuthor = usePRStore((s) => s.addHiddenAuthor)
+  const removeHiddenAuthor = usePRStore((s) => s.removeHiddenAuthor)
+  const addHiddenRepo = usePRStore((s) => s.addHiddenRepo)
+  const removeHiddenRepo = usePRStore((s) => s.removeHiddenRepo)
+  const { repos = [], hasNextPage, truncated, loadedCount, totalCount } = usePullRequests()
+
+  const currentView = viewFilters[section]
+
+  useEffect(() => {
+    document.body.style.overflow = open ? 'hidden' : ''
+    return () => { document.body.style.overflow = '' }
+  }, [open])
+
+  const activeCount =
+    currentView.repos.length + globalFilters.hiddenAuthors.length + globalFilters.hiddenRepos.length
+
+  function toggleRepo(repo: string) {
+    setViewFilters(section, {
+      repos: currentView.repos.includes(repo)
+        ? currentView.repos.filter((r) => r !== repo)
+        : [...currentView.repos, repo],
+    })
+  }
+
+  function handleMutedKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key !== 'Enter') return
+    const trimmed = mutedInput.trim()
+    if (trimmed) {
+      addHiddenAuthor(trimmed)
+      setMutedInput('')
+    }
+  }
+
+  function handleHiddenRepoKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key !== 'Enter') return
+    const trimmed = hiddenRepoInput.trim()
+    if (trimmed) {
+      addHiddenRepo(trimmed)
+      setHiddenRepoInput('')
+      // drop any selected repos that are now globally hidden
+      const remaining = currentView.repos.filter((r) => !r.includes(trimmed))
+      if (remaining.length !== currentView.repos.length) setViewFilters(section, { repos: remaining })
+    }
+  }
+
+  const showWarning =
+    (currentView.repos.length > 0 || globalFilters.showHidden) && !!hasNextPage && !truncated
+
+  return (
+    <>
+      <ButtonWithTooltip
+        label="Settings"
+        onClick={() => setOpen((o) => !o)}
+        buttonClassName={`relative flex items-center justify-center w-8 h-8 rounded-md transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none
+          ${open ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)]'}`}
+      >
+        <Settings size={16} />
+        {activeCount > 0 && (
+          <span className="absolute -top-1 -right-1 text-[10px] font-medium bg-[var(--color-accent)] text-white rounded-full w-4 h-4 flex items-center justify-center leading-none">
+            {activeCount}
+          </span>
+        )}
+      </ButtonWithTooltip>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40 bg-black/40" onClick={() => setOpen(false)} />
+          <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+            <div className="pointer-events-auto w-96 max-h-[80vh] overflow-y-auto rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-surface)] shadow-lg p-4 space-y-4">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-[var(--color-text-primary)]">Settings</p>
+                <button
+                  onClick={() => setOpen(false)}
+                  className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none rounded"
+                  aria-label="Close settings"
+                >
+                  <X size={16} />
+                </button>
+              </div>
+              {repos.length > 1 && (
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider">
+                      Repository{currentView.repos.length > 0 && ` (${currentView.repos.length})`}
+                    </p>
+                    {currentView.repos.length > 0 && (
+                      <button
+                        onClick={() => setViewFilters(section, { repos: [] })}
+                        className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-danger)] transition-colors cursor-pointer"
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
+                  <div className="space-y-0.5 max-h-48 overflow-y-auto">
+                    {repos.filter((r) => !globalFilters.hiddenRepos.some((h) => h.includes('/') ? r.toLowerCase() === h : r.toLowerCase().split('/')[0] === h)).map((repo) => {
+                      const selected = currentView.repos.includes(repo)
+                      return (
+                        <label
+                          key={repo}
+                          className={`flex items-center gap-2 px-1 py-1 rounded cursor-pointer group
+                            ${selected ? 'bg-[var(--color-accent-subtle)]' : 'hover:bg-[var(--color-surface-overlay)]'}`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={() => toggleRepo(repo)}
+                            className="accent-[var(--color-accent)] cursor-pointer"
+                          />
+                          <span
+                            className={`text-xs truncate ${selected ? 'text-[var(--color-text-primary)] font-medium' : 'text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]'}`}
+                          >
+                            {repo.split('/')[1]}
+                          </span>
+                        </label>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {section !== 'authored' && (
+                <>
+                  <div>
+                    <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2">
+                      Muted authors
+                      {globalFilters.hiddenAuthors.length > 0 &&
+                        ` (${globalFilters.hiddenAuthors.length})`}
+                    </p>
+                    <input
+                      type="text"
+                      value={mutedInput}
+                      onChange={(e) => setMutedInput(e.target.value)}
+                      onKeyDown={handleMutedKeyDown}
+                      placeholder="e.g. renovate, dependabot"
+                      className="w-full text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] bg-[var(--color-surface)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+                    />
+                    {globalFilters.hiddenAuthors.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-2">
+                        {globalFilters.hiddenAuthors.map((pattern) => (
+                          <span
+                            key={pattern}
+                            className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-[var(--color-surface-overlay)] text-[var(--color-text-secondary)]"
+                          >
+                            {pattern}
+                            <button
+                              onClick={() => removeHiddenAuthor(pattern)}
+                              className="text-[var(--color-text-muted)] hover:text-[var(--color-danger)] transition-colors cursor-pointer"
+                              aria-label={`Remove ${pattern}`}
+                            >
+                              <X size={10} />
+                            </button>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <div>
+                    <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2">
+                      Hidden repos
+                      {globalFilters.hiddenRepos.length > 0 &&
+                        ` (${globalFilters.hiddenRepos.length})`}
+                    </p>
+                    <input
+                      type="text"
+                      value={hiddenRepoInput}
+                      onChange={(e) => setHiddenRepoInput(e.target.value)}
+                      onKeyDown={handleHiddenRepoKeyDown}
+                      placeholder="e.g. owner/repo or owner"
+                      className="w-full text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] bg-[var(--color-surface)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+                    />
+                    {globalFilters.hiddenRepos.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-2">
+                        {globalFilters.hiddenRepos.map((repo) => (
+                          <span
+                            key={repo}
+                            className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-[var(--color-surface-overlay)] text-[var(--color-text-secondary)]"
+                          >
+                            {repo}
+                            <button
+                              onClick={() => removeHiddenRepo(repo)}
+                              className="text-[var(--color-text-muted)] hover:text-[var(--color-danger)] transition-colors cursor-pointer"
+                              aria-label={`Remove ${repo}`}
+                            >
+                              <X size={10} />
+                            </button>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+
+              {showWarning && (
+                <p className="text-xs text-[var(--color-warning)]">
+                  ⚠ Filters apply to {loadedCount} of ~{totalCount} PRs
+                </p>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  )
+}

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { Settings, X } from 'lucide-react'
 import { usePRStore } from '../../stores/prStore'
 import { usePullRequests } from '../../queries/useGitHubPRs'
+import { isRepoMatchedBy } from '../../lib/prFilters'
 import { ButtonWithTooltip } from '@/shared/components/ui/ButtonWithTooltip'
 
 export function SettingsModal() {
@@ -115,14 +116,7 @@ export function SettingsModal() {
                   </div>
                   <div className="space-y-0.5 max-h-48 overflow-y-auto">
                     {repos
-                      .filter(
-                        (r) =>
-                          !globalFilters.hiddenRepos.some((h) =>
-                            h.includes('/')
-                              ? r.toLowerCase() === h
-                              : r.toLowerCase().split('/')[0] === h
-                          )
-                      )
+                      .filter((r) => !globalFilters.hiddenRepos.some((h) => isRepoMatchedBy(r, h)))
                       .map((repo) => {
                         const selected = currentView.repos.includes(repo)
                         return (

--- a/src/features/pull-requests/lib/prFilters.test.ts
+++ b/src/features/pull-requests/lib/prFilters.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { applyFilters } from './prFilters'
 import type { PullRequest } from '@/types/github'
-import type { PRFilters } from '../stores/prStore'
+import type { GlobalFilters, ViewFilters } from '../stores/prStore'
 
 const makePR = (login: string): PullRequest =>
   ({
@@ -16,58 +16,96 @@ const makePR = (login: string): PullRequest =>
     updatedAt: '2024-01-01T00:00:00Z',
   }) as unknown as PullRequest
 
-const baseFilters: PRFilters = {
-  section: 'review-requested',
-  showHidden: false,
-  showDrafts: true,
-  repos: [],
-  search: '',
+const baseGlobal: GlobalFilters = {
   hiddenAuthors: [],
+  hiddenRepos: [],
+  showHidden: false,
+}
+
+const baseView: ViewFilters = {
+  repos: [],
+  showDrafts: true,
+  search: '',
 }
 
 describe('applyFilters — hiddenAuthors exact match', () => {
   it('hides a PR whose author exactly matches a muted entry', () => {
     // GIVEN renovate is muted
-    const filters = { ...baseFilters, hiddenAuthors: ['renovate'] }
+    const global = { ...baseGlobal, hiddenAuthors: ['renovate'] }
     // WHEN filtering a PR by renovate
-    const actual = applyFilters([makePR('renovate')], filters)
+    const actual = applyFilters([makePR('renovate')], global, baseView)
     // THEN the PR is hidden
     expect(actual).toHaveLength(0)
   })
 
   it('does NOT hide a PR whose author only partially matches', () => {
     // GIVEN renovate is muted
-    const filters = { ...baseFilters, hiddenAuthors: ['renovate'] }
+    const global = { ...baseGlobal, hiddenAuthors: ['renovate'] }
     // WHEN filtering a PR by doctolib-renovate
-    const actual = applyFilters([makePR('doctolib-renovate')], filters)
+    const actual = applyFilters([makePR('doctolib-renovate')], global, baseView)
     // THEN the PR is visible
     expect(actual).toHaveLength(1)
   })
 
   it('is case-insensitive', () => {
     // GIVEN Renovate (capitalised) is muted
-    const filters = { ...baseFilters, hiddenAuthors: ['Renovate'] }
+    const global = { ...baseGlobal, hiddenAuthors: ['Renovate'] }
     // WHEN filtering a PR by renovate (lowercase)
-    const actual = applyFilters([makePR('renovate')], filters)
+    const actual = applyFilters([makePR('renovate')], global, baseView)
     // THEN the PR is hidden
     expect(actual).toHaveLength(0)
   })
 
   it('does not hide unrelated authors', () => {
     // GIVEN renovate is muted
-    const filters = { ...baseFilters, hiddenAuthors: ['renovate'] }
+    const global = { ...baseGlobal, hiddenAuthors: ['renovate'] }
     // WHEN filtering a PR by dependabot
-    const actual = applyFilters([makePR('dependabot')], filters)
+    const actual = applyFilters([makePR('dependabot')], global, baseView)
     // THEN the PR is visible
     expect(actual).toHaveLength(1)
   })
 
   it('shows muted-author PRs when showHidden is true', () => {
     // GIVEN renovate is muted but showHidden is on
-    const filters = { ...baseFilters, hiddenAuthors: ['renovate'], showHidden: true }
+    const global = { ...baseGlobal, hiddenAuthors: ['renovate'], showHidden: true }
     // WHEN filtering a PR by renovate
-    const actual = applyFilters([makePR('renovate')], filters)
+    const actual = applyFilters([makePR('renovate')], global, baseView)
     // THEN the PR is visible because showHidden overrides the mute
+    expect(actual).toHaveLength(1)
+  })
+})
+
+describe('applyFilters — hiddenRepos deny-list', () => {
+  const orgPR = {
+    ...makePR('author'),
+    repository: { nameWithOwner: 'myorg/awesome-repo' },
+  } as PullRequest
+
+  it('hides a PR by exact owner/repo match', () => {
+    // GIVEN myorg/awesome-repo is denied
+    const global = { ...baseGlobal, hiddenRepos: ['myorg/awesome-repo'] }
+    const actual = applyFilters([orgPR], global, baseView)
+    expect(actual).toHaveLength(0)
+  })
+
+  it('hides a PR by org-level match', () => {
+    // GIVEN myorg (all repos) is denied
+    const global = { ...baseGlobal, hiddenRepos: ['myorg'] }
+    const actual = applyFilters([orgPR], global, baseView)
+    expect(actual).toHaveLength(0)
+  })
+
+  it('does NOT hide a PR from a different org', () => {
+    // GIVEN otherapg is denied but PR is from myorg
+    const global = { ...baseGlobal, hiddenRepos: ['otherorg'] }
+    const actual = applyFilters([orgPR], global, baseView)
+    expect(actual).toHaveLength(1)
+  })
+
+  it('shows denied-repo PRs when showHidden is true', () => {
+    // GIVEN myorg is denied but showHidden is on
+    const global = { ...baseGlobal, hiddenRepos: ['myorg'], showHidden: true }
+    const actual = applyFilters([orgPR], global, baseView)
     expect(actual).toHaveLength(1)
   })
 })
@@ -77,48 +115,40 @@ describe('applyFilters — showDrafts', () => {
 
   it('hides draft PRs when showDrafts is false', () => {
     // GIVEN showDrafts is off
-    const filters = { ...baseFilters, showDrafts: false }
+    const view = { ...baseView, showDrafts: false }
     // WHEN filtering a draft PR
-    const actual = applyFilters([draftPR], filters)
+    const actual = applyFilters([draftPR], baseGlobal, view)
     // THEN the draft is hidden
     expect(actual).toHaveLength(0)
   })
 
   it('shows draft PRs when showDrafts is true', () => {
     // GIVEN showDrafts is on
-    const filters = { ...baseFilters, showDrafts: true }
-    // WHEN filtering a draft PR
-    const actual = applyFilters([draftPR], filters)
+    const actual = applyFilters([draftPR], baseGlobal, baseView)
     // THEN the draft is visible
     expect(actual).toHaveLength(1)
   })
 })
 
-describe('applyFilters — repos', () => {
+describe('applyFilters — repos allow-list', () => {
   const repoPR = { ...makePR('author'), repository: { nameWithOwner: 'org/repo-a' } } as PullRequest
 
   it('keeps PRs from selected repos', () => {
     // GIVEN org/repo-a is selected
-    const filters = { ...baseFilters, repos: ['org/repo-a'] }
-    // WHEN filtering
-    const actual = applyFilters([repoPR], filters)
-    // THEN the PR is included
+    const view = { ...baseView, repos: ['org/repo-a'] }
+    const actual = applyFilters([repoPR], baseGlobal, view)
     expect(actual).toHaveLength(1)
   })
 
   it('hides PRs from repos not in the selection', () => {
     // GIVEN org/repo-b is selected
-    const filters = { ...baseFilters, repos: ['org/repo-b'] }
-    // WHEN filtering a PR from org/repo-a
-    const actual = applyFilters([repoPR], filters)
-    // THEN the PR is excluded
+    const view = { ...baseView, repos: ['org/repo-b'] }
+    const actual = applyFilters([repoPR], baseGlobal, view)
     expect(actual).toHaveLength(0)
   })
 
   it('shows all repos when repos list is empty', () => {
-    // GIVEN no repo filter
-    const filters = { ...baseFilters, repos: [] }
-    const actual = applyFilters([repoPR], filters)
+    const actual = applyFilters([repoPR], baseGlobal, baseView)
     expect(actual).toHaveLength(1)
   })
 })
@@ -127,23 +157,20 @@ describe('applyFilters — search', () => {
   const pr = { ...makePR('author'), title: 'fix: update login flow' } as PullRequest
 
   it('matches PRs whose title contains the search string', () => {
-    // GIVEN search is "login"
-    const filters = { ...baseFilters, search: 'login' }
-    const actual = applyFilters([pr], filters)
+    const view = { ...baseView, search: 'login' }
+    const actual = applyFilters([pr], baseGlobal, view)
     expect(actual).toHaveLength(1)
   })
 
   it('is case-insensitive', () => {
-    // GIVEN search is "LOGIN"
-    const filters = { ...baseFilters, search: 'LOGIN' }
-    const actual = applyFilters([pr], filters)
+    const view = { ...baseView, search: 'LOGIN' }
+    const actual = applyFilters([pr], baseGlobal, view)
     expect(actual).toHaveLength(1)
   })
 
   it('excludes PRs that do not match', () => {
-    // GIVEN search is "payment"
-    const filters = { ...baseFilters, search: 'payment' }
-    const actual = applyFilters([pr], filters)
+    const view = { ...baseView, search: 'payment' }
+    const actual = applyFilters([pr], baseGlobal, view)
     expect(actual).toHaveLength(0)
   })
 })

--- a/src/features/pull-requests/lib/prFilters.test.ts
+++ b/src/features/pull-requests/lib/prFilters.test.ts
@@ -32,8 +32,8 @@ describe('applyFilters — hiddenAuthors exact match', () => {
   it('hides a PR whose author exactly matches a muted entry', () => {
     // GIVEN renovate is muted
     const global = { ...baseGlobal, hiddenAuthors: ['renovate'] }
-    // WHEN filtering a PR by renovate
-    const actual = applyFilters([makePR('renovate')], global, baseView)
+    // WHEN filtering a PR by renovate on review-requested section
+    const actual = applyFilters([makePR('renovate')], global, baseView, 'review-requested')
     // THEN the PR is hidden
     expect(actual).toHaveLength(0)
   })
@@ -42,7 +42,7 @@ describe('applyFilters — hiddenAuthors exact match', () => {
     // GIVEN renovate is muted
     const global = { ...baseGlobal, hiddenAuthors: ['renovate'] }
     // WHEN filtering a PR by doctolib-renovate
-    const actual = applyFilters([makePR('doctolib-renovate')], global, baseView)
+    const actual = applyFilters([makePR('doctolib-renovate')], global, baseView, 'review-requested')
     // THEN the PR is visible
     expect(actual).toHaveLength(1)
   })
@@ -51,7 +51,7 @@ describe('applyFilters — hiddenAuthors exact match', () => {
     // GIVEN Renovate (capitalised) is muted
     const global = { ...baseGlobal, hiddenAuthors: ['Renovate'] }
     // WHEN filtering a PR by renovate (lowercase)
-    const actual = applyFilters([makePR('renovate')], global, baseView)
+    const actual = applyFilters([makePR('renovate')], global, baseView, 'review-requested')
     // THEN the PR is hidden
     expect(actual).toHaveLength(0)
   })
@@ -60,7 +60,7 @@ describe('applyFilters — hiddenAuthors exact match', () => {
     // GIVEN renovate is muted
     const global = { ...baseGlobal, hiddenAuthors: ['renovate'] }
     // WHEN filtering a PR by dependabot
-    const actual = applyFilters([makePR('dependabot')], global, baseView)
+    const actual = applyFilters([makePR('dependabot')], global, baseView, 'review-requested')
     // THEN the PR is visible
     expect(actual).toHaveLength(1)
   })
@@ -69,8 +69,17 @@ describe('applyFilters — hiddenAuthors exact match', () => {
     // GIVEN renovate is muted but showHidden is on
     const global = { ...baseGlobal, hiddenAuthors: ['renovate'], showHidden: true }
     // WHEN filtering a PR by renovate
-    const actual = applyFilters([makePR('renovate')], global, baseView)
+    const actual = applyFilters([makePR('renovate')], global, baseView, 'review-requested')
     // THEN the PR is visible because showHidden overrides the mute
+    expect(actual).toHaveLength(1)
+  })
+
+  it('does NOT apply hiddenAuthors to authored section', () => {
+    // GIVEN renovate is muted
+    const global = { ...baseGlobal, hiddenAuthors: ['renovate'] }
+    // WHEN viewing authored PRs
+    const actual = applyFilters([makePR('renovate')], global, baseView, 'authored')
+    // THEN PR still shows (you authored it, you should see it)
     expect(actual).toHaveLength(1)
   })
 })
@@ -84,28 +93,37 @@ describe('applyFilters — hiddenRepos deny-list', () => {
   it('hides a PR by exact owner/repo match', () => {
     // GIVEN myorg/awesome-repo is denied
     const global = { ...baseGlobal, hiddenRepos: ['myorg/awesome-repo'] }
-    const actual = applyFilters([orgPR], global, baseView)
+    const actual = applyFilters([orgPR], global, baseView, 'review-requested')
     expect(actual).toHaveLength(0)
   })
 
   it('hides a PR by org-level match', () => {
     // GIVEN myorg (all repos) is denied
     const global = { ...baseGlobal, hiddenRepos: ['myorg'] }
-    const actual = applyFilters([orgPR], global, baseView)
+    const actual = applyFilters([orgPR], global, baseView, 'review-requested')
     expect(actual).toHaveLength(0)
   })
 
   it('does NOT hide a PR from a different org', () => {
     // GIVEN otherapg is denied but PR is from myorg
     const global = { ...baseGlobal, hiddenRepos: ['otherorg'] }
-    const actual = applyFilters([orgPR], global, baseView)
+    const actual = applyFilters([orgPR], global, baseView, 'review-requested')
     expect(actual).toHaveLength(1)
   })
 
   it('shows denied-repo PRs when showHidden is true', () => {
     // GIVEN myorg is denied but showHidden is on
     const global = { ...baseGlobal, hiddenRepos: ['myorg'], showHidden: true }
-    const actual = applyFilters([orgPR], global, baseView)
+    const actual = applyFilters([orgPR], global, baseView, 'review-requested')
+    expect(actual).toHaveLength(1)
+  })
+
+  it('does NOT apply hiddenRepos to authored section', () => {
+    // GIVEN myorg is denied
+    const global = { ...baseGlobal, hiddenRepos: ['myorg'] }
+    // WHEN viewing authored PRs
+    const actual = applyFilters([orgPR], global, baseView, 'authored')
+    // THEN PR still shows (it's your own PR)
     expect(actual).toHaveLength(1)
   })
 })
@@ -117,14 +135,14 @@ describe('applyFilters — showDrafts', () => {
     // GIVEN showDrafts is off
     const view = { ...baseView, showDrafts: false }
     // WHEN filtering a draft PR
-    const actual = applyFilters([draftPR], baseGlobal, view)
+    const actual = applyFilters([draftPR], baseGlobal, view, 'review-requested')
     // THEN the draft is hidden
     expect(actual).toHaveLength(0)
   })
 
   it('shows draft PRs when showDrafts is true', () => {
     // GIVEN showDrafts is on
-    const actual = applyFilters([draftPR], baseGlobal, baseView)
+    const actual = applyFilters([draftPR], baseGlobal, baseView, 'review-requested')
     // THEN the draft is visible
     expect(actual).toHaveLength(1)
   })
@@ -136,19 +154,19 @@ describe('applyFilters — repos allow-list', () => {
   it('keeps PRs from selected repos', () => {
     // GIVEN org/repo-a is selected
     const view = { ...baseView, repos: ['org/repo-a'] }
-    const actual = applyFilters([repoPR], baseGlobal, view)
+    const actual = applyFilters([repoPR], baseGlobal, view, 'review-requested')
     expect(actual).toHaveLength(1)
   })
 
   it('hides PRs from repos not in the selection', () => {
     // GIVEN org/repo-b is selected
     const view = { ...baseView, repos: ['org/repo-b'] }
-    const actual = applyFilters([repoPR], baseGlobal, view)
+    const actual = applyFilters([repoPR], baseGlobal, view, 'review-requested')
     expect(actual).toHaveLength(0)
   })
 
   it('shows all repos when repos list is empty', () => {
-    const actual = applyFilters([repoPR], baseGlobal, baseView)
+    const actual = applyFilters([repoPR], baseGlobal, baseView, 'review-requested')
     expect(actual).toHaveLength(1)
   })
 })
@@ -158,19 +176,19 @@ describe('applyFilters — search', () => {
 
   it('matches PRs whose title contains the search string', () => {
     const view = { ...baseView, search: 'login' }
-    const actual = applyFilters([pr], baseGlobal, view)
+    const actual = applyFilters([pr], baseGlobal, view, 'review-requested')
     expect(actual).toHaveLength(1)
   })
 
   it('is case-insensitive', () => {
     const view = { ...baseView, search: 'LOGIN' }
-    const actual = applyFilters([pr], baseGlobal, view)
+    const actual = applyFilters([pr], baseGlobal, view, 'review-requested')
     expect(actual).toHaveLength(1)
   })
 
   it('excludes PRs that do not match', () => {
     const view = { ...baseView, search: 'payment' }
-    const actual = applyFilters([pr], baseGlobal, view)
+    const actual = applyFilters([pr], baseGlobal, view, 'review-requested')
     expect(actual).toHaveLength(0)
   })
 })

--- a/src/features/pull-requests/lib/prFilters.test.ts
+++ b/src/features/pull-requests/lib/prFilters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { applyFilters } from './prFilters'
+import { applyFilters, isRepoMatchedBy } from './prFilters'
 import type { PullRequest } from '@/types/github'
 import type { GlobalFilters, ViewFilters } from '../stores/prStore'
 
@@ -81,6 +81,21 @@ describe('applyFilters — hiddenAuthors exact match', () => {
     const actual = applyFilters([makePR('renovate')], global, baseView, 'authored')
     // THEN PR still shows (you authored it, you should see it)
     expect(actual).toHaveLength(1)
+  })
+})
+
+describe('isRepoMatchedBy', () => {
+  it('matches exact owner/repo', () => {
+    expect(isRepoMatchedBy('myorg/repo', 'myorg/repo')).toBe(true)
+  })
+  it('matches org-wide pattern', () => {
+    expect(isRepoMatchedBy('myorg/repo', 'myorg')).toBe(true)
+  })
+  it('does not match a different org', () => {
+    expect(isRepoMatchedBy('myorg/repo', 'otherorg')).toBe(false)
+  })
+  it('does not match a partial repo name without slash', () => {
+    expect(isRepoMatchedBy('myorg/repo', 'myorg/rep')).toBe(false)
   })
 })
 

--- a/src/features/pull-requests/lib/prFilters.ts
+++ b/src/features/pull-requests/lib/prFilters.ts
@@ -1,6 +1,12 @@
 import type { PullRequest } from '@/types/github'
 import type { GlobalFilters, PRSection, ViewFilters } from '../stores/prStore'
 
+// supports "owner/repo" (exact) or "owner" (org-wide)
+export function isRepoMatchedBy(repoNameWithOwner: string, pattern: string): boolean {
+  const repo = repoNameWithOwner.toLowerCase()
+  return pattern.includes('/') ? repo === pattern : repo.split('/')[0] === pattern
+}
+
 export function applyFilters(
   nodes: PullRequest[],
   global: GlobalFilters,
@@ -18,11 +24,7 @@ export function applyFilters(
         return false
       if (
         !global.showHidden &&
-        global.hiddenRepos.some((r) => {
-          const repo = pr.repository.nameWithOwner.toLowerCase()
-          // supports "owner/repo" (exact) or "owner" (org-wide)
-          return r.includes('/') ? repo === r : repo.split('/')[0] === r
-        })
+        global.hiddenRepos.some((r) => isRepoMatchedBy(pr.repository.nameWithOwner, r))
       )
         return false
     }

--- a/src/features/pull-requests/lib/prFilters.ts
+++ b/src/features/pull-requests/lib/prFilters.ts
@@ -1,28 +1,31 @@
 import type { PullRequest } from '@/types/github'
-import type { GlobalFilters, ViewFilters } from '../stores/prStore'
+import type { GlobalFilters, PRSection, ViewFilters } from '../stores/prStore'
 
 export function applyFilters(
   nodes: PullRequest[],
   global: GlobalFilters,
-  view: ViewFilters
+  view: ViewFilters,
+  section: PRSection
 ): PullRequest[] {
   return nodes.filter((pr) => {
     if (!global.showHidden && pr.isHidden) return false
-    if (
-      !global.showHidden &&
-      pr.author &&
-      global.hiddenAuthors.some((p) => pr.author!.login.toLowerCase() === p.toLowerCase())
-    )
-      return false
-    if (
-      !global.showHidden &&
-      global.hiddenRepos.some((r) => {
-        const repo = pr.repository.nameWithOwner.toLowerCase()
-        // supports "owner/repo" (exact) or "owner" (org-wide)
-        return r.includes('/') ? repo === r : repo.split('/')[0] === r
-      })
-    )
-      return false
+    if (section !== 'authored') {
+      if (
+        !global.showHidden &&
+        pr.author &&
+        global.hiddenAuthors.some((p) => pr.author!.login.toLowerCase() === p.toLowerCase())
+      )
+        return false
+      if (
+        !global.showHidden &&
+        global.hiddenRepos.some((r) => {
+          const repo = pr.repository.nameWithOwner.toLowerCase()
+          // supports "owner/repo" (exact) or "owner" (org-wide)
+          return r.includes('/') ? repo === r : repo.split('/')[0] === r
+        })
+      )
+        return false
+    }
     if (!view.showDrafts && pr.isDraft) return false
     if (view.repos.length && !view.repos.includes(pr.repository.nameWithOwner)) return false
     if (view.search && !pr.title.toLowerCase().includes(view.search.toLowerCase())) return false

--- a/src/features/pull-requests/lib/prFilters.ts
+++ b/src/features/pull-requests/lib/prFilters.ts
@@ -1,19 +1,31 @@
 import type { PullRequest } from '@/types/github'
-import type { PRFilters } from '../stores/prStore'
+import type { GlobalFilters, ViewFilters } from '../stores/prStore'
 
-export function applyFilters(nodes: PullRequest[], filters: PRFilters): PullRequest[] {
+export function applyFilters(
+  nodes: PullRequest[],
+  global: GlobalFilters,
+  view: ViewFilters
+): PullRequest[] {
   return nodes.filter((pr) => {
-    if (!filters.showHidden && pr.isHidden) return false
+    if (!global.showHidden && pr.isHidden) return false
     if (
-      !filters.showHidden &&
+      !global.showHidden &&
       pr.author &&
-      filters.hiddenAuthors.some((p) => pr.author!.login.toLowerCase() === p.toLowerCase())
+      global.hiddenAuthors.some((p) => pr.author!.login.toLowerCase() === p.toLowerCase())
     )
       return false
-    if (!filters.showDrafts && pr.isDraft) return false
-    if (filters.repos.length && !filters.repos.includes(pr.repository.nameWithOwner)) return false
-    if (filters.search && !pr.title.toLowerCase().includes(filters.search.toLowerCase()))
+    if (
+      !global.showHidden &&
+      global.hiddenRepos.some((r) => {
+        const repo = pr.repository.nameWithOwner.toLowerCase()
+        // supports "owner/repo" (exact) or "owner" (org-wide)
+        return r.includes('/') ? repo === r : repo.split('/')[0] === r
+      })
+    )
       return false
+    if (!view.showDrafts && pr.isDraft) return false
+    if (view.repos.length && !view.repos.includes(pr.repository.nameWithOwner)) return false
+    if (view.search && !pr.title.toLowerCase().includes(view.search.toLowerCase())) return false
     return true
   })
 }

--- a/src/features/pull-requests/queries/useGitHubPRs.ts
+++ b/src/features/pull-requests/queries/useGitHubPRs.ts
@@ -66,8 +66,8 @@ export function usePullRequests() {
 
   const currentView = viewFilters[section]
   const filtered = useMemo(
-    () => applyFilters(allNodes, globalFilters, currentView),
-    [allNodes, globalFilters, currentView]
+    () => applyFilters(allNodes, globalFilters, currentView, section),
+    [allNodes, globalFilters, currentView, section]
   )
   const { priorityPRs, regular } = useMemo(
     () => sortAndPartition(filtered, priorityIds),

--- a/src/features/pull-requests/queries/useGitHubPRs.ts
+++ b/src/features/pull-requests/queries/useGitHubPRs.ts
@@ -23,14 +23,16 @@ interface SearchResult {
 export function usePullRequests() {
   const token = useAuthStore((s) => s.token)
   const user = useAuthStore((s) => s.user)
-  const filters = usePRStore((s) => s.filters)
+  const section = usePRStore((s) => s.section)
+  const globalFilters = usePRStore((s) => s.globalFilters)
+  const viewFilters = usePRStore((s) => s.viewFilters)
   const priorityIds = usePRStore((s) => s.priorityIds)
   const hiddenIds = usePRStore((s) => s.hiddenIds)
 
-  const searchQuery = buildSearchQuery(filters.section, user?.login ?? '')
+  const searchQuery = buildSearchQuery(section, user?.login ?? '')
 
   const query = useInfiniteQuery<SearchResult>({
-    queryKey: ['prs', filters.section, user?.login],
+    queryKey: ['prs', section, user?.login],
     enabled: !!token && !!user,
     staleTime: 60_000,
     initialPageParam: null,
@@ -62,7 +64,11 @@ export function usePullRequests() {
     [query.data, user, priorityIds, hiddenIds]
   )
 
-  const filtered = useMemo(() => applyFilters(allNodes, filters), [allNodes, filters])
+  const currentView = viewFilters[section]
+  const filtered = useMemo(
+    () => applyFilters(allNodes, globalFilters, currentView),
+    [allNodes, globalFilters, currentView]
+  )
   const { priorityPRs, regular } = useMemo(
     () => sortAndPartition(filtered, priorityIds),
     [filtered, priorityIds]

--- a/src/features/pull-requests/stores/prStore.test.ts
+++ b/src/features/pull-requests/stores/prStore.test.ts
@@ -3,13 +3,12 @@ import { usePRStore } from './prStore'
 
 beforeEach(() => {
   usePRStore.setState({
-    filters: {
-      section: 'review-requested',
-      repos: [],
-      hiddenAuthors: [],
-      showDrafts: false,
-      showHidden: false,
-      search: '',
+    section: 'review-requested',
+    globalFilters: { hiddenAuthors: [], hiddenRepos: [], showHidden: false },
+    viewFilters: {
+      'review-requested': { repos: [], showDrafts: false, search: '' },
+      authored: { repos: [], showDrafts: false, search: '' },
+      mentioned: { repos: [], showDrafts: false, search: '' },
     },
     priorityIds: [],
     hiddenIds: [],
@@ -17,11 +16,16 @@ beforeEach(() => {
 })
 
 describe('prStore', () => {
-  it('setFilters merges partial update', () => {
-    usePRStore.getState().setFilters({ search: 'foo' })
-    const { filters } = usePRStore.getState()
-    expect(filters.search).toBe('foo')
-    expect(filters.section).toBe('review-requested')
+  it('setViewFilters merges partial update', () => {
+    usePRStore.getState().setViewFilters('review-requested', { search: 'foo' })
+    const { viewFilters, section } = usePRStore.getState()
+    expect(viewFilters[section].search).toBe('foo')
+    expect(section).toBe('review-requested')
+  })
+
+  it('setSection changes the active section', () => {
+    usePRStore.getState().setSection('authored')
+    expect(usePRStore.getState().section).toBe('authored')
   })
 
   it('togglePriority adds an id', () => {
@@ -43,31 +47,53 @@ describe('prStore', () => {
 
   it('addHiddenAuthor adds a pattern', () => {
     usePRStore.getState().addHiddenAuthor('renovate')
-    expect(usePRStore.getState().filters.hiddenAuthors).toContain('renovate')
+    expect(usePRStore.getState().globalFilters.hiddenAuthors).toContain('renovate')
   })
 
   it('addHiddenAuthor normalizes to lowercase', () => {
     usePRStore.getState().addHiddenAuthor('Renovate')
-    expect(usePRStore.getState().filters.hiddenAuthors).toContain('renovate')
-    expect(usePRStore.getState().filters.hiddenAuthors).not.toContain('Renovate')
+    expect(usePRStore.getState().globalFilters.hiddenAuthors).toContain('renovate')
+    expect(usePRStore.getState().globalFilters.hiddenAuthors).not.toContain('Renovate')
   })
 
   it('addHiddenAuthor does not duplicate case-insensitively', () => {
     usePRStore.getState().addHiddenAuthor('Renovate')
     usePRStore.getState().addHiddenAuthor('renovate')
-    expect(usePRStore.getState().filters.hiddenAuthors).toHaveLength(1)
+    expect(usePRStore.getState().globalFilters.hiddenAuthors).toHaveLength(1)
   })
 
   it('removeHiddenAuthor removes an existing pattern', () => {
     usePRStore.getState().addHiddenAuthor('dependabot')
     usePRStore.getState().removeHiddenAuthor('dependabot')
-    expect(usePRStore.getState().filters.hiddenAuthors).not.toContain('dependabot')
+    expect(usePRStore.getState().globalFilters.hiddenAuthors).not.toContain('dependabot')
   })
 
   it('removeHiddenAuthor is a no-op for unknown pattern', () => {
     usePRStore.getState().addHiddenAuthor('renovate')
     usePRStore.getState().removeHiddenAuthor('unknown')
-    expect(usePRStore.getState().filters.hiddenAuthors).toHaveLength(1)
+    expect(usePRStore.getState().globalFilters.hiddenAuthors).toHaveLength(1)
+  })
+
+  it('addHiddenRepo adds a repo', () => {
+    usePRStore.getState().addHiddenRepo('myorg/repo')
+    expect(usePRStore.getState().globalFilters.hiddenRepos).toContain('myorg/repo')
+  })
+
+  it('addHiddenRepo normalizes to lowercase', () => {
+    usePRStore.getState().addHiddenRepo('MyOrg/Repo')
+    expect(usePRStore.getState().globalFilters.hiddenRepos).toContain('myorg/repo')
+  })
+
+  it('addHiddenRepo does not duplicate', () => {
+    usePRStore.getState().addHiddenRepo('myorg/repo')
+    usePRStore.getState().addHiddenRepo('myorg/repo')
+    expect(usePRStore.getState().globalFilters.hiddenRepos).toHaveLength(1)
+  })
+
+  it('removeHiddenRepo removes an existing repo', () => {
+    usePRStore.getState().addHiddenRepo('myorg/repo')
+    usePRStore.getState().removeHiddenRepo('myorg/repo')
+    expect(usePRStore.getState().globalFilters.hiddenRepos).not.toContain('myorg/repo')
   })
 
   it('toggleHide adds id when not hidden', () => {
@@ -81,15 +107,15 @@ describe('prStore', () => {
     expect(usePRStore.getState().hiddenIds).not.toContain('pr-1')
   })
 
-  it('resetFilters resets all filters to defaults', () => {
-    usePRStore.getState().setFilters({ search: 'foo', section: 'authored', showDrafts: true })
+  it('resetFilters resets only the current section view filters', () => {
+    usePRStore.getState().setViewFilters('review-requested', { search: 'foo', showDrafts: true, repos: ['org/repo'] })
+    usePRStore.getState().addHiddenAuthor('renovate')
     usePRStore.getState().resetFilters()
-    const { filters } = usePRStore.getState()
-    expect(filters.search).toBe('')
-    expect(filters.section).toBe('review-requested')
-    expect(filters.showDrafts).toBe(false)
-    expect(filters.repos).toEqual([])
-    expect(filters.hiddenAuthors).toEqual([])
-    expect(filters.showHidden).toBe(false)
+    const { viewFilters, globalFilters } = usePRStore.getState()
+    expect(viewFilters['review-requested'].search).toBe('')
+    expect(viewFilters['review-requested'].showDrafts).toBe(false)
+    expect(viewFilters['review-requested'].repos).toEqual([])
+    // global filters are preserved
+    expect(globalFilters.hiddenAuthors).toContain('renovate')
   })
 })

--- a/src/features/pull-requests/stores/prStore.test.ts
+++ b/src/features/pull-requests/stores/prStore.test.ts
@@ -108,7 +108,9 @@ describe('prStore', () => {
   })
 
   it('resetFilters resets only the current section view filters', () => {
-    usePRStore.getState().setViewFilters('review-requested', { search: 'foo', showDrafts: true, repos: ['org/repo'] })
+    usePRStore
+      .getState()
+      .setViewFilters('review-requested', { search: 'foo', showDrafts: true, repos: ['org/repo'] })
     usePRStore.getState().addHiddenAuthor('renovate')
     usePRStore.getState().resetFilters()
     const { viewFilters, globalFilters } = usePRStore.getState()

--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -15,7 +15,7 @@ export interface ViewFilters {
   search: string
 }
 
-interface PRStore {
+export interface PRStore {
   view: 'prs' | 'branches'
   section: PRSection
   globalFilters: GlobalFilters
@@ -144,6 +144,8 @@ export const usePRStore = create<PRStore>()(
           ...(p.section ? { section: p.section } : {}),
           globalFilters: { ...current.globalFilters, ...(p.globalFilters ?? {}) },
           viewFilters: { ...current.viewFilters, ...(p.viewFilters ?? {}) },
+          priorityIds: p.priorityIds ?? current.priorityIds,
+          hiddenIds: p.hiddenIds ?? current.hiddenIds,
         }
       },
     }

--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -3,47 +3,109 @@ import { persist } from 'zustand/middleware'
 
 export type PRSection = 'review-requested' | 'authored' | 'mentioned'
 
-export interface PRFilters {
-  section: PRSection
-  repos: string[] // empty = all
-  hiddenAuthors: string[] // empty = all
-  showDrafts: boolean
+export interface GlobalFilters {
+  hiddenAuthors: string[]
+  hiddenRepos: string[]
   showHidden: boolean
+}
+
+export interface ViewFilters {
+  repos: string[]
+  showDrafts: boolean
   search: string
 }
 
 interface PRStore {
   view: 'prs' | 'branches'
-  filters: PRFilters
+  section: PRSection
+  globalFilters: GlobalFilters
+  viewFilters: Record<PRSection, ViewFilters>
   priorityIds: string[]
   hiddenIds: string[]
   setView: (v: 'prs' | 'branches') => void
-  setFilters: (filters: Partial<PRFilters>) => void
-  togglePriority: (id: string) => void
-  toggleHide: (id: string) => void
+  setSection: (s: PRSection) => void
+  setGlobalFilters: (partial: Partial<GlobalFilters>) => void
+  setViewFilters: (s: PRSection, partial: Partial<ViewFilters>) => void
   addHiddenAuthor: (pattern: string) => void
   removeHiddenAuthor: (pattern: string) => void
+  addHiddenRepo: (repo: string) => void
+  removeHiddenRepo: (repo: string) => void
+  togglePriority: (id: string) => void
+  toggleHide: (id: string) => void
   resetFilters: () => void
 }
 
-const defaultFilters: PRFilters = {
-  section: 'review-requested',
+const defaultViewFilters: ViewFilters = {
   repos: [],
-  hiddenAuthors: [],
   showDrafts: false,
-  showHidden: false,
   search: '',
+}
+
+const defaultGlobalFilters: GlobalFilters = {
+  hiddenAuthors: [],
+  hiddenRepos: [],
+  showHidden: false,
+}
+
+const defaultViewFiltersAll: Record<PRSection, ViewFilters> = {
+  'review-requested': { ...defaultViewFilters },
+  authored: { ...defaultViewFilters },
+  mentioned: { ...defaultViewFilters },
 }
 
 export const usePRStore = create<PRStore>()(
   persist(
     (set) => ({
       view: 'prs' as const,
-      filters: defaultFilters,
+      section: 'review-requested' as PRSection,
+      globalFilters: defaultGlobalFilters,
+      viewFilters: defaultViewFiltersAll,
       priorityIds: [],
       hiddenIds: [],
-      setView: (v) => set((state) => ({ view: v, filters: { ...state.filters, search: '' } })),
-      setFilters: (partial) => set((state) => ({ filters: { ...state.filters, ...partial } })),
+      setView: (v) => set({ view: v }),
+      setSection: (s) => set({ section: s }),
+      setGlobalFilters: (partial) =>
+        set((state) => ({ globalFilters: { ...state.globalFilters, ...partial } })),
+      setViewFilters: (s, partial) =>
+        set((state) => ({
+          viewFilters: { ...state.viewFilters, [s]: { ...state.viewFilters[s], ...partial } },
+        })),
+      addHiddenAuthor: (pattern) =>
+        set((state) => {
+          const normalized = pattern.toLowerCase()
+          if (state.globalFilters.hiddenAuthors.includes(normalized)) return state
+          return {
+            globalFilters: {
+              ...state.globalFilters,
+              hiddenAuthors: [...state.globalFilters.hiddenAuthors, normalized],
+            },
+          }
+        }),
+      removeHiddenAuthor: (pattern) =>
+        set((state) => ({
+          globalFilters: {
+            ...state.globalFilters,
+            hiddenAuthors: state.globalFilters.hiddenAuthors.filter((a) => a !== pattern),
+          },
+        })),
+      addHiddenRepo: (repo) =>
+        set((state) => {
+          const normalized = repo.toLowerCase()
+          if (state.globalFilters.hiddenRepos.includes(normalized)) return state
+          return {
+            globalFilters: {
+              ...state.globalFilters,
+              hiddenRepos: [...state.globalFilters.hiddenRepos, normalized],
+            },
+          }
+        }),
+      removeHiddenRepo: (repo) =>
+        set((state) => ({
+          globalFilters: {
+            ...state.globalFilters,
+            hiddenRepos: state.globalFilters.hiddenRepos.filter((r) => r !== repo),
+          },
+        })),
       togglePriority: (id) =>
         set((state) => ({
           priorityIds: state.priorityIds.includes(id)
@@ -56,35 +118,32 @@ export const usePRStore = create<PRStore>()(
             ? state.hiddenIds.filter((p) => p !== id)
             : [...state.hiddenIds, id],
         })),
-      addHiddenAuthor: (pattern) =>
-        set((state) => {
-          const normalized = pattern.toLowerCase()
-          if (state.filters.hiddenAuthors.includes(normalized)) return state
-          return {
-            filters: {
-              ...state.filters,
-              hiddenAuthors: [...state.filters.hiddenAuthors, normalized],
-            },
-          }
-        }),
-      removeHiddenAuthor: (pattern) =>
+      resetFilters: () =>
         set((state) => ({
-          filters: {
-            ...state.filters,
-            hiddenAuthors: state.filters.hiddenAuthors.filter((a) => a !== pattern),
+          viewFilters: {
+            ...state.viewFilters,
+            [state.section]: { ...defaultViewFilters },
           },
         })),
-      resetFilters: () => set({ filters: defaultFilters }),
     }),
     {
       name: 'pr-dashboard-state',
       merge: (persisted, current) => {
         const p = persisted as Partial<PRStore>
         const validViews = new Set<string>(['prs', 'branches'])
+        // ponytail: drop old 'filters' key — muted authors lost once on first upgrade
+        if (!p.globalFilters) {
+          return {
+            ...current,
+            ...(p.view && validViews.has(p.view) ? { view: p.view } : {}),
+          }
+        }
         return {
           ...current,
           ...(p.view && validViews.has(p.view) ? { view: p.view } : {}),
-          filters: { ...current.filters, ...(p.filters ?? {}) },
+          ...(p.section ? { section: p.section } : {}),
+          globalFilters: { ...current.globalFilters, ...(p.globalFilters ?? {}) },
+          viewFilters: { ...current.viewFilters, ...(p.viewFilters ?? {}) },
         }
       },
     }

--- a/src/shared/components/ui/ButtonWithTooltip.tsx
+++ b/src/shared/components/ui/ButtonWithTooltip.tsx
@@ -26,7 +26,7 @@ export function ButtonWithTooltip({
         {children}
       </button>
       <span
-        className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none transition-opacity ${tooltipClassName}`}
+        className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] whitespace-nowrap pointer-events-none opacity-0 group-hover/tooltip:opacity-100 transition-opacity ${tooltipClassName}`}
       >
         {label}
       </span>


### PR DESCRIPTION
## What

Improve the settings UI/UX by using a dedicated modal, it allows a better option to add more settings in the future like being able to mute repository.

## Why

When you work in an organisation, you can be part of a team that owns multiple things **but** you're not interested by every scopes. That's why we must be able to mute a given repository.

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
