### PR TITLE
feat: make all check row clickable

### DIFF
--- a/src/features/pull-requests/components/PRCheckRow/PRCheckRow.test.tsx
+++ b/src/features/pull-requests/components/PRCheckRow/PRCheckRow.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PRCheckRow } from './PRCheckRow'
+import type { CheckRunContext, StatusContextItem } from '@/types/github'
+
+const checkRun: CheckRunContext = {
+  __typename: 'CheckRun',
+  name: 'CI / build',
+  status: 'COMPLETED',
+  conclusion: 'SUCCESS',
+  detailsUrl: 'https://github.com/org/repo/runs/1',
+}
+
+const statusContext: StatusContextItem = {
+  __typename: 'StatusContext',
+  context: 'ci/circleci',
+  state: 'SUCCESS',
+  targetUrl: null,
+}
+
+describe('PRCheckRow', () => {
+  it('GIVEN CheckRun with url WHEN rendered THEN shows name as a link', () => {
+    render(<PRCheckRow check={checkRun} />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', checkRun.detailsUrl)
+    expect(screen.getByText('CI / build')).toBeInTheDocument()
+  })
+
+  it('GIVEN CheckRun with null url WHEN rendered THEN shows name without a link', () => {
+    render(<PRCheckRow check={{ ...checkRun, detailsUrl: null }} />)
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getByText('CI / build')).toBeInTheDocument()
+  })
+
+  it('GIVEN StatusContext with null url WHEN rendered THEN shows context name without a link', () => {
+    render(<PRCheckRow check={statusContext} />)
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getByText('ci/circleci')).toBeInTheDocument()
+  })
+
+  it('GIVEN StatusContext with url WHEN rendered THEN shows context name as a link', () => {
+    render(<PRCheckRow check={{ ...statusContext, targetUrl: 'https://circleci.com/build/1' }} />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://circleci.com/build/1')
+    expect(screen.getByText('ci/circleci')).toBeInTheDocument()
+  })
+
+  it('GIVEN link present WHEN rendered THEN has noopener noreferrer', () => {
+    render(<PRCheckRow check={checkRun} />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+})

--- a/src/features/pull-requests/components/PRCheckRow/PRCheckRow.tsx
+++ b/src/features/pull-requests/components/PRCheckRow/PRCheckRow.tsx
@@ -1,39 +1,53 @@
-import type {CheckRunContext, StatusContextItem} from "@/types/github.ts";
-import {PRCheckIcon} from "@/features/pull-requests/components/PRChecksModal/PRCheckIcon.tsx";
-import {ExternalLink} from "lucide-react";
-import type {PropsWithChildren} from "react";
-import {twMerge} from "tailwind-merge";
+import type { CheckRunContext, StatusContextItem } from '@/types/github.ts'
+import { PRCheckIcon } from '@/features/pull-requests/components/PRChecksModal/PRCheckIcon.tsx'
+import { ExternalLink } from 'lucide-react'
+import type { PropsWithChildren } from 'react'
+import { twMerge } from 'tailwind-merge'
 
 interface Props {
-    check: CheckRunContext | StatusContextItem
+  check: CheckRunContext | StatusContextItem
 }
 
-const CLASSNAME = 'group flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-[var(--color-surface-overlay)]'
+const CLASSNAME =
+  'group flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-[var(--color-surface-overlay)]'
 
-const Wrapper = ({children, url}: {children: PropsWithChildren['children'],  url: string | null}) => {
-    return url ? (
-        <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={twMerge(CLASSNAME, 'cursor-pointer')}
-        >
-            {children}
-        </a>
-    ) : <div className={CLASSNAME}>{children}</div>
+const Wrapper = ({
+  children,
+  url,
+}: {
+  children: PropsWithChildren['children']
+  url: string | null
+}) => {
+  return url ? (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={twMerge(CLASSNAME, 'cursor-pointer')}
+    >
+      {children}
+    </a>
+  ) : (
+    <div className={CLASSNAME}>{children}</div>
+  )
 }
 
-export function PRCheckRow({check}: Props) {
-    const name = check.__typename === 'CheckRun' ? check.name : check.context
-    const url = check.__typename === 'CheckRun' ? check.detailsUrl : check.targetUrl
+export function PRCheckRow({ check }: Props) {
+  const name = check.__typename === 'CheckRun' ? check.name : check.context
+  const url = check.__typename === 'CheckRun' ? check.detailsUrl : check.targetUrl
 
-    return (
-        <Wrapper url={url}>
-            <PRCheckIcon check={check} />
-            <span className="text-xs text-[var(--color-text-secondary)] group-hover:text-[var(--color-accent)] flex-1 truncate">
-                {name}
-              </span>
-            {url && (<ExternalLink size={11} className="text-[var(--color-text-muted)] group-hover:text-[var(--color-accent)]" />)}
-        </Wrapper>
-    )
+  return (
+    <Wrapper url={url}>
+      <PRCheckIcon check={check} />
+      <span className="text-xs text-[var(--color-text-secondary)] group-hover:text-[var(--color-accent)] flex-1 truncate">
+        {name}
+      </span>
+      {url && (
+        <ExternalLink
+          size={11}
+          className="text-[var(--color-text-muted)] group-hover:text-[var(--color-accent)]"
+        />
+      )}
+    </Wrapper>
+  )
 }

--- a/src/features/pull-requests/components/PRCheckRow/PRCheckRow.tsx
+++ b/src/features/pull-requests/components/PRCheckRow/PRCheckRow.tsx
@@ -1,0 +1,39 @@
+import type {CheckRunContext, StatusContextItem} from "@/types/github.ts";
+import {PRCheckIcon} from "@/features/pull-requests/components/PRChecksModal/PRCheckIcon.tsx";
+import {ExternalLink} from "lucide-react";
+import type {PropsWithChildren} from "react";
+import {twMerge} from "tailwind-merge";
+
+interface Props {
+    check: CheckRunContext | StatusContextItem
+}
+
+const CLASSNAME = 'group flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-[var(--color-surface-overlay)]'
+
+const Wrapper = ({children, url}: {children: PropsWithChildren['children'],  url: string | null}) => {
+    return url ? (
+        <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={twMerge(CLASSNAME, 'cursor-pointer')}
+        >
+            {children}
+        </a>
+    ) : <div className={CLASSNAME}>{children}</div>
+}
+
+export function PRCheckRow({check}: Props) {
+    const name = check.__typename === 'CheckRun' ? check.name : check.context
+    const url = check.__typename === 'CheckRun' ? check.detailsUrl : check.targetUrl
+
+    return (
+        <Wrapper url={url}>
+            <PRCheckIcon check={check} />
+            <span className="text-xs text-[var(--color-text-secondary)] group-hover:text-[var(--color-accent)] flex-1 truncate">
+                {name}
+              </span>
+            {url && (<ExternalLink size={11} className="text-[var(--color-text-muted)] group-hover:text-[var(--color-accent)]" />)}
+        </Wrapper>
+    )
+}

--- a/src/features/pull-requests/components/PRChecksModal/PRChecksModal.tsx
+++ b/src/features/pull-requests/components/PRChecksModal/PRChecksModal.tsx
@@ -1,7 +1,7 @@
 import { Clock } from 'lucide-react'
 import type { CheckRunContext, StatusContextItem, CheckRollupState } from '@/types/github.ts'
 import { Modal } from '@/shared/components/ui/Modal.tsx'
-import {PRCheckRow} from "@/features/pull-requests/components/PRCheckRow/PRCheckRow.tsx";
+import { PRCheckRow } from '@/features/pull-requests/components/PRCheckRow/PRCheckRow.tsx'
 
 interface Props {
   isOpen: boolean

--- a/src/features/pull-requests/components/PRChecksModal/PRChecksModal.tsx
+++ b/src/features/pull-requests/components/PRChecksModal/PRChecksModal.tsx
@@ -1,7 +1,7 @@
-import { Clock, ExternalLink } from 'lucide-react'
+import { Clock } from 'lucide-react'
 import type { CheckRunContext, StatusContextItem, CheckRollupState } from '@/types/github.ts'
-import { PRCheckIcon } from '@/features/pull-requests/components/PRChecksModal/PRCheckIcon.tsx'
 import { Modal } from '@/shared/components/ui/Modal.tsx'
+import {PRCheckRow} from "@/features/pull-requests/components/PRCheckRow/PRCheckRow.tsx";
 
 interface Props {
   isOpen: boolean
@@ -21,29 +21,7 @@ export function PRChecksModal({ isOpen, prTitle, checks, rollupState, onClose, i
         <p className="px-3 py-2 text-xs text-[var(--color-text-muted)]">No checks found</p>
       ) : (
         checks.map((check, i) => {
-          const name = check.__typename === 'CheckRun' ? check.name : check.context
-          const url = check.__typename === 'CheckRun' ? check.detailsUrl : check.targetUrl
-          return (
-            <div
-              key={i}
-              className="flex items-center gap-2 px-3 py-1.5 hover:bg-[var(--color-surface-overlay)]"
-            >
-              <PRCheckIcon check={check} />
-              <span className="text-xs text-[var(--color-text-secondary)] flex-1 truncate">
-                {name}
-              </span>
-              {url && (
-                <a
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="shrink-0 text-[var(--color-text-muted)] hover:text-[var(--color-accent)]"
-                >
-                  <ExternalLink size={11} />
-                </a>
-              )}
-            </div>
-          )
+          return <PRCheckRow check={check} key={i} />
         })
       )}
       {!isLoading && (rollupState === 'PENDING' || rollupState === 'EXPECTED') && (


### PR DESCRIPTION
## What

Extract check rows into a dedicated `PRCheckRow` component that wraps the entire row in an `<a>` tag when a URL is available, making the full row clickable instead of just the external-link icon.

## Why

Previously, only the small `ExternalLink` icon was clickable on check rows with a URL. This makes the whole row the clickable target, which is a much larger and more ergonomic hit area.

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes

---
_This pull request was created with AI assistance._