### PR TITLE
fix: preserve all settings across app updates

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -190,7 +190,12 @@ function createWindow() {
 ipcMain.handle('dirs:filter-existing', async (_e, paths: string[]) => {
   if (!Array.isArray(paths)) return []
   const results = await Promise.all(
-    paths.map((p) => fs.promises.access(p).then(() => p).catch(() => null))
+    paths.map((p) =>
+      fs.promises
+        .access(p)
+        .then(() => p)
+        .catch(() => null)
+    )
   )
   return results.filter((p): p is string => p !== null)
 })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,7 @@ import { autoUpdater } from 'electron-updater'
 import { spawn, execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
+import fs from 'node:fs'
 
 const execFileAsync = promisify(execFile)
 
@@ -185,6 +186,14 @@ function createWindow() {
     win.loadFile(path.join(__dirname, '../renderer/index.html'))
   }
 }
+
+ipcMain.handle('dirs:filter-existing', async (_e, paths: string[]) => {
+  if (!Array.isArray(paths)) return []
+  const results = await Promise.all(
+    paths.map((p) => fs.promises.access(p).then(() => p).catch(() => null))
+  )
+  return results.filter((p): p is string => p !== null)
+})
 
 ipcMain.handle('update:install', () => autoUpdater.quitAndInstall())
 // ponytail: flag so the banner can catch updates downloaded before it mounts

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -19,6 +19,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     remove: (repoPath: string, worktreePath: string, force: boolean): Promise<void> =>
       ipcRenderer.invoke('worktrees:remove', repoPath, worktreePath, force),
   },
+  dirs: {
+    filterExisting: (paths: string[]): Promise<string[]> =>
+      ipcRenderer.invoke('dirs:filter-existing', paths),
+  },
   dialog: {
     openDirectory: (): Promise<string | null> => ipcRenderer.invoke('dialog:open'),
   },

--- a/src/features/branches/components/BranchList/BranchList.tsx
+++ b/src/features/branches/components/BranchList/BranchList.tsx
@@ -1,6 +1,6 @@
 import { useQueries } from '@tanstack/react-query'
 import { FolderPlus, RefreshCw, X } from 'lucide-react'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { usePullRequests } from '@/features/pull-requests/exports'
 import { useBranchStore } from '../../stores/branchStore'
 import type { Worktree } from '../../types'
@@ -13,6 +13,16 @@ export function BranchList() {
   const { localPaths, addLocalPath, removeLocalPath } = useBranchStore()
   const { branchSearch } = useBranchStore()
   const { allPRs } = usePullRequests()
+
+  useEffect(() => {
+    window.electronAPI!.dirs
+      .filterExisting(localPaths)
+      .then((existing) => {
+        localPaths.filter((p) => !existing.includes(p)).forEach(removeLocalPath)
+      })
+      .catch(() => {}) // silently ignore — stale paths survive until next mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // ponytail: run once on mount — stale paths from previous session
 
   const branchQueries = useQueries({
     queries: localPaths.map((p) => ({

--- a/src/features/branches/components/BranchList/BranchList.tsx
+++ b/src/features/branches/components/BranchList/BranchList.tsx
@@ -15,8 +15,8 @@ export function BranchList() {
   const { allPRs } = usePullRequests()
 
   useEffect(() => {
-    window.electronAPI!.dirs
-      .filterExisting(localPaths)
+    window
+      .electronAPI!.dirs.filterExisting(localPaths)
       .then((existing) => {
         localPaths.filter((p) => !existing.includes(p)).forEach(removeLocalPath)
       })

--- a/src/features/branches/stores/branchStore.ts
+++ b/src/features/branches/stores/branchStore.ts
@@ -19,6 +19,13 @@ export const useBranchStore = create<BranchStore>()(
         set((state) => ({ localPaths: state.localPaths.filter((p) => p !== path) })),
       setBranchSearch: (s) => set({ branchSearch: s }),
     }),
-    { name: 'branch-dashboard-state' }
+    {
+      name: 'branch-dashboard-state',
+      merge: (persisted, current) => {
+        const p = persisted as Partial<BranchStore>
+        return { ...current, localPaths: p.localPaths ?? current.localPaths }
+        // ponytail: skip branchSearch — ephemeral
+      },
+    }
   )
 )

--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -131,19 +131,53 @@ export const usePRStore = create<PRStore>()(
       merge: (persisted, current) => {
         const p = persisted as Partial<PRStore>
         const validViews = new Set<string>(['prs', 'branches'])
-        // ponytail: drop old 'filters' key — muted authors lost once on first upgrade
+        // migrate from pre-1.6.0 format: flat `filters` key → globalFilters + viewFilters + section
         if (!p.globalFilters) {
+          const old = (
+            persisted as {
+              filters?: {
+                section?: PRSection
+                hiddenAuthors?: string[]
+                showHidden?: boolean
+                repos?: string[]
+                showDrafts?: boolean
+              }
+            }
+          ).filters
+          const section: PRSection = old?.section ?? current.section
           return {
             ...current,
             ...(p.view && validViews.has(p.view) ? { view: p.view } : {}),
+            section,
+            globalFilters: {
+              ...current.globalFilters,
+              hiddenAuthors: old?.hiddenAuthors ?? [],
+              showHidden: old?.showHidden ?? false,
+            },
+            viewFilters: {
+              ...current.viewFilters,
+              [section]: {
+                ...current.viewFilters[section],
+                repos: old?.repos ?? [],
+                showDrafts: old?.showDrafts ?? false,
+              },
+            },
+            priorityIds: p.priorityIds ?? current.priorityIds,
+            hiddenIds: p.hiddenIds ?? current.hiddenIds,
           }
         }
+        const validSections = new Set<string>(['review-requested', 'authored', 'mentioned'])
         return {
           ...current,
           ...(p.view && validViews.has(p.view) ? { view: p.view } : {}),
-          ...(p.section ? { section: p.section } : {}),
+          ...(p.section && validSections.has(p.section) ? { section: p.section } : {}),
           globalFilters: { ...current.globalFilters, ...(p.globalFilters ?? {}) },
-          viewFilters: { ...current.viewFilters, ...(p.viewFilters ?? {}) },
+          viewFilters: Object.fromEntries(
+            (Object.keys(current.viewFilters) as PRSection[]).map((s) => [
+              s,
+              { ...current.viewFilters[s], ...(p.viewFilters?.[s] ?? {}) },
+            ])
+          ) as Record<PRSection, ViewFilters>,
           priorityIds: p.priorityIds ?? current.priorityIds,
           hiddenIds: p.hiddenIds ?? current.hiddenIds,
         }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -19,6 +19,9 @@ interface Window {
       list: (repoPath: string) => Promise<import('../features/branches/types').Worktree[]>
       remove: (repoPath: string, worktreePath: string, force: boolean) => Promise<void>
     }
+    dirs: {
+      filterExisting: (paths: string[]) => Promise<string[]>
+    }
     dialog: {
       openDirectory: () => Promise<string | null>
     }


### PR DESCRIPTION
## What

Fix settings being lost when upgrading from v1.5.x to v1.6.0, and ensure all Zustand-persisted settings survive future upgrades.

Also adds cleanup of stale branch repo paths that no longer exist on disk.

## Why

The v1.6.0 refactor (`globalFilters` + `viewFilters` replacing the flat `filters` key) introduced a migration in the Zustand `merge` function that only preserved `view`, dropping everything else — starred PRs, hidden PRs, muted authors, selected repos, showDrafts, and section.

Additionally, `branchStore` had no explicit `merge`, and no mechanism to remove repo paths that were deleted or moved between sessions.

## Changes

- **prStore migration** (pre-1.6.0 → 1.6.0): now restores `hiddenAuthors`, `showHidden`, `repos`, `showDrafts`, `section`, `priorityIds`, `hiddenIds`
- **prStore normal merge**: added `section` validation (like `view` already had), and deep-merges `viewFilters` per-section so new fields get current-version defaults
- **branchStore**: explicit `merge` function for safe future upgrades
- **`dirs:filter-existing` IPC**: async (non-blocking, uses `fs.promises.access`), filters repo paths that no longer exist on disk
- **BranchList**: runs cleanup on mount — removes stale `localPaths` from the store

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [ ] `npm run build` passes