### PR TITLE
feat: new prs available

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ CI (`.github/workflows/ci.yml`) runs `lint`, `test:run`, then `build` on every P
 - Filters: by repository (checkboxes, shown only when >1 repo loaded), title search (navbar), show/hide **drafts**, show/hide **hidden**.
 - Each card shows repo, author, `#number`, opened/updated ages, diff size (`+/-`), draft/hidden badges, **my review-state** badge, a **CI checks** badge that opens a `PRChecksModal` popover (lazy-loads per-check contexts), and a **conflict** badge when `mergeable === 'CONFLICTING'`. In the authored section, cards also show grouped **reviewer avatars** (approved / changes-requested / commented / pending).
 - Paging: pages auto-load in the background (capped at `MAX_PAGES = 10`); a spinner in the header badge shows while more pages are fetching.
+- **Focus refresh**: when the window regains focus, `useFocusRefresh` (`hooks/useFocusRefresh.ts`) snapshots the current PR IDs and triggers a refetch. If new PRs appear, a `NewPRsBadge` is shown above the list; the list stays frozen at the pre-focus snapshot until the badge is dismissed or clicked. The `authored` section is excluded from this detection. Local mutations (star/hide) pass through the snapshot filter so they are always reflected immediately.
 
 **Branches view** (`branches`, **Electron-only**) — `BranchList` reads *local* git repos the user adds via a native directory picker:
 - Lists branches per repo with **worktree detection**, a **dirty-state** dot for uncommitted changes, and the **linked open PR** (matched by `repo/headRefName`).
@@ -67,7 +68,9 @@ src/
       exports.ts               public surface: { BranchList }
     pull-requests/   PR inbox feature
       components/    Filters/ (+ Filters.test.tsx), PRCard/ (PRCard, PRCard.test.tsx,
-                     ReviewerAvatars, PRChecksModal), PRList/ (PRList, PRList.test.tsx, VisibilityToggles)
+                     ReviewerAvatars, PRChecksModal), PRList/ (PRList, PRList.test.tsx, VisibilityToggles),
+                     NewPRsBadge/ (NewPRsBadge, NewPRsBadge.test.tsx)
+      hooks/         useFocusRefresh.ts + useFocusRefresh.test.tsx
       lib/           prUtils.ts & prUtils.test.ts, prFilters.ts & prFilters.test.ts, timeAgo.ts & timeAgo.test.ts
       queries/       useGitHubPRs.ts + useGitHubPRs.test.ts, useCheckContexts.ts, usePRDetails.ts, useViewer.ts
       stores/        prStore.ts + prStore.test.ts (Zustand, persisted)
@@ -121,7 +124,7 @@ Two layers, deliberately separated:
 `usePullRequests` (`src/features/pull-requests/queries/useGitHubPRs.ts`) is the core read path:
 
 1. `buildSearchQuery(section, login)` turns the active section (`review-requested` / `authored` / `mentioned`) into a GitHub search string.
-2. `useInfiniteQuery` pages the GraphQL `search` via `PR_LIST_QUERY` (20/page, capped at `MAX_PAGES = 10`). Pages auto-fetch sequentially via a `useEffect`; `PRListHeader` shows a spinner while `isFetchingNextPage`. The list query returns only lightweight fields — `reviews`, `reviewRequests`, `commits`, and `mergeable` are **not** fetched here.
+2. `useInfiniteQuery` pages the GraphQL `search` via `PR_LIST_QUERY` (20/page, capped at `MAX_PAGES = 10`), sorted `sort:updated-desc`. Pages auto-fetch sequentially via a `useEffect`; `PRListHeader` shows a spinner while `isFetchingNextPage`. The list query returns only lightweight fields — `reviews`, `reviewRequests`, `commits`, and `mergeable` are **not** fetched here.
 3. Each node is enriched in-memory with `isTopPriority`, `isHidden`.
 4. `applyFilters` (`src/lib/prFilters.ts`) drops drafts/hidden/repo/author/search misses.
 5. `sortAndPartition` (`src/lib/prUtils.ts`) sorts by `updatedAt` and splits priority PRs (pinned on top) from the rest.

--- a/src/features/pull-requests/components/NewPRsBadge/NewPRsBadge.test.tsx
+++ b/src/features/pull-requests/components/NewPRsBadge/NewPRsBadge.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { NewPRsBadge } from './NewPRsBadge'
+
+describe('NewPRsBadge', () => {
+  it('renders singular label for count=1', () => {
+    render(<NewPRsBadge count={1} onDismiss={vi.fn()} />)
+    expect(screen.getByText(/1 new pull request$/)).toBeInTheDocument()
+  })
+
+  it('renders plural label for count>1', () => {
+    render(<NewPRsBadge count={3} onDismiss={vi.fn()} />)
+    expect(screen.getByText(/3 new pull requests/)).toBeInTheDocument()
+  })
+
+  it('calls onDismiss when clicked', async () => {
+    const dismiss = vi.fn()
+    render(<NewPRsBadge count={2} onDismiss={dismiss} />)
+    await userEvent.click(screen.getByRole('button'))
+    expect(dismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/pull-requests/components/NewPRsBadge/NewPRsBadge.tsx
+++ b/src/features/pull-requests/components/NewPRsBadge/NewPRsBadge.tsx
@@ -5,6 +5,8 @@ export const NewPRsBadge = ({ count, onDismiss }: Props) => (
     onClick={onDismiss}
     className="mb-3 w-full flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--color-accent-subtle)] border border-[var(--color-accent)] text-[var(--color-accent)] text-xs cursor-pointer hover:opacity-80 focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
   >
-    <strong>{count} new pull request{count > 1 ? 's' : ''}</strong>
+    <strong>
+      {count} new pull request{count > 1 ? 's' : ''}
+    </strong>
   </button>
 )

--- a/src/features/pull-requests/components/NewPRsBadge/NewPRsBadge.tsx
+++ b/src/features/pull-requests/components/NewPRsBadge/NewPRsBadge.tsx
@@ -1,0 +1,10 @@
+type Props = { count: number; onDismiss: () => void }
+
+export const NewPRsBadge = ({ count, onDismiss }: Props) => (
+  <button
+    onClick={onDismiss}
+    className="mb-3 w-full flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--color-accent-subtle)] border border-[var(--color-accent)] text-[var(--color-accent)] text-xs cursor-pointer hover:opacity-80 focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+  >
+    <strong>{count} new pull request{count > 1 ? 's' : ''}</strong>
+  </button>
+)

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -2,6 +2,8 @@ import { usePullRequests } from '../../queries/useGitHubPRs'
 import { usePRStore } from '../../stores/prStore'
 import { PRCard } from '../PRCard/PRCard'
 import { PRListHeader } from '@/features/pull-requests/components/PRListHeader/PRListHeader.tsx'
+import { useFocusRefresh } from '../../hooks/useFocusRefresh'
+import { NewPRsBadge } from '../NewPRsBadge/NewPRsBadge'
 
 const sectionLabels: Record<string, string> = {
   'review-requested': 'Review requested',
@@ -13,6 +15,7 @@ export const PRList = () => {
   const {
     data: prs = [],
     priorityPRs = [],
+    allPRs = [],
     isLoading,
     isFetching,
     isFetchingNextPage,
@@ -21,21 +24,40 @@ export const PRList = () => {
     totalCount,
   } = usePullRequests()
   const section = usePRStore((s) => s.section)
+  const globalFilters = usePRStore((s) => s.globalFilters)
+  const viewFilters = usePRStore((s) => s.viewFilters)
 
-  const handleRefetch = () => void refetch()
+  const { displayedPRs, displayedPriorityPRs, newCount, dismiss } = useFocusRefresh({
+    allPRs,
+    prs,
+    priorityPRs,
+    refetch: () => void refetch(),
+    isFetching,
+    isFetchingNextPage,
+    globalFilters,
+    view: viewFilters[section],
+    section,
+  })
+
+  const handleRefetch = () => {
+    dismiss()
+    void refetch()
+  }
 
   return (
     <div className="flex-1 min-w-0">
       <PRListHeader
         title={sectionLabels[section]}
         displayCounter={!isLoading}
-        counter={prs.length + priorityPRs.length}
+        counter={displayedPRs.length + displayedPriorityPRs.length}
         totalCount={totalCount}
-        displayTotalCount={totalCount > prs.length + priorityPRs.length}
+        displayTotalCount={totalCount > displayedPRs.length + displayedPriorityPRs.length}
         refetch={handleRefetch}
         isFetching={isFetching}
         isLoadingMore={isFetchingNextPage}
       />
+
+      {newCount > 0 && <NewPRsBadge count={newCount} onDismiss={dismiss} />}
 
       {isLoading && (
         <div className="space-y-3">
@@ -54,7 +76,7 @@ export const PRList = () => {
         </div>
       )}
 
-      {!isLoading && !error && prs.length === 0 && priorityPRs.length === 0 && (
+      {!isLoading && !error && displayedPRs.length === 0 && displayedPriorityPRs.length === 0 && (
         <div className="text-center py-16 text-[var(--color-text-muted)]">
           <p className="text-sm">No pull requests found.</p>
           <p className="text-xs mt-1">Try adjusting your filters.</p>
@@ -72,22 +94,22 @@ export const PRList = () => {
         </div>
       )}
 
-      {!isLoading && !error && priorityPRs.length > 0 && (
+      {!isLoading && !error && displayedPriorityPRs.length > 0 && (
         <div className="mb-4">
           <p className="text-sm font-semibold text-[var(--color-text-primary)] mb-2">
             Top priority
           </p>
           <div className="space-y-2">
-            {priorityPRs.map((pr) => (
+            {displayedPriorityPRs.map((pr) => (
               <PRCard key={pr.id} pr={pr} isAuthored={section === 'authored'} />
             ))}
           </div>
         </div>
       )}
 
-      {!isLoading && !error && prs.length > 0 && (
+      {!isLoading && !error && displayedPRs.length > 0 && (
         <div className="space-y-2">
-          {prs.map((pr) => (
+          {displayedPRs.map((pr) => (
             <PRCard key={pr.id} pr={pr} isAuthored={section === 'authored'} />
           ))}
         </div>

--- a/src/features/pull-requests/hooks/useFocusRefresh.test.tsx
+++ b/src/features/pull-requests/hooks/useFocusRefresh.test.tsx
@@ -1,0 +1,193 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import type { PullRequest } from '@/types/github'
+import type { GlobalFilters, PRSection, ViewFilters } from '../stores/prStore'
+import { useFocusRefresh } from './useFocusRefresh'
+
+export const makePR = (id: string, author = 'alice', repo = 'org/repo'): PullRequest =>
+  ({
+    id,
+    number: 1,
+    title: `PR ${id}`,
+    url: '',
+    isDraft: false,
+    isHidden: false,
+    isTopPriority: false,
+    author: { login: author, avatarUrl: '' },
+    repository: { nameWithOwner: repo },
+  }) as unknown as PullRequest
+
+const gf: GlobalFilters = { hiddenAuthors: [], hiddenRepos: [], showHidden: false }
+const vf: ViewFilters = { repos: [], showDrafts: false, search: '' }
+const section: PRSection = 'review-requested'
+
+type Props = {
+  allPRs: PullRequest[]
+  prs: PullRequest[]
+  priorityPRs: PullRequest[]
+  refetch: () => void
+  isFetching: boolean
+  isFetchingNextPage: boolean
+  globalFilters: GlobalFilters
+  view: ViewFilters
+  section: PRSection
+}
+
+const defaults: Props = {
+  allPRs: [],
+  prs: [],
+  priorityPRs: [],
+  refetch: vi.fn(),
+  isFetching: false,
+  isFetchingNextPage: false,
+  globalFilters: gf,
+  view: vf,
+  section,
+}
+
+const useHook = (p: Props) => useFocusRefresh(p)
+
+describe('useFocusRefresh', () => {
+  it('GIVEN idle THEN displayedPRs mirrors prs', () => {
+    const pr = makePR('1')
+    const { result } = renderHook(() => useHook({ ...defaults, allPRs: [pr], prs: [pr] }))
+    expect(result.current.displayedPRs).toEqual([pr])
+    expect(result.current.newCount).toBe(0)
+  })
+
+  it('GIVEN focus fires during initial fetch THEN no snapshot taken and newCount stays 0', async () => {
+    const existing = makePR('existing')
+    const newPR = makePR('new')
+    const refetch = vi.fn()
+    const { result, rerender } = renderHook((props: Props) => useHook(props), {
+      initialProps: { ...defaults, refetch, isFetching: true, allPRs: [], prs: [], priorityPRs: [] } as Props,
+    })
+
+    // focus fires while initial fetch is in-flight
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'))
+    })
+
+    // fetch completes with data
+    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing, newPR], prs: [existing, newPR] })
+
+    expect(result.current.newCount).toBe(0)
+    expect(result.current.displayedPRs).toEqual([existing, newPR])
+  })
+
+  it('GIVEN focus fires with data loaded THEN new PR triggers badge after refetch', async () => {
+    const existing = makePR('existing')
+    const newPR = makePR('new')
+    const refetch = vi.fn()
+    const { result, rerender } = renderHook((props: Props) => useHook(props), {
+      initialProps: { ...defaults, refetch, allPRs: [existing], prs: [existing], priorityPRs: [] },
+    })
+
+    // focus: snapshot taken of [existing]
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'))
+    })
+
+    // refetch in-flight
+    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing], prs: [existing], priorityPRs: [] })
+    // refetch completes with new PR
+    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing, newPR], prs: [existing, newPR], priorityPRs: [] })
+
+    expect(result.current.newCount).toBe(1)
+    expect(result.current.displayedPRs).toEqual([existing])
+  })
+
+  it('GIVEN badge showing THEN dismiss resets newCount and reveals full prs', async () => {
+    const existing = makePR('existing')
+    const newPR = makePR('new')
+    const refetch = vi.fn()
+    const { result, rerender } = renderHook((props: Props) => useHook(props), {
+      initialProps: { ...defaults, refetch, allPRs: [existing], prs: [existing], priorityPRs: [] },
+    })
+
+    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
+    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing], prs: [existing], priorityPRs: [] })
+    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing, newPR], prs: [existing, newPR], priorityPRs: [] })
+    expect(result.current.newCount).toBe(1)
+
+    act(() => { result.current.dismiss() })
+
+    expect(result.current.newCount).toBe(0)
+    expect(result.current.displayedPRs).toEqual([existing, newPR])
+  })
+
+  it('GIVEN focus fires and PR is removed THEN displayedPRs excludes removed PR and newCount stays 0', async () => {
+    const existing1 = makePR('existing1')
+    const existing2 = makePR('existing2')
+    const refetch = vi.fn()
+    const { result, rerender } = renderHook((props: Props) => useHook(props), {
+      initialProps: { ...defaults, refetch, allPRs: [existing1, existing2], prs: [existing1, existing2], priorityPRs: [] },
+    })
+
+    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
+
+    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing1, existing2], prs: [existing1, existing2], priorityPRs: [] })
+    // existing2 removed from review list
+    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing1], prs: [existing1], priorityPRs: [] })
+
+    expect(result.current.newCount).toBe(0)
+    expect(result.current.displayedPRs).toEqual([existing1])
+  })
+
+  it('GIVEN focus fires and PR removed + new PR added THEN displayedPRs hides new PR but not removed, newCount is 1', async () => {
+    const existing1 = makePR('existing1')
+    const existing2 = makePR('existing2')
+    const newPR = makePR('new')
+    const refetch = vi.fn()
+    const { result, rerender } = renderHook((props: Props) => useHook(props), {
+      initialProps: { ...defaults, refetch, allPRs: [existing1, existing2], prs: [existing1, existing2], priorityPRs: [] },
+    })
+
+    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
+
+    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing1, existing2], prs: [existing1, existing2], priorityPRs: [] })
+    // existing2 gone, new PR appeared
+    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing1, newPR], prs: [existing1, newPR], priorityPRs: [] })
+
+    expect(result.current.newCount).toBe(1)
+    expect(result.current.displayedPRs).toEqual([existing1])
+  })
+
+  it('GIVEN new PR appears then disappears before dismiss THEN newCount resets to 0', async () => {
+    const existing = makePR('existing')
+    const newPR = makePR('new')
+    const refetch = vi.fn()
+    const { result, rerender } = renderHook((props: Props) => useHook(props), {
+      initialProps: { ...defaults, refetch, allPRs: [existing], prs: [existing], priorityPRs: [] },
+    })
+
+    // focus: snapshot taken of [existing], newPR appears
+    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
+    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing], prs: [existing], priorityPRs: [] })
+    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing, newPR], prs: [existing, newPR], priorityPRs: [] })
+    expect(result.current.newCount).toBe(1)
+
+    // second focus: newPR is gone before dismiss
+    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
+    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing, newPR], prs: [existing, newPR], priorityPRs: [] })
+    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing], prs: [existing], priorityPRs: [] })
+
+    expect(result.current.newCount).toBe(0)
+    expect(result.current.displayedPRs).toEqual([existing])
+  })
+
+  it('GIVEN load-more completes without focus THEN newCount stays 0', async () => {
+    const existing = makePR('existing')
+    const paginated = makePR('paginated')
+    const refetch = vi.fn()
+    const { result, rerender } = renderHook((props: Props) => useHook(props), {
+      initialProps: { ...defaults, refetch, allPRs: [existing], prs: [existing], priorityPRs: [] },
+    })
+
+    // load-more without a prior focus
+    rerender({ ...defaults, refetch, isFetchingNextPage: true, allPRs: [existing], prs: [existing], priorityPRs: [] })
+    rerender({ ...defaults, refetch, isFetchingNextPage: false, allPRs: [existing, paginated], prs: [existing, paginated], priorityPRs: [] })
+
+    expect(result.current.newCount).toBe(0)
+  })
+})

--- a/src/features/pull-requests/hooks/useFocusRefresh.test.tsx
+++ b/src/features/pull-requests/hooks/useFocusRefresh.test.tsx
@@ -60,7 +60,14 @@ describe('useFocusRefresh', () => {
     const newPR = makePR('new')
     const refetch = vi.fn()
     const { result, rerender } = renderHook((props: Props) => useHook(props), {
-      initialProps: { ...defaults, refetch, isFetching: true, allPRs: [], prs: [], priorityPRs: [] } as Props,
+      initialProps: {
+        ...defaults,
+        refetch,
+        isFetching: true,
+        allPRs: [],
+        prs: [],
+        priorityPRs: [],
+      } as Props,
     })
 
     // focus fires while initial fetch is in-flight
@@ -69,7 +76,13 @@ describe('useFocusRefresh', () => {
     })
 
     // fetch completes with data
-    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing, newPR], prs: [existing, newPR] })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: false,
+      allPRs: [existing, newPR],
+      prs: [existing, newPR],
+    })
 
     expect(result.current.newCount).toBe(0)
     expect(result.current.displayedPRs).toEqual([existing, newPR])
@@ -89,9 +102,23 @@ describe('useFocusRefresh', () => {
     })
 
     // refetch in-flight
-    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing], prs: [existing], priorityPRs: [] })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: true,
+      allPRs: [existing],
+      prs: [existing],
+      priorityPRs: [],
+    })
     // refetch completes with new PR
-    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing, newPR], prs: [existing, newPR], priorityPRs: [] })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: false,
+      allPRs: [existing, newPR],
+      prs: [existing, newPR],
+      priorityPRs: [],
+    })
 
     expect(result.current.newCount).toBe(1)
     expect(result.current.displayedPRs).toEqual([existing])
@@ -105,12 +132,30 @@ describe('useFocusRefresh', () => {
       initialProps: { ...defaults, refetch, allPRs: [existing], prs: [existing], priorityPRs: [] },
     })
 
-    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
-    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing], prs: [existing], priorityPRs: [] })
-    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing, newPR], prs: [existing, newPR], priorityPRs: [] })
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'))
+    })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: true,
+      allPRs: [existing],
+      prs: [existing],
+      priorityPRs: [],
+    })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: false,
+      allPRs: [existing, newPR],
+      prs: [existing, newPR],
+      priorityPRs: [],
+    })
     expect(result.current.newCount).toBe(1)
 
-    act(() => { result.current.dismiss() })
+    act(() => {
+      result.current.dismiss()
+    })
 
     expect(result.current.newCount).toBe(0)
     expect(result.current.displayedPRs).toEqual([existing, newPR])
@@ -121,14 +166,36 @@ describe('useFocusRefresh', () => {
     const existing2 = makePR('existing2')
     const refetch = vi.fn()
     const { result, rerender } = renderHook((props: Props) => useHook(props), {
-      initialProps: { ...defaults, refetch, allPRs: [existing1, existing2], prs: [existing1, existing2], priorityPRs: [] },
+      initialProps: {
+        ...defaults,
+        refetch,
+        allPRs: [existing1, existing2],
+        prs: [existing1, existing2],
+        priorityPRs: [],
+      },
     })
 
-    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'))
+    })
 
-    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing1, existing2], prs: [existing1, existing2], priorityPRs: [] })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: true,
+      allPRs: [existing1, existing2],
+      prs: [existing1, existing2],
+      priorityPRs: [],
+    })
     // existing2 removed from review list
-    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing1], prs: [existing1], priorityPRs: [] })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: false,
+      allPRs: [existing1],
+      prs: [existing1],
+      priorityPRs: [],
+    })
 
     expect(result.current.newCount).toBe(0)
     expect(result.current.displayedPRs).toEqual([existing1])
@@ -140,14 +207,36 @@ describe('useFocusRefresh', () => {
     const newPR = makePR('new')
     const refetch = vi.fn()
     const { result, rerender } = renderHook((props: Props) => useHook(props), {
-      initialProps: { ...defaults, refetch, allPRs: [existing1, existing2], prs: [existing1, existing2], priorityPRs: [] },
+      initialProps: {
+        ...defaults,
+        refetch,
+        allPRs: [existing1, existing2],
+        prs: [existing1, existing2],
+        priorityPRs: [],
+      },
     })
 
-    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'))
+    })
 
-    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing1, existing2], prs: [existing1, existing2], priorityPRs: [] })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: true,
+      allPRs: [existing1, existing2],
+      prs: [existing1, existing2],
+      priorityPRs: [],
+    })
     // existing2 gone, new PR appeared
-    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing1, newPR], prs: [existing1, newPR], priorityPRs: [] })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: false,
+      allPRs: [existing1, newPR],
+      prs: [existing1, newPR],
+      priorityPRs: [],
+    })
 
     expect(result.current.newCount).toBe(1)
     expect(result.current.displayedPRs).toEqual([existing1])
@@ -162,15 +251,47 @@ describe('useFocusRefresh', () => {
     })
 
     // focus: snapshot taken of [existing], newPR appears
-    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
-    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing], prs: [existing], priorityPRs: [] })
-    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing, newPR], prs: [existing, newPR], priorityPRs: [] })
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'))
+    })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: true,
+      allPRs: [existing],
+      prs: [existing],
+      priorityPRs: [],
+    })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: false,
+      allPRs: [existing, newPR],
+      prs: [existing, newPR],
+      priorityPRs: [],
+    })
     expect(result.current.newCount).toBe(1)
 
     // second focus: newPR is gone before dismiss
-    await act(async () => { window.dispatchEvent(new FocusEvent('focus')) })
-    rerender({ ...defaults, refetch, isFetching: true, allPRs: [existing, newPR], prs: [existing, newPR], priorityPRs: [] })
-    rerender({ ...defaults, refetch, isFetching: false, allPRs: [existing], prs: [existing], priorityPRs: [] })
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'))
+    })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: true,
+      allPRs: [existing, newPR],
+      prs: [existing, newPR],
+      priorityPRs: [],
+    })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetching: false,
+      allPRs: [existing],
+      prs: [existing],
+      priorityPRs: [],
+    })
 
     expect(result.current.newCount).toBe(0)
     expect(result.current.displayedPRs).toEqual([existing])
@@ -185,8 +306,22 @@ describe('useFocusRefresh', () => {
     })
 
     // load-more without a prior focus
-    rerender({ ...defaults, refetch, isFetchingNextPage: true, allPRs: [existing], prs: [existing], priorityPRs: [] })
-    rerender({ ...defaults, refetch, isFetchingNextPage: false, allPRs: [existing, paginated], prs: [existing, paginated], priorityPRs: [] })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetchingNextPage: true,
+      allPRs: [existing],
+      prs: [existing],
+      priorityPRs: [],
+    })
+    rerender({
+      ...defaults,
+      refetch,
+      isFetchingNextPage: false,
+      allPRs: [existing, paginated],
+      prs: [existing, paginated],
+      priorityPRs: [],
+    })
 
     expect(result.current.newCount).toBe(0)
   })

--- a/src/features/pull-requests/hooks/useFocusRefresh.ts
+++ b/src/features/pull-requests/hooks/useFocusRefresh.ts
@@ -1,0 +1,131 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import type { PullRequest } from '@/types/github'
+import type { GlobalFilters, PRSection, ViewFilters } from '../stores/prStore'
+import { applyFilters } from '../lib/prFilters'
+
+type FocusRefreshArgs = {
+  allPRs: PullRequest[]
+  prs: PullRequest[]
+  priorityPRs: PullRequest[]
+  refetch: () => void
+  isFetching: boolean
+  isFetchingNextPage: boolean
+  globalFilters: GlobalFilters
+  view: ViewFilters
+  section: PRSection
+}
+
+export const useFocusRefresh = ({
+  allPRs,
+  prs,
+  priorityPRs,
+  refetch,
+  isFetching,
+  isFetchingNextPage,
+  globalFilters,
+  view,
+  section,
+}: FocusRefreshArgs): {
+  displayedPRs: PullRequest[]
+  displayedPriorityPRs: PullRequest[]
+  newCount: number
+  dismiss: () => void
+} => {
+  const [displayedPRs, setDisplayedPRs] = useState(prs)
+  const [displayedPriorityPRs, setDisplayedPriorityPRs] = useState(priorityPRs)
+  const [newCount, setNewCount] = useState(0)
+  const [detecting, setDetecting] = useState(false)
+  const snapshotIds = useRef<Set<string> | null>(null)
+  const allPRsRef = useRef(allPRs)
+  const sectionRef = useRef(section)
+  const globalFiltersRef = useRef(globalFilters)
+  const viewFiltersRef = useRef(view)
+  const isFetchingRef = useRef(isFetching)
+  const isFetchingNextPageRef = useRef(isFetchingNextPage)
+
+  // Sync volatile refs without triggering display-state effects
+  useEffect(() => {
+    allPRsRef.current = allPRs
+    globalFiltersRef.current = globalFilters
+    viewFiltersRef.current = view
+    isFetchingRef.current = isFetching
+    isFetchingNextPageRef.current = isFetchingNextPage
+  }, [allPRs, globalFilters, view, isFetching, isFetchingNextPage])
+
+  // Display sync: keeps displayedPRs in step with prs changes.
+  // While detecting, filters by snapshot so new-from-GitHub PRs stay hidden; local mutations (star/hide) pass through.
+  useEffect(() => {
+    if (detecting) {
+      if (sectionRef.current !== section) {
+        snapshotIds.current = null
+        setDetecting(false)
+        setNewCount(0)
+      } else {
+        setDisplayedPRs(prs.filter((pr) => snapshotIds.current!.has(pr.id)))
+        setDisplayedPriorityPRs(priorityPRs.filter((pr) => snapshotIds.current!.has(pr.id)))
+      }
+    } else {
+      setDisplayedPRs(prs)
+      setDisplayedPriorityPRs(priorityPRs)
+    }
+    sectionRef.current = section
+  }, [prs, priorityPRs, section, detecting])
+
+  // Recalculates newCount when filters change mid-detection so the badge stays accurate
+  useEffect(() => {
+    if (snapshotIds.current === null) return
+    const newPRs = allPRsRef.current.filter((pr) => !snapshotIds.current!.has(pr.id))
+    const count = applyFilters(newPRs, globalFilters, view, section).length
+    if (count > 0) setNewCount(count)
+    else {
+      snapshotIds.current = null
+      setDetecting(false)  // triggers display sync with current prs
+      setNewCount(0)
+    }
+    // ponytail: allPRsRef used intentionally — allPRs excluded from deps so this only fires on filter/section changes, not fetches
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [globalFilters, view, section])
+
+  // Post-fetch detection: fires when focus-triggered refetch + auto-pagination settle
+  useEffect(() => {
+    if (isFetching || isFetchingNextPage || snapshotIds.current === null) return
+    const newPRs = allPRsRef.current.filter((pr) => !snapshotIds.current!.has(pr.id))
+    const count = applyFilters(newPRs, globalFiltersRef.current, viewFiltersRef.current, sectionRef.current).length
+    if (count > 0) setNewCount(count)
+    else {
+      snapshotIds.current = null
+      setDetecting(false)  // triggers display sync with current prs
+      setNewCount(0)
+    }
+    // ponytail: refs used intentionally — prs/priorityPRs excluded; display sync fires via detecting state change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFetching, isFetchingNextPage])
+
+  // Focus handler: snapshots current PR ids before triggering a refetch
+  useEffect(() => {
+    const onFocus = () => {
+      // don't snapshot during an in-flight fetch; stale/empty allPRs would produce a wrong baseline
+      if (isFetchingRef.current || isFetchingNextPageRef.current || sectionRef.current === 'authored') {
+        refetch()
+        return
+      }
+      if (snapshotIds.current === null) {
+        snapshotIds.current = new Set(allPRsRef.current.map((pr) => pr.id))
+        setDetecting(true)
+      }
+      refetch()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+    // ponytail: refetch excluded (stable TanStack ref); all mutable values read via refs to avoid stale closure
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const dismiss = useCallback(() => {
+    snapshotIds.current = null
+    setDetecting(false)
+    setNewCount(0)
+  }, [])
+
+  return { displayedPRs, displayedPriorityPRs, newCount, dismiss }
+}

--- a/src/features/pull-requests/hooks/useFocusRefresh.ts
+++ b/src/features/pull-requests/hooks/useFocusRefresh.ts
@@ -79,7 +79,7 @@ export const useFocusRefresh = ({
     if (count > 0) setNewCount(count)
     else {
       snapshotIds.current = null
-      setDetecting(false)  // triggers display sync with current prs
+      setDetecting(false) // triggers display sync with current prs
       setNewCount(0)
     }
     // ponytail: allPRsRef used intentionally — allPRs excluded from deps so this only fires on filter/section changes, not fetches
@@ -90,11 +90,16 @@ export const useFocusRefresh = ({
   useEffect(() => {
     if (isFetching || isFetchingNextPage || snapshotIds.current === null) return
     const newPRs = allPRsRef.current.filter((pr) => !snapshotIds.current!.has(pr.id))
-    const count = applyFilters(newPRs, globalFiltersRef.current, viewFiltersRef.current, sectionRef.current).length
+    const count = applyFilters(
+      newPRs,
+      globalFiltersRef.current,
+      viewFiltersRef.current,
+      sectionRef.current
+    ).length
     if (count > 0) setNewCount(count)
     else {
       snapshotIds.current = null
-      setDetecting(false)  // triggers display sync with current prs
+      setDetecting(false) // triggers display sync with current prs
       setNewCount(0)
     }
     // ponytail: refs used intentionally — prs/priorityPRs excluded; display sync fires via detecting state change
@@ -105,7 +110,11 @@ export const useFocusRefresh = ({
   useEffect(() => {
     const onFocus = () => {
       // don't snapshot during an in-flight fetch; stale/empty allPRs would produce a wrong baseline
-      if (isFetchingRef.current || isFetchingNextPageRef.current || sectionRef.current === 'authored') {
+      if (
+        isFetchingRef.current ||
+        isFetchingNextPageRef.current ||
+        sectionRef.current === 'authored'
+      ) {
         refetch()
         return
       }

--- a/src/features/pull-requests/lib/prUtils.ts
+++ b/src/features/pull-requests/lib/prUtils.ts
@@ -13,7 +13,7 @@ export type ReviewerSummary = {
 }
 
 export const buildSearchQuery = (section: string, login: string): string => {
-  const base = 'is:open is:pr archived:false'
+  const base = 'is:open is:pr archived:false sort:updated-desc'
   switch (section) {
     case 'review-requested':
       return `${base} review-requested:${login}`

--- a/src/features/pull-requests/queries/useGitHubPRs.test.ts
+++ b/src/features/pull-requests/queries/useGitHubPRs.test.ts
@@ -77,6 +77,7 @@ describe('deriveMyReviewState', () => {
   })
 })
 
+
 describe('sortAndPartition', () => {
   describe('sort order', () => {
     it('GIVEN mixed dates THEN descending order (newest first)', () => {

--- a/src/features/pull-requests/queries/useGitHubPRs.test.ts
+++ b/src/features/pull-requests/queries/useGitHubPRs.test.ts
@@ -77,7 +77,6 @@ describe('deriveMyReviewState', () => {
   })
 })
 
-
 describe('sortAndPartition', () => {
   describe('sort order', () => {
     it('GIVEN mixed dates THEN descending order (newest first)', () => {


### PR DESCRIPTION
## What

Indicates to the user that new PRs are available. Under the hood, we're doing a refetch at window focus and we compare ids to determine if it's a new PR or not.

## Why

It allows to have a fixed list, and only update it when needed. Also, it eliminates the need of a manual refresh.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes
