### PR TITLE
feat: add version bump type input to pre-release workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,6 +3,12 @@ name: Pre-release
 on:
   workflow_dispatch:
     inputs:
+      bump:
+        description: 'Version bump type'
+        required: false
+        default: 'patch'
+        type: choice
+        options: [patch, minor, major]
       label:
         description: 'Pre-release label'
         required: false
@@ -24,7 +30,8 @@ jobs:
         id: tag
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          TAG="v${VERSION}-${{ inputs.label }}.${{ github.run_number }}"
+          NEXT=$(node -p "const [M,m,p]=require('./package.json').version.split('.').map(Number);({'patch':M+'.'+(m)+'.'+(p+1),'minor':M+'.'+(m+1)+'.0','major':(M+1)+'.0.0'})['${{ inputs.bump }}']")
+          TAG="v${NEXT}-${{ inputs.label }}.${{ github.run_number }}"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
       - run: npm install
       - run: npx electron-vite build


### PR DESCRIPTION
## What

Add a `bump` input (patch / minor / major) to the pre-release workflow, and compute the next version before generating the pre-release tag.

## Why

The pre-release workflow was tagging builds as `v<current>-beta.N`, which collides with an already-published release. The next version must be bumped so the tag is unambiguous (e.g. `v1.6.1-beta.N` instead of `v1.6.0-beta.N`).

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes