### PR TITLE
feat: improve initial PR query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ CI (`.github/workflows/ci.yml`) runs `lint`, `test:run`, then `build` on every P
 - **Mute authors**: free-form patterns (e.g. `dependabot`) that filter out their PRs.
 - Filters: by repository (checkboxes, shown only when >1 repo loaded), title search (navbar), show/hide **drafts**, show/hide **hidden**.
 - Each card shows repo, author, `#number`, opened/updated ages, diff size (`+/-`), draft/hidden badges, **my review-state** badge, a **CI checks** badge that opens a `PRChecksModal` popover (lazy-loads per-check contexts), and a **conflict** badge when `mergeable === 'CONFLICTING'`. In the authored section, cards also show grouped **reviewer avatars** (approved / changes-requested / commented / pending).
-- Paging: "Load more" / "Load all" (capped — see pipeline below), with a truncation notice past the cap.
+- Paging: pages auto-load in the background (capped at `MAX_PAGES = 10`); a spinner in the header badge shows while more pages are fetching.
 
 **Branches view** (`branches`, **Electron-only**) — `BranchList` reads *local* git repos the user adds via a native directory picker:
 - Lists branches per repo with **worktree detection**, a **dirty-state** dot for uncommitted changes, and the **linked open PR** (matched by `repo/headRefName`).
@@ -69,7 +69,7 @@ src/
       components/    Filters/ (+ Filters.test.tsx), PRCard/ (PRCard, PRCard.test.tsx,
                      ReviewerAvatars, PRChecksModal), PRList/ (PRList, PRList.test.tsx, VisibilityToggles)
       lib/           prUtils.ts & prUtils.test.ts, prFilters.ts & prFilters.test.ts, timeAgo.ts & timeAgo.test.ts
-      queries/       useGitHubPRs.ts + useGitHubPRs.test.ts, useCheckContexts.ts, useViewer.ts
+      queries/       useGitHubPRs.ts + useGitHubPRs.test.ts, useCheckContexts.ts, usePRDetails.ts, useViewer.ts
       stores/        prStore.ts + prStore.test.ts (Zustand, persisted)
       exports.ts     public surface: { Filters, PRList, usePRStore, … }
     updates/         OTA self-update (Electron-only)
@@ -121,10 +121,11 @@ Two layers, deliberately separated:
 `usePullRequests` (`src/features/pull-requests/queries/useGitHubPRs.ts`) is the core read path:
 
 1. `buildSearchQuery(section, login)` turns the active section (`review-requested` / `authored` / `mentioned`) into a GitHub search string.
-2. `useInfiniteQuery` pages the GraphQL `search` (20/page, capped at `MAX_PAGES = 10`; `truncated` flags when the cap hides more).
-3. Each node is enriched in-memory with `myReviewState` (`deriveMyReviewState`), `isTopPriority`, `isHidden`.
+2. `useInfiniteQuery` pages the GraphQL `search` via `PR_LIST_QUERY` (20/page, capped at `MAX_PAGES = 10`). Pages auto-fetch sequentially via a `useEffect`; `PRListHeader` shows a spinner while `isFetchingNextPage`. The list query returns only lightweight fields — `reviews`, `reviewRequests`, `commits`, and `mergeable` are **not** fetched here.
+3. Each node is enriched in-memory with `isTopPriority`, `isHidden`.
 4. `applyFilters` (`src/lib/prFilters.ts`) drops drafts/hidden/repo/author/search misses.
 5. `sortAndPartition` (`src/lib/prUtils.ts`) sorts by `updatedAt` and splits priority PRs (pinned on top) from the rest.
+6. **Per-card detail loading**: `PRCard` calls `usePRDetails(pr.id)` (`src/features/pull-requests/queries/usePRDetails.ts`) which lazily fetches the heavy per-PR fields (`reviews`, `reviewRequests`, `mergeable`, `commits`/`statusCheckRollup`). `myReviewState`, `checkState`, and conflict badge are derived from the merged result — so they appear progressively as details load. `reviews`, `reviewRequests`, `commits`, and `mergeable` are optional on the `PullRequest` type for this reason.
 
 All GraphQL queries live as exported template strings in `src/providers/github.ts`. The pure derivation helpers in `prUtils.ts` (review summaries, check rollup state) are the most heavily unit-tested part of the app — keep them pure and add cases there rather than testing through components.
 

--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -3,10 +3,17 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { PRCard } from './PRCard'
 import { usePRStore } from '../../stores/prStore'
+import { useAuthStore } from '@/features/auth/stores/authStore'
+import { usePRDetails } from '../../queries/usePRDetails'
 import type { PullRequest, ReviewState } from '@/types/github'
+
+const mockUsePRDetails = vi.mocked(usePRDetails)
 
 vi.mock('../../queries/useCheckContexts', () => ({
   useCheckContexts: vi.fn(() => ({ checks: [], isLoading: false })),
+}))
+vi.mock('../../queries/usePRDetails', () => ({
+  usePRDetails: vi.fn(() => ({ data: undefined })),
 }))
 
 const pr: PullRequest = {
@@ -31,6 +38,8 @@ const pr: PullRequest = {
 
 beforeEach(() => {
   usePRStore.setState({ priorityIds: [], hiddenIds: [] })
+  useAuthStore.setState({ user: { login: 'viewer', avatarUrl: '', name: 'Viewer' }, token: 'test' })
+  mockUsePRDetails.mockReturnValue({ data: undefined } as never)
 })
 
 describe('PRCard', () => {
@@ -133,33 +142,51 @@ describe('PRCard', () => {
   })
 
   describe('review state badge', () => {
-    const prWithReview = (state: ReviewState) => {
-      return { ...pr, myReviewState: state }
-    }
+    const makeDetailsWithReview = (state: ReviewState) => ({
+      data: {
+        id: pr.id,
+        reviews: {
+          nodes: [
+            {
+              state,
+              submittedAt: '2024-01-01T10:00:00Z',
+              author: { login: 'viewer', avatarUrl: '' },
+            },
+          ],
+        },
+        reviewRequests: { nodes: [] },
+        mergeable: 'MERGEABLE' as const,
+        commits: { nodes: [] },
+      },
+    })
 
-    it('GIVEN myReviewState APPROVED WHEN rendered THEN shows Approved badge', () => {
-      render(<PRCard pr={prWithReview('APPROVED')} />)
+    it('GIVEN details returns APPROVED review WHEN rendered THEN shows Approved badge', () => {
+      mockUsePRDetails.mockReturnValue(makeDetailsWithReview('APPROVED') as never)
+      render(<PRCard pr={pr} />)
       expect(screen.getByText('Approved')).toBeInTheDocument()
     })
 
-    it('GIVEN myReviewState CHANGES_REQUESTED WHEN rendered THEN shows Changes requested badge', () => {
-      render(<PRCard pr={prWithReview('CHANGES_REQUESTED')} />)
+    it('GIVEN details returns CHANGES_REQUESTED review WHEN rendered THEN shows Changes requested badge', () => {
+      mockUsePRDetails.mockReturnValue(makeDetailsWithReview('CHANGES_REQUESTED') as never)
+      render(<PRCard pr={pr} />)
       expect(screen.getByText('Changes requested')).toBeInTheDocument()
     })
 
-    it('GIVEN myReviewState COMMENTED WHEN rendered THEN shows Commented badge', () => {
-      render(<PRCard pr={prWithReview('COMMENTED')} />)
+    it('GIVEN details returns COMMENTED review WHEN rendered THEN shows Commented badge', () => {
+      mockUsePRDetails.mockReturnValue(makeDetailsWithReview('COMMENTED') as never)
+      render(<PRCard pr={pr} />)
       expect(screen.getByText('Commented')).toBeInTheDocument()
     })
 
-    it('GIVEN no myReviewState WHEN rendered THEN no review badge', () => {
-      render(<PRCard pr={{ ...pr, myReviewState: null }} />)
+    it('GIVEN details returns no matching review WHEN rendered THEN no review badge', () => {
+      render(<PRCard pr={pr} />)
       expect(screen.queryByText('Approved')).not.toBeInTheDocument()
       expect(screen.queryByText('Changes requested')).not.toBeInTheDocument()
     })
 
-    it('GIVEN isAuthored=true with APPROVED state WHEN rendered THEN no review badge shown', () => {
-      render(<PRCard pr={prWithReview('APPROVED')} isAuthored />)
+    it('GIVEN isAuthored=true WHEN rendered THEN no review badge shown', () => {
+      mockUsePRDetails.mockReturnValue(makeDetailsWithReview('APPROVED') as never)
+      render(<PRCard pr={pr} isAuthored />)
       expect(screen.queryByText('Approved')).not.toBeInTheDocument()
     })
   })

--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -14,8 +14,9 @@ import { usePRStore } from '../../stores/prStore'
 import { useAuthStore } from '@/features/auth/stores/authStore'
 import { ReviewerAvatars } from './ReviewerAvatars'
 import { PRChecksModal } from '../PRChecksModal/PRChecksModal.tsx'
-import { deriveCheckState } from '../../lib/prUtils'
+import { deriveCheckState, deriveMyReviewState } from '../../lib/prUtils'
 import { useCheckContexts } from '../../queries/useCheckContexts'
+import { usePRDetails } from '../../queries/usePRDetails'
 import { timeAgo } from '../../lib/timeAgo'
 import { PRCardActions } from '@/features/pull-requests/components/PRCardActions/PRCardActions.tsx'
 
@@ -104,10 +105,13 @@ export const PRCard = ({ pr, isAuthored = false }: Props) => {
   const viewerLogin = useAuthStore((s) => s.user?.login ?? '')
   const isPriority = priorityIds.includes(pr.id)
   const isHidden = pr.isHidden ?? false
-  const badge = !isAuthored && pr.myReviewState ? reviewBadge[pr.myReviewState] : null
-  const checkState = deriveCheckState(pr)
+  const { data: details } = usePRDetails(pr.id)
+  const merged = details ? { ...pr, ...details } : pr
+  const myReviewState = deriveMyReviewState(merged, viewerLogin)
+  const badge = !isAuthored && myReviewState ? reviewBadge[myReviewState] : null
+  const checkState = deriveCheckState(merged)
   const ciBadge = checkState ? ciStateBadge[checkState] : null
-  const showConflict = pr.mergeable === 'CONFLICTING'
+  const showConflict = merged.mergeable === 'CONFLICTING'
   const { checks, isLoading: checksLoading } = useCheckContexts(pr.id, checksOpen)
 
   const handleHide = () => {
@@ -241,7 +245,7 @@ export const PRCard = ({ pr, isAuthored = false }: Props) => {
             {/* Reviewer avatars (authored section only) */}
             {isAuthored && (
               <div className="mt-2">
-                <ReviewerAvatars pr={pr} authorLogin={viewerLogin} />
+                <ReviewerAvatars pr={merged} authorLogin={viewerLogin} />
               </div>
             )}
           </div>

--- a/src/features/pull-requests/components/PRList/PRList.test.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.test.tsx
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { PRList } from './PRList'
 import type { PullRequest } from '@/types/github'
 
 vi.mock('@/features/pull-requests/queries/useGitHubPRs', () => ({ usePullRequests: vi.fn() }))
 vi.mock('@/features/pull-requests/stores/prStore', () => ({ usePRStore: vi.fn() }))
-vi.mock('@/features/pull-requests/components/VisibilityToggles/VisibilityToggles', () => ({
-  VisibilityToggles: () => null,
-}))
 vi.mock('@/features/pull-requests/queries/useCheckContexts', () => ({
   useCheckContexts: vi.fn(() => ({ checks: [], isLoading: false })),
+}))
+vi.mock('@/features/pull-requests/queries/usePRDetails', () => ({
+  usePRDetails: vi.fn(() => ({ data: undefined })),
 }))
 
 import { usePullRequests } from '@/features/pull-requests/queries/useGitHubPRs'
@@ -29,23 +29,19 @@ const makePR = (id: string, title: string): PullRequest => {
     updatedAt: '2024-01-01T00:00:00Z',
     author: { login: 'user', avatarUrl: 'https://example.com/avatar.png' },
     repository: { name: 'repo', nameWithOwner: 'org/repo', url: 'https://github.com/org/repo' },
-    reviewRequests: { nodes: [] },
-    reviews: { nodes: [] },
     additions: 0,
     deletions: 0,
-    mergeable: 'MERGEABLE',
-    commits: { nodes: [] },
     isHidden: false,
   }
 }
 
-const mockStoreFilters = (viewOverrides: Record<string, unknown> = {}) => {
+const mockStoreFilters = () => {
   mockUsePRStore.mockImplementation((selector) =>
     selector({
       section: 'review-requested',
       globalFilters: { hiddenAuthors: [], hiddenRepos: [], showHidden: false },
       viewFilters: {
-        'review-requested': { repos: [], showDrafts: false, search: '', ...viewOverrides },
+        'review-requested': { repos: [], showDrafts: false, search: '' },
         authored: { repos: [], showDrafts: false, search: '' },
         mentioned: { repos: [], showDrafts: false, search: '' },
       },
@@ -70,14 +66,10 @@ const mockStoreFilters = (viewOverrides: Record<string, unknown> = {}) => {
 const defaultQuery = {
   isLoading: false,
   isFetching: false,
-  isFetchingNextPage: false,
-  fetchNextPage: vi.fn(),
-  hasNextPage: false,
   error: null,
   refetch: vi.fn(),
   totalCount: 0,
   loadedCount: 0,
-  truncated: false,
   repos: [],
 }
 
@@ -133,7 +125,7 @@ describe('PRList', () => {
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
-  it('GIVEN truncated THEN shows of {totalCount}', () => {
+  it('GIVEN totalCount > loadedCount THEN shows of {totalCount}', () => {
     const prs = [makePR('1', 'PR')]
     mockUsePullRequests.mockReturnValue({
       ...defaultQuery,
@@ -144,68 +136,5 @@ describe('PRList', () => {
     } as never)
     render(<PRList />)
     expect(screen.getByText(/of 500/)).toBeInTheDocument()
-  })
-
-  describe('pagination CTAs', () => {
-    it('GIVEN hasNextPage and no active filters THEN shows "Load more" only', () => {
-      const prs = [makePR('1', 'PR')]
-      mockUsePullRequests.mockReturnValue({
-        ...defaultQuery,
-        data: prs,
-        priorityPRs: [],
-        hasNextPage: true,
-        totalCount: 100,
-        loadedCount: 50,
-      } as never)
-      render(<PRList />)
-      expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: 'Load all' })).not.toBeInTheDocument()
-      expect(screen.queryByText(/Filters apply to/)).not.toBeInTheDocument()
-    })
-
-    it('GIVEN hasNextPage=false THEN no pagination CTAs', () => {
-      const prs = [makePR('1', 'PR')]
-      mockUsePullRequests.mockReturnValue({
-        ...defaultQuery,
-        data: prs,
-        priorityPRs: [],
-        hasNextPage: false,
-      } as never)
-      render(<PRList />)
-      expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: 'Load all' })).not.toBeInTheDocument()
-    })
-
-    it('GIVEN "Load more" clicked THEN fetchNextPage is called', () => {
-      const fetchNextPage = vi.fn()
-      const prs = [makePR('1', 'PR')]
-      mockUsePullRequests.mockReturnValue({
-        ...defaultQuery,
-        data: prs,
-        priorityPRs: [],
-        hasNextPage: true,
-        fetchNextPage,
-        totalCount: 100,
-        loadedCount: 50,
-      } as never)
-      render(<PRList />)
-      fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
-      expect(fetchNextPage).toHaveBeenCalledOnce()
-    })
-
-    it('GIVEN hasNextPage and active filter THEN shows "Load all" button', () => {
-      mockStoreFilters({ repos: ['org/repo'] }) // viewOverrides for review-requested
-      const prs = [makePR('1', 'PR')]
-      mockUsePullRequests.mockReturnValue({
-        ...defaultQuery,
-        data: prs,
-        priorityPRs: [],
-        hasNextPage: true,
-        totalCount: 100,
-        loadedCount: 50,
-      } as never)
-      render(<PRList />)
-      expect(screen.getByRole('button', { name: 'Load all' })).toBeInTheDocument()
-    })
   })
 })

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from 'react'
 import { usePullRequests } from '../../queries/useGitHubPRs'
 import { usePRStore } from '../../stores/prStore'
 import { PRCard } from '../PRCard/PRCard'
@@ -17,39 +16,16 @@ export const PRList = () => {
     isLoading,
     isFetching,
     isFetchingNextPage,
-    fetchNextPage,
-    hasNextPage,
     refetch,
     error,
     totalCount,
-    truncated,
   } = usePullRequests()
   const section = usePRStore((s) => s.section)
-  const viewFilters = usePRStore((s) => s.viewFilters)
-  const globalFilters = usePRStore((s) => s.globalFilters)
-  const currentView = viewFilters[section]
-  const loadAllRef = useRef(false)
 
   const handleRefetch = () => void refetch()
 
-  const hasActiveFilters =
-    currentView.repos.length > 0 ||
-    globalFilters.hiddenAuthors.length > 0 ||
-    currentView.showDrafts ||
-    currentView.search.length > 0
-
-  useEffect(() => {
-    if (loadAllRef.current && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage()
-    }
-    if (!hasNextPage) {
-      loadAllRef.current = false
-    }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
-
   return (
     <div className="flex-1 min-w-0">
-      {/* Header */}
       <PRListHeader
         title={sectionLabels[section]}
         displayCounter={!isLoading}
@@ -58,9 +34,9 @@ export const PRList = () => {
         displayTotalCount={totalCount > prs.length + priorityPRs.length}
         refetch={handleRefetch}
         isFetching={isFetching}
+        isLoadingMore={isFetchingNextPage}
       />
 
-      {/* States */}
       {isLoading && (
         <div className="space-y-3">
           {[...Array(5)].map((_, i) => (
@@ -75,12 +51,6 @@ export const PRList = () => {
       {error && (
         <div className="rounded-lg border border-[var(--color-danger)] bg-[var(--color-danger-subtle)] p-4 text-sm text-[var(--color-danger)]">
           Failed to load pull requests. Check your token and network.
-        </div>
-      )}
-
-      {truncated && !isFetching && (
-        <div className="text-xs text-[var(--color-text-muted)] mb-3 px-3 py-2 rounded bg-[var(--color-surface-raised)] border border-[var(--color-border)]">
-          Showing first 1000 PRs — refine filters on GitHub to narrow results.
         </div>
       )}
 
@@ -120,32 +90,6 @@ export const PRList = () => {
           {prs.map((pr) => (
             <PRCard key={pr.id} pr={pr} isAuthored={section === 'authored'} />
           ))}
-        </div>
-      )}
-
-      {!isLoading && !error && hasNextPage && !truncated && (
-        <div className="mt-4 flex flex-col items-center gap-2">
-          <div className="flex gap-2">
-            <button
-              onClick={() => fetchNextPage()}
-              disabled={isFetchingNextPage}
-              className="text-xs px-3 py-1.5 rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer disabled:opacity-40"
-            >
-              {isFetchingNextPage ? 'Loading…' : 'Load more'}
-            </button>
-            {hasActiveFilters && (
-              <button
-                onClick={() => {
-                  loadAllRef.current = true
-                  fetchNextPage()
-                }}
-                disabled={isFetchingNextPage}
-                className="text-xs px-3 py-1.5 rounded border border-[var(--color-accent)] text-[var(--color-accent)] hover:bg-[var(--color-accent-subtle)] transition-colors cursor-pointer disabled:opacity-40"
-              >
-                {isFetchingNextPage ? 'Loading…' : 'Load all'}
-              </button>
-            )}
-          </div>
         </div>
       )}
     </div>

--- a/src/features/pull-requests/components/PRListHeader/PRListHeader.tsx
+++ b/src/features/pull-requests/components/PRListHeader/PRListHeader.tsx
@@ -1,5 +1,5 @@
 import { VisibilityToggles } from '@/features/pull-requests/components/VisibilityToggles/VisibilityToggles.tsx'
-import { RefreshCw } from 'lucide-react'
+import { RefreshCw, Loader2 } from 'lucide-react'
 
 type Props = {
   title: string
@@ -9,6 +9,7 @@ type Props = {
   displayTotalCount: boolean
   refetch: () => void
   isFetching: boolean
+  isLoadingMore?: boolean
 }
 
 export const PRListHeader = ({
@@ -19,17 +20,19 @@ export const PRListHeader = ({
   displayTotalCount,
   refetch,
   isFetching,
+  isLoadingMore,
 }: Props) => {
   return (
     <div className="flex flex-wrap items-center justify-between mb-4">
       <div className="flex items-center gap-3">
         <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</h2>
         {displayCounter && (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-[var(--color-surface-overlay)] text-[var(--color-text-secondary)]">
+          <span className="flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full bg-[var(--color-surface-overlay)] text-[var(--color-text-secondary)]">
             {counter}
             {displayTotalCount && (
               <span className="text-[var(--color-text-muted)]"> of {totalCount}</span>
             )}
+            {isLoadingMore && <Loader2 size={10} className="animate-spin text-[var(--color-text-muted)]" />}
           </span>
         )}
       </div>

--- a/src/features/pull-requests/components/PRListHeader/PRListHeader.tsx
+++ b/src/features/pull-requests/components/PRListHeader/PRListHeader.tsx
@@ -32,7 +32,9 @@ export const PRListHeader = ({
             {displayTotalCount && (
               <span className="text-[var(--color-text-muted)]"> of {totalCount}</span>
             )}
-            {isLoadingMore && <Loader2 size={10} className="animate-spin text-[var(--color-text-muted)]" />}
+            {isLoadingMore && (
+              <Loader2 size={10} className="animate-spin text-[var(--color-text-muted)]" />
+            )}
           </span>
         )}
       </div>

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -19,7 +19,7 @@ export const SettingsModal = () => {
   const removeHiddenAuthor = usePRStore((s) => s.removeHiddenAuthor)
   const addHiddenRepo = usePRStore((s) => s.addHiddenRepo)
   const removeHiddenRepo = usePRStore((s) => s.removeHiddenRepo)
-  const { repos = [], hasNextPage, truncated, loadedCount, totalCount } = usePullRequests()
+  const { repos = [] } = usePullRequests()
 
   const currentView = viewFilters[section]
 
@@ -58,9 +58,6 @@ export const SettingsModal = () => {
         setViewFilters(section, { repos: remaining })
     }
   }
-
-  const showWarning =
-    (currentView.repos.length > 0 || globalFilters.showHidden) && hasNextPage && !truncated
 
   return (
     <>
@@ -196,11 +193,7 @@ export const SettingsModal = () => {
           </>
         )}
 
-        {showWarning && (
-          <p className="text-xs text-[var(--color-warning)]">
-            ⚠ Filters apply to {loadedCount} of ~{totalCount} PRs
-          </p>
-        )}
+
       </Modal>
     </>
   )

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -192,8 +192,6 @@ export const SettingsModal = () => {
             </div>
           </>
         )}
-
-
       </Modal>
     </>
   )

--- a/src/features/pull-requests/lib/prUtils.test.ts
+++ b/src/features/pull-requests/lib/prUtils.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import type { PullRequest } from '@/types/github'
-import { deriveReviewerSummary, buildSearchQuery, deriveCheckState, deriveMyReviewState } from './prUtils'
+import {
+  deriveReviewerSummary,
+  buildSearchQuery,
+  deriveCheckState,
+  deriveMyReviewState,
+} from './prUtils'
 
 const makePR = (overrides: Partial<PullRequest> = {}): PullRequest => {
   return {

--- a/src/features/pull-requests/lib/prUtils.test.ts
+++ b/src/features/pull-requests/lib/prUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { PullRequest } from '@/types/github'
-import { deriveReviewerSummary, buildSearchQuery, deriveCheckState } from './prUtils'
+import { deriveReviewerSummary, buildSearchQuery, deriveCheckState, deriveMyReviewState } from './prUtils'
 
 const makePR = (overrides: Partial<PullRequest> = {}): PullRequest => {
   return {
@@ -47,7 +47,19 @@ describe('buildSearchQuery', () => {
   })
 })
 
+describe('deriveMyReviewState', () => {
+  it('GIVEN PR with undefined reviews WHEN called THEN returns null', () => {
+    const pr = makePR({ reviews: undefined })
+    expect(deriveMyReviewState(pr, 'alice')).toBeNull()
+  })
+})
+
 describe('deriveCheckState', () => {
+  it('GIVEN PR with undefined commits WHEN called THEN returns null', () => {
+    const pr = makePR({ commits: undefined })
+    expect(deriveCheckState(pr)).toBeNull()
+  })
+
   it('GIVEN PR with no commits WHEN called THEN returns null', () => {
     const pr = makePR({ commits: { nodes: [] } })
     expect(deriveCheckState(pr)).toBeNull()
@@ -92,6 +104,15 @@ describe('deriveCheckState', () => {
 })
 
 describe('deriveReviewerSummary', () => {
+  it('GIVEN PR with undefined reviews and reviewRequests WHEN called THEN all buckets are empty', () => {
+    const pr = makePR({ reviews: undefined, reviewRequests: undefined })
+    const result = deriveReviewerSummary(pr, 'author')
+    expect(result.approved).toHaveLength(0)
+    expect(result.changesRequested).toHaveLength(0)
+    expect(result.commented).toHaveLength(0)
+    expect(result.pending).toHaveLength(0)
+  })
+
   it('GIVEN empty reviews and requests WHEN called THEN all buckets are empty', () => {
     const pr = makePR()
     const result = deriveReviewerSummary(pr, 'author')

--- a/src/features/pull-requests/lib/prUtils.ts
+++ b/src/features/pull-requests/lib/prUtils.ts
@@ -27,7 +27,7 @@ export const buildSearchQuery = (section: string, login: string): string => {
 }
 
 export const deriveMyReviewState = (pr: PullRequest, login: string): ReviewState | null => {
-  const myReviews = pr.reviews.nodes.filter((r) => r.author?.login === login)
+  const myReviews = (pr.reviews?.nodes ?? []).filter((r) => r.author?.login === login)
   if (!myReviews.length) return null
   const sorted = [...myReviews].sort(
     (a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime()
@@ -36,7 +36,7 @@ export const deriveMyReviewState = (pr: PullRequest, login: string): ReviewState
 }
 
 export const deriveReviewerSummary = (pr: PullRequest, authorLogin: string): ReviewerSummary => {
-  const sorted = [...pr.reviews.nodes]
+  const sorted = [...(pr.reviews?.nodes ?? [])]
     .filter((r) => r.author && r.author.login !== authorLogin)
     .sort((a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime())
 
@@ -58,7 +58,7 @@ export const deriveReviewerSummary = (pr: PullRequest, authorLogin: string): Rev
     else buckets.commented.push(reviewer)
   }
 
-  for (const rr of pr.reviewRequests.nodes) {
+  for (const rr of pr.reviewRequests?.nodes ?? []) {
     if (rr.requestedReviewer.__typename !== 'User') continue
     const r = rr.requestedReviewer as { __typename: 'User'; login: string; avatarUrl: string }
     if (!seen.has(r.login)) {
@@ -70,7 +70,7 @@ export const deriveReviewerSummary = (pr: PullRequest, authorLogin: string): Rev
 }
 
 export const deriveCheckState = (pr: PullRequest): CheckRollupState | null => {
-  return pr.commits.nodes[0]?.commit?.statusCheckRollup?.state ?? null
+  return pr.commits?.nodes[0]?.commit?.statusCheckRollup?.state ?? null
 }
 
 export const sortAndPartition = (

--- a/src/features/pull-requests/queries/useGitHubPRs.test.ts
+++ b/src/features/pull-requests/queries/useGitHubPRs.test.ts
@@ -28,7 +28,9 @@ const mid = makePR('2', '2024-06-01T00:00:00Z')
 const newest = makePR('3', '2024-12-01T00:00:00Z')
 
 describe('deriveMyReviewState', () => {
-  const makePRWithReviews = (reviews: NonNullable<PullRequest['reviews']>['nodes']): PullRequest => {
+  const makePRWithReviews = (
+    reviews: NonNullable<PullRequest['reviews']>['nodes']
+  ): PullRequest => {
     return { ...makePR('1', '2024-01-01T00:00:00Z'), reviews: { nodes: reviews } }
   }
 

--- a/src/features/pull-requests/queries/useGitHubPRs.test.ts
+++ b/src/features/pull-requests/queries/useGitHubPRs.test.ts
@@ -28,7 +28,7 @@ const mid = makePR('2', '2024-06-01T00:00:00Z')
 const newest = makePR('3', '2024-12-01T00:00:00Z')
 
 describe('deriveMyReviewState', () => {
-  const makePRWithReviews = (reviews: PullRequest['reviews']['nodes']): PullRequest => {
+  const makePRWithReviews = (reviews: NonNullable<PullRequest['reviews']>['nodes']): PullRequest => {
     return { ...makePR('1', '2024-01-01T00:00:00Z'), reviews: { nodes: reviews } }
   }
 

--- a/src/features/pull-requests/queries/useGitHubPRs.ts
+++ b/src/features/pull-requests/queries/useGitHubPRs.ts
@@ -49,7 +49,11 @@ export const usePullRequests = () => {
 
   // Auto-fetch subsequent pages in background, capped at MAX_PAGES
   useEffect(() => {
-    if (query.hasNextPage && !query.isFetchingNextPage && (query.data?.pages.length ?? 0) < MAX_PAGES) {
+    if (
+      query.hasNextPage &&
+      !query.isFetchingNextPage &&
+      (query.data?.pages.length ?? 0) < MAX_PAGES
+    ) {
       void query.fetchNextPage()
     }
   }, [query.hasNextPage, query.isFetchingNextPage, query.data?.pages.length, query.fetchNextPage])

--- a/src/features/pull-requests/queries/useGitHubPRs.ts
+++ b/src/features/pull-requests/queries/useGitHubPRs.ts
@@ -1,9 +1,9 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { createClient, PULL_REQUESTS_QUERY } from '@/providers/github'
+import { createClient, PR_LIST_QUERY } from '@/providers/github'
 import { useAuthStore } from '@/features/auth/stores/authStore'
 import { usePRStore } from '@/features/pull-requests/stores/prStore'
-import { buildSearchQuery, deriveMyReviewState, sortAndPartition } from '../lib/prUtils'
+import { buildSearchQuery, sortAndPartition } from '../lib/prUtils'
 import { applyFilters } from '../lib/prFilters'
 import type { PullRequest } from '@/types/github'
 
@@ -12,7 +12,7 @@ export { useViewer } from './useViewer'
 
 const MAX_PAGES = 10
 
-type SearchResult = {
+type SearchPage = {
   search: {
     issueCount: number
     pageInfo: { hasNextPage: boolean; endCursor: string }
@@ -31,38 +31,43 @@ export const usePullRequests = () => {
 
   const searchQuery = buildSearchQuery(section, user?.login ?? '')
 
-  const query = useInfiniteQuery<SearchResult>({
+  const query = useInfiniteQuery<SearchPage>({
     queryKey: ['prs', section, user?.login],
     enabled: !!token && !!user,
     staleTime: 60_000,
-    initialPageParam: null,
+    refetchOnWindowFocus: false,
+    initialPageParam: null as string | null,
+    getNextPageParam: (last) =>
+      last.search.pageInfo.hasNextPage ? last.search.pageInfo.endCursor : undefined,
     queryFn: async ({ pageParam }) => {
-      const client = createClient(token)
-      return client.request<SearchResult>(PULL_REQUESTS_QUERY, {
+      return createClient(token).request<SearchPage>(PR_LIST_QUERY, {
         searchQuery,
-        cursor: pageParam ?? undefined,
+        cursor: pageParam,
       })
-    },
-    getNextPageParam: (lastPage, pages) => {
-      if (pages.length >= MAX_PAGES) return undefined
-      return lastPage.search.pageInfo.hasNextPage ? lastPage.search.pageInfo.endCursor : undefined
     },
   })
 
-  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query
+  // Auto-fetch subsequent pages in background, capped at MAX_PAGES
+  useEffect(() => {
+    if (query.hasNextPage && !query.isFetchingNextPage && (query.data?.pages.length ?? 0) < MAX_PAGES) {
+      void query.fetchNextPage()
+    }
+  }, [query.hasNextPage, query.isFetchingNextPage, query.data?.pages.length, query.fetchNextPage])
 
-  const allNodes = useMemo(
-    () =>
-      (query.data?.pages ?? [])
-        .flatMap((p) => p.search.nodes)
-        .map((pr) => ({
-          ...pr,
-          myReviewState: deriveMyReviewState(pr, user!.login),
-          isTopPriority: priorityIds.includes(pr.id),
-          isHidden: hiddenIds.includes(pr.id),
-        })),
-    [query.data, user, priorityIds, hiddenIds]
-  )
+  const allNodes = useMemo(() => {
+    const seen = new Set<string>()
+    return (query.data?.pages.flatMap((p) => p.search.nodes) ?? [])
+      .map((pr) => ({
+        ...pr,
+        isTopPriority: priorityIds.includes(pr.id),
+        isHidden: hiddenIds.includes(pr.id),
+      }))
+      .filter((pr) => {
+        if (seen.has(pr.id)) return false
+        seen.add(pr.id)
+        return true
+      })
+  }, [query.data, priorityIds, hiddenIds])
 
   const currentView = viewFilters[section]
   const filtered = useMemo(
@@ -79,11 +84,7 @@ export const usePullRequests = () => {
     [allNodes]
   )
 
-  const totalCount = query.data?.pages[0]?.search.issueCount ?? 0
-  const loadedCount = allNodes.length
-  const lastPage = query.data?.pages[query.data.pages.length - 1]
-  const hitPageCap = (query.data?.pages.length ?? 0) >= MAX_PAGES
-  const truncated = hitPageCap && !!lastPage?.search.pageInfo.hasNextPage
+  const truncated = (query.data?.pages.length ?? 0) >= MAX_PAGES && query.hasNextPage
 
   return {
     ...query,
@@ -91,11 +92,8 @@ export const usePullRequests = () => {
     priorityPRs,
     allPRs: allNodes,
     repos,
-    totalCount,
-    loadedCount,
+    totalCount: query.data?.pages[0]?.search.issueCount ?? 0,
+    loadedCount: allNodes.length,
     truncated,
-    hasNextPage,
-    isFetchingNextPage,
-    fetchNextPage,
   }
 }

--- a/src/features/pull-requests/queries/usePRDetails.ts
+++ b/src/features/pull-requests/queries/usePRDetails.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query'
+import { createClient, PR_DETAILS_SINGLE_QUERY } from '@/providers/github'
+import { useAuthStore } from '@/features/auth/stores/authStore'
+import type { PullRequest } from '@/types/github'
+
+type NodeResult = {
+  node: Pick<PullRequest, 'id' | 'mergeable' | 'commits' | 'reviewRequests' | 'reviews'>
+}
+
+export const usePRDetails = (prId: string) => {
+  const token = useAuthStore((s) => s.token)
+  return useQuery<NodeResult['node']>({
+    queryKey: ['pr-details', prId],
+    enabled: !!token,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const data = await createClient(token).request<NodeResult>(PR_DETAILS_SINGLE_QUERY, {
+        nodeId: prId,
+      })
+      return data.node
+    },
+  })
+}

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -67,7 +67,7 @@ export const VIEWER_QUERY = /* GraphQL */ `
   }
 `
 
-export const PULL_REQUESTS_QUERY = /* GraphQL */ `
+export const PR_LIST_QUERY = /* GraphQL */ `
   query GetPullRequests($searchQuery: String!, $cursor: String) {
     search(query: $searchQuery, type: ISSUE, first: 20, after: $cursor) {
       issueCount
@@ -87,16 +87,6 @@ export const PULL_REQUESTS_QUERY = /* GraphQL */ `
           updatedAt
           additions
           deletions
-          mergeable
-          commits(last: 1) {
-            nodes {
-              commit {
-                statusCheckRollup {
-                  state
-                }
-              }
-            }
-          }
           author {
             login
             avatarUrl
@@ -106,29 +96,49 @@ export const PULL_REQUESTS_QUERY = /* GraphQL */ `
             nameWithOwner
             url
           }
-          reviewRequests(first: 10) {
-            nodes {
-              requestedReviewer {
-                __typename
-                ... on User {
-                  login
-                  avatarUrl
-                }
-                ... on Team {
-                  name
-                  slug
-                }
+        }
+      }
+    }
+  }
+`
+
+export const PR_DETAILS_SINGLE_QUERY = /* GraphQL */ `
+  query GetPRDetails($nodeId: ID!) {
+    node(id: $nodeId) {
+      ... on PullRequest {
+        id
+        mergeable
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                state
               }
             }
           }
-          reviews(first: 20) {
-            nodes {
-              state
-              submittedAt
-              author {
+        }
+        reviewRequests(first: 10) {
+          nodes {
+            requestedReviewer {
+              __typename
+              ... on User {
                 login
                 avatarUrl
               }
+              ... on Team {
+                name
+                slug
+              }
+            }
+          }
+        }
+        reviews(first: 20) {
+          nodes {
+            state
+            submittedAt
+            author {
+              login
+              avatarUrl
             }
           }
         }

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -61,16 +61,16 @@ export type PullRequest = {
     nameWithOwner: string
     url: string
   }
-  reviewRequests: {
+  reviewRequests?: {
     nodes: ReviewRequest[]
   }
-  reviews: {
+  reviews?: {
     nodes: Review[]
   }
   additions: number
   deletions: number
-  mergeable: MergeableState
-  commits: {
+  mergeable?: MergeableState
+  commits?: {
     nodes: {
       commit: {
         statusCheckRollup: {


### PR DESCRIPTION
## What

Improving the PR query to be able to load all PRs at once (when 100+ PRs), we're now doing an auto pagination with a proper UX feedback and defer informations to PR card directly.

## Why

Allows to have a better overview of what needs to be reviewed and be sure that no information is forgotten.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes
