### PR TITLE
fix: remove stale SSO token hint from empty PR list state

### DIFF
--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -91,17 +91,6 @@ export const PRList = () => {
         <div className="text-center py-16 text-[var(--color-text-muted)]">
           <p className="text-sm">No pull requests found.</p>
           <p className="text-xs mt-1">Try adjusting your filters.</p>
-          <p className="text-xs mt-3 text-[var(--color-text-muted)]">
-            Missing PRs from an organization?{' '}
-            <a
-              href="https://github.com/settings/tokens"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--color-accent)] hover:underline"
-            >
-              Authorize your token for SSO →
-            </a>
-          </p>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- The empty PR list state suggested "Authorize your token for SSO" and linked to `github.com/settings/tokens` — a leftover from PAT-based web auth.
- This doesn't apply to the Electron app (the primary target), which authenticates via the local `gh` CLI and never manages a token.
- Removed the hint entirely rather than replacing it with Electron-specific guidance, since the empty state already tells users to check their filters.

Fixes #117

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run -- src/features/pull-requests/components/PRList`