### PR TITLE
fix: refresh CI checks on focus and add manual reload in checks modal

### DIFF
--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -5,12 +5,14 @@ import { PRCard } from './PRCard'
 import { usePRStore } from '../../stores/prStore'
 import { useAuthStore } from '@/features/auth/stores/authStore'
 import { usePRDetails } from '../../queries/usePRDetails'
+import { useCheckContexts } from '../../queries/useCheckContexts'
 import type { PullRequest, ReviewState } from '@/types/github'
 
 const mockUsePRDetails = vi.mocked(usePRDetails)
+const mockUseCheckContexts = vi.mocked(useCheckContexts)
 
 vi.mock('../../queries/useCheckContexts', () => ({
-  useCheckContexts: vi.fn(() => ({ checks: [], isLoading: false })),
+  useCheckContexts: vi.fn(() => ({ checks: [], isLoading: false, refetch: vi.fn() })),
 }))
 vi.mock('../../queries/usePRDetails', () => ({
   usePRDetails: vi.fn(() => ({ data: undefined })),
@@ -40,6 +42,7 @@ beforeEach(() => {
   usePRStore.setState({ priorityIds: [], hiddenIds: [] })
   useAuthStore.setState({ user: { login: 'viewer', avatarUrl: '', name: 'Viewer' }, token: 'test' })
   mockUsePRDetails.mockReturnValue({ data: undefined } as never)
+  mockUseCheckContexts.mockReturnValue({ checks: [], isLoading: false, refetch: vi.fn() } as never)
 })
 
 describe('PRCard', () => {
@@ -138,6 +141,16 @@ describe('PRCard', () => {
       expect(
         screen.queryByText('Some checks may still be pending or not yet shown')
       ).not.toBeInTheDocument()
+    })
+
+    it('GIVEN checks modal open WHEN reload button clicked THEN refetch is called', async () => {
+      const refetch = vi.fn()
+      mockUseCheckContexts.mockReturnValue({ checks: [], isLoading: false, refetch } as never)
+      const user = userEvent.setup()
+      render(<PRCard pr={makePrWithRollup('SUCCESS')} />)
+      await user.click(screen.getByText('Checks pass'))
+      await user.click(screen.getByTitle('Reload checks'))
+      expect(refetch).toHaveBeenCalled()
     })
   })
 

--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -112,7 +112,12 @@ export const PRCard = ({ pr, isAuthored = false }: Props) => {
   const checkState = deriveCheckState(merged)
   const ciBadge = checkState ? ciStateBadge[checkState] : null
   const showConflict = merged.mergeable === 'CONFLICTING'
-  const { checks, isLoading: checksLoading } = useCheckContexts(pr.id, checksOpen)
+  const {
+    checks,
+    isLoading: checksLoading,
+    isRefetching: checksRefetching,
+    refetch: refetchChecks,
+  } = useCheckContexts(pr.id, checksOpen)
 
   const handleHide = () => {
     toggleHide(pr.id)
@@ -232,8 +237,10 @@ export const PRCard = ({ pr, isAuthored = false }: Props) => {
                     prTitle={pr.title}
                     checks={checks}
                     isLoading={checksLoading}
+                    isRefreshing={checksRefetching}
                     rollupState={checkState}
                     onClose={() => setChecksOpen(false)}
+                    onRefresh={refetchChecks}
                   />
                 </div>
               )}

--- a/src/features/pull-requests/components/PRChecksModal/PRChecksModal.tsx
+++ b/src/features/pull-requests/components/PRChecksModal/PRChecksModal.tsx
@@ -1,4 +1,4 @@
-import { Clock } from 'lucide-react'
+import { Clock, RefreshCw } from 'lucide-react'
 import type { CheckRunContext, StatusContextItem, CheckRollupState } from '@/types/github.ts'
 import { Modal } from '@/shared/components/ui/Modal.tsx'
 import { PRCheckRow } from '@/features/pull-requests/components/PRCheckRow/PRCheckRow.tsx'
@@ -9,7 +9,9 @@ type Props = {
   checks: (CheckRunContext | StatusContextItem)[]
   rollupState?: CheckRollupState | null
   onClose: () => void
+  onRefresh: () => void
   isLoading?: boolean
+  isRefreshing?: boolean
 }
 
 export const PRChecksModal = ({
@@ -18,10 +20,22 @@ export const PRChecksModal = ({
   checks,
   rollupState,
   onClose,
+  onRefresh,
   isLoading,
+  isRefreshing,
 }: Props) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={`${prTitle}'s checks`}>
+      <div className="flex justify-end">
+        <button
+          onClick={onRefresh}
+          disabled={isLoading || isRefreshing}
+          title="Reload checks"
+          className="p-1 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+        >
+          <RefreshCw size={13} className={isRefreshing ? 'animate-spin' : ''} />
+        </button>
+      </div>
       {isLoading ? (
         [0, 1, 2].map((i) => (
           <div key={i} className="flex items-center gap-2 px-3 py-1.5">

--- a/src/features/pull-requests/components/PRChecksModal/PRChecksModal.tsx
+++ b/src/features/pull-requests/components/PRChecksModal/PRChecksModal.tsx
@@ -25,8 +25,11 @@ export const PRChecksModal = ({
   isRefreshing,
 }: Props) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title={`${prTitle}'s checks`}>
-      <div className="flex justify-end">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`${prTitle}'s checks`}
+      actions={
         <button
           onClick={onRefresh}
           disabled={isLoading || isRefreshing}
@@ -35,7 +38,8 @@ export const PRChecksModal = ({
         >
           <RefreshCw size={13} className={isRefreshing ? 'animate-spin' : ''} />
         </button>
-      </div>
+      }
+    >
       {isLoading ? (
         [0, 1, 2].map((i) => (
           <div key={i} className="flex items-center gap-2 px-3 py-1.5">

--- a/src/features/pull-requests/components/PRList/PRList.test.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.test.tsx
@@ -1,12 +1,14 @@
+import type { ReactElement } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { PRList } from './PRList'
 import type { PullRequest } from '@/types/github'
 
 vi.mock('@/features/pull-requests/queries/useGitHubPRs', () => ({ usePullRequests: vi.fn() }))
 vi.mock('@/features/pull-requests/stores/prStore', () => ({ usePRStore: vi.fn() }))
 vi.mock('@/features/pull-requests/queries/useCheckContexts', () => ({
-  useCheckContexts: vi.fn(() => ({ checks: [], isLoading: false })),
+  useCheckContexts: vi.fn(() => ({ checks: [], isLoading: false, refetch: vi.fn() })),
 }))
 vi.mock('@/features/pull-requests/queries/usePRDetails', () => ({
   usePRDetails: vi.fn(() => ({ data: undefined })),
@@ -73,15 +75,21 @@ const defaultQuery = {
   repos: [],
 }
 
+let queryClient: QueryClient
+
+const renderWithClient = (ui: ReactElement) =>
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockStoreFilters()
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 })
 
 describe('PRList', () => {
   it('GIVEN no PRs THEN shows empty state', () => {
     mockUsePullRequests.mockReturnValue({ ...defaultQuery, data: [], priorityPRs: [] } as never)
-    render(<PRList />)
+    renderWithClient(<PRList />)
     expect(screen.getByText('No pull requests found.')).toBeInTheDocument()
   })
 
@@ -94,7 +102,7 @@ describe('PRList', () => {
       totalCount: 1,
       loadedCount: 1,
     } as never)
-    render(<PRList />)
+    renderWithClient(<PRList />)
     expect(screen.getByText('Top priority')).toBeInTheDocument()
   })
 
@@ -107,7 +115,7 @@ describe('PRList', () => {
       totalCount: 1,
       loadedCount: 1,
     } as never)
-    render(<PRList />)
+    renderWithClient(<PRList />)
     expect(screen.queryByText('Top priority')).not.toBeInTheDocument()
   })
 
@@ -121,7 +129,7 @@ describe('PRList', () => {
       totalCount: 2,
       loadedCount: 2,
     } as never)
-    render(<PRList />)
+    renderWithClient(<PRList />)
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
@@ -134,7 +142,25 @@ describe('PRList', () => {
       totalCount: 500,
       loadedCount: 1,
     } as never)
-    render(<PRList />)
+    renderWithClient(<PRList />)
     expect(screen.getByText(/of 500/)).toBeInTheDocument()
+  })
+
+  it('GIVEN refresh button clicked THEN pr-details and pr-checks queries are invalidated', () => {
+    const p = makePR('1', 'PR')
+    mockUsePullRequests.mockReturnValue({
+      ...defaultQuery,
+      data: [p],
+      priorityPRs: [],
+      totalCount: 1,
+      loadedCount: 1,
+    } as never)
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    renderWithClient(<PRList />)
+
+    fireEvent.click(screen.getByTitle('Refresh'))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['pr-details'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['pr-checks'] })
   })
 })

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { usePullRequests } from '../../queries/useGitHubPRs'
 import { usePRStore } from '../../stores/prStore'
 import { PRCard } from '../PRCard/PRCard'
@@ -26,12 +27,22 @@ export const PRList = () => {
   const section = usePRStore((s) => s.section)
   const globalFilters = usePRStore((s) => s.globalFilters)
   const viewFilters = usePRStore((s) => s.viewFilters)
+  const queryClient = useQueryClient()
+
+  // Checks/details are fetched per-PR (usePRDetails/useCheckContexts) and won't
+  // pick up window-focus refreshes on their own since refetchOnWindowFocus is
+  // disabled globally — invalidate them alongside the PR list refetch.
+  const refetchAll = () => {
+    void queryClient.invalidateQueries({ queryKey: ['pr-details'] })
+    void queryClient.invalidateQueries({ queryKey: ['pr-checks'] })
+    void refetch()
+  }
 
   const { displayedPRs, displayedPriorityPRs, newCount, dismiss } = useFocusRefresh({
     allPRs,
     prs,
     priorityPRs,
-    refetch: () => void refetch(),
+    refetch: refetchAll,
     isFetching,
     isFetchingNextPage,
     globalFilters,
@@ -41,7 +52,7 @@ export const PRList = () => {
 
   const handleRefetch = () => {
     dismiss()
-    void refetch()
+    refetchAll()
   }
 
   return (

--- a/src/features/pull-requests/lib/prUtils.test.ts
+++ b/src/features/pull-requests/lib/prUtils.test.ts
@@ -113,9 +113,18 @@ describe('dedupeChecks', () => {
   const checkRun = (
     name: string,
     conclusion: CheckRunContext['conclusion'] = 'SUCCESS'
-  ): CheckRunContext => ({ __typename: 'CheckRun', name, status: 'COMPLETED', conclusion, detailsUrl: null })
+  ): CheckRunContext => ({
+    __typename: 'CheckRun',
+    name,
+    status: 'COMPLETED',
+    conclusion,
+    detailsUrl: null,
+  })
 
-  const statusContext = (context: string, state: StatusContextItem['state']): StatusContextItem => ({
+  const statusContext = (
+    context: string,
+    state: StatusContextItem['state']
+  ): StatusContextItem => ({
     __typename: 'StatusContext',
     context,
     state,

--- a/src/features/pull-requests/lib/prUtils.test.ts
+++ b/src/features/pull-requests/lib/prUtils.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import type { PullRequest } from '@/types/github'
+import type { CheckRunContext, PullRequest, StatusContextItem } from '@/types/github'
 import {
   deriveReviewerSummary,
   buildSearchQuery,
   deriveCheckState,
   deriveMyReviewState,
+  dedupeChecks,
 } from './prUtils'
 
 const makePR = (overrides: Partial<PullRequest> = {}): PullRequest => {
@@ -105,6 +106,43 @@ describe('deriveCheckState', () => {
       },
     })
     expect(deriveCheckState(pr)).toBe('FAILURE')
+  })
+})
+
+describe('dedupeChecks', () => {
+  const checkRun = (
+    name: string,
+    conclusion: CheckRunContext['conclusion'] = 'SUCCESS'
+  ): CheckRunContext => ({ __typename: 'CheckRun', name, status: 'COMPLETED', conclusion, detailsUrl: null })
+
+  const statusContext = (context: string, state: StatusContextItem['state']): StatusContextItem => ({
+    __typename: 'StatusContext',
+    context,
+    state,
+    targetUrl: null,
+  })
+
+  it('GIVEN no duplicate names WHEN called THEN returns all checks unchanged', () => {
+    const checks = [checkRun('build'), checkRun('lint')]
+    expect(dedupeChecks(checks)).toEqual(checks)
+  })
+
+  it('GIVEN a CheckRun name repeated (rerun) WHEN called THEN keeps only the last occurrence', () => {
+    const stale = checkRun('build', 'FAILURE')
+    const rerun = checkRun('build', 'SUCCESS')
+    expect(dedupeChecks([stale, rerun])).toEqual([rerun])
+  })
+
+  it('GIVEN a StatusContext context repeated WHEN called THEN keeps only the last occurrence', () => {
+    const stale = statusContext('ci/build', 'PENDING')
+    const latest = statusContext('ci/build', 'SUCCESS')
+    expect(dedupeChecks([stale, latest])).toEqual([latest])
+  })
+
+  it('GIVEN a CheckRun and a StatusContext with the same name WHEN called THEN both are kept', () => {
+    const run = checkRun('build')
+    const status = statusContext('build', 'SUCCESS')
+    expect(dedupeChecks([run, status])).toEqual([run, status])
   })
 })
 

--- a/src/features/pull-requests/lib/prUtils.ts
+++ b/src/features/pull-requests/lib/prUtils.ts
@@ -1,4 +1,10 @@
-import type { PullRequest, ReviewState, CheckRollupState } from '@/types/github'
+import type {
+  PullRequest,
+  ReviewState,
+  CheckRollupState,
+  CheckRunContext,
+  StatusContextItem,
+} from '@/types/github'
 
 export type Reviewer = {
   login: string
@@ -71,6 +77,19 @@ export const deriveReviewerSummary = (pr: PullRequest, authorLogin: string): Rev
 
 export const deriveCheckState = (pr: PullRequest): CheckRollupState | null => {
   return pr.commits?.nodes[0]?.commit?.statusCheckRollup?.state ?? null
+}
+
+// GitHub's rollup can list the same check name multiple times (reruns, multiple
+// check suites) — keep only the most recent entry per name.
+export const dedupeChecks = (
+  checks: (CheckRunContext | StatusContextItem)[]
+): (CheckRunContext | StatusContextItem)[] => {
+  const byKey = new Map<string, CheckRunContext | StatusContextItem>()
+  for (const check of checks) {
+    const name = check.__typename === 'CheckRun' ? check.name : check.context
+    byKey.set(`${check.__typename}:${name}`, check)
+  }
+  return [...byKey.values()]
 }
 
 export const sortAndPartition = (

--- a/src/features/pull-requests/queries/useCheckContexts.ts
+++ b/src/features/pull-requests/queries/useCheckContexts.ts
@@ -34,5 +34,10 @@ export const useCheckContexts = (prId: string, enabled: boolean) => {
   const checks: (CheckRunContext | StatusContextItem)[] =
     query.data?.node?.commits.nodes[0]?.commit?.statusCheckRollup?.contexts.nodes ?? []
 
-  return { checks, isLoading: query.isFetching }
+  return {
+    checks,
+    isLoading: query.isFetching && !query.isRefetching,
+    isRefetching: query.isRefetching,
+    refetch: () => void query.refetch(),
+  }
 }

--- a/src/features/pull-requests/queries/useCheckContexts.ts
+++ b/src/features/pull-requests/queries/useCheckContexts.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { createClient, PR_CHECK_CONTEXTS_QUERY } from '@/providers/github'
 import { useAuthStore } from '@/features/auth/stores/authStore'
+import { dedupeChecks } from '../lib/prUtils'
 import type { CheckRunContext, StatusContextItem } from '@/types/github'
 
 type CheckContextsResult = {
@@ -31,8 +32,9 @@ export const useCheckContexts = (prId: string, enabled: boolean) => {
     },
   })
 
-  const checks: (CheckRunContext | StatusContextItem)[] =
+  const checks: (CheckRunContext | StatusContextItem)[] = dedupeChecks(
     query.data?.node?.commits.nodes[0]?.commit?.statusCheckRollup?.contexts.nodes ?? []
+  )
 
   return {
     checks,

--- a/src/shared/components/ui/Modal.tsx
+++ b/src/shared/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react'
-import { type PropsWithChildren, useEffect } from 'react'
+import { type PropsWithChildren, type ReactNode, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 
 type Props = PropsWithChildren & {
@@ -7,9 +7,10 @@ type Props = PropsWithChildren & {
   title: string
   onClose: () => void
   className?: string
+  actions?: ReactNode
 }
 
-export const Modal = ({ children, isOpen, title, onClose, className }: Props) => {
+export const Modal = ({ children, isOpen, title, onClose, className, actions }: Props) => {
   useEffect(() => {
     if (!isOpen) return
     document.body.style.overflow = 'hidden'
@@ -29,14 +30,19 @@ export const Modal = ({ children, isOpen, title, onClose, className }: Props) =>
           className={`pointer-events-auto max-w-xl max-h-[80vh] overflow-y-auto rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-surface)] shadow-lg p-4 space-y-4 ${className ?? ''}`}
         >
           <div className="flex items-center justify-between gap-4">
-            <p className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</p>
-            <button
-              onClick={onClose}
-              className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none rounded"
-              aria-label={`Close ${title}`}
-            >
-              <X size={16} />
-            </button>
+            <p className="text-sm font-semibold text-[var(--color-text-primary)] truncate">
+              {title}
+            </p>
+            <div className="flex items-center gap-3 shrink-0">
+              {actions}
+              <button
+                onClick={onClose}
+                className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none rounded"
+                aria-label={`Close ${title}`}
+              >
+                <X size={16} />
+              </button>
+            </div>
           </div>
           {children}
         </div>


### PR DESCRIPTION
## Summary
- Check contexts and per-PR details were only fetched once per mount — `refetchOnWindowFocus` is disabled globally, and `useFocusRefresh` only refetched the PR list query, not the per-PR `pr-details`/`pr-checks` queries the CI badge and modal derive from.
- `PRList` now invalidates `pr-details`/`pr-checks` alongside the list refetch, on both window focus and the manual refresh button.
- Added a manual reload button in `PRChecksModal` to refresh a single PR's checks on demand (spins while refetching, distinct from the initial-load skeleton).

Fixes #113

## Test plan
- [x] `npm run test:run` — 161 passed
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)