### PR TITLE
fix: hide settings button when the modal has no content

### DIFF
--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.test.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SettingsModal } from './SettingsModal'
+import { usePRStore } from '../../stores/prStore'
+import { usePullRequests } from '../../queries/useGitHubPRs'
+
+vi.mock('../../queries/useGitHubPRs', () => ({
+  usePullRequests: vi.fn(),
+}))
+
+const mockUsePullRequests = vi.mocked(usePullRequests)
+
+describe('SettingsModal', () => {
+  it('GIVEN authored section with a single repo WHEN rendered THEN renders nothing', () => {
+    usePRStore.setState({ section: 'authored' })
+    mockUsePullRequests.mockReturnValue({ repos: ['org/repo'] } as never)
+
+    const { container } = render(<SettingsModal />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('GIVEN authored section with multiple repos WHEN rendered THEN shows the settings button', () => {
+    usePRStore.setState({ section: 'authored' })
+    mockUsePullRequests.mockReturnValue({ repos: ['org/repo', 'org/other'] } as never)
+
+    render(<SettingsModal />)
+
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('GIVEN review-requested section with a single repo WHEN rendered THEN still shows the settings button', () => {
+    usePRStore.setState({ section: 'review-requested' })
+    mockUsePullRequests.mockReturnValue({ repos: ['org/repo'] } as never)
+
+    render(<SettingsModal />)
+
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+})

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -22,6 +22,7 @@ export const SettingsModal = () => {
   const { repos = [] } = usePullRequests()
 
   const currentView = viewFilters[section]
+  const hasContent = repos.length > 1 || section !== 'authored'
 
   const activeCount =
     currentView.repos.length +
@@ -58,6 +59,8 @@ export const SettingsModal = () => {
         setViewFilters(section, { repos: remaining })
     }
   }
+
+  if (!hasContent) return null
 
   return (
     <>


### PR DESCRIPTION
## What

Hides the PR-list settings button when the modal it opens would have nothing to show.

## Why

On the "My PRs" section with a single repo, neither the repo filter (only rendered for >1 repo) nor the muted-authors/hidden-repos controls (hidden for the `authored` section) render — leaving an empty modal behind an always-visible settings button. The button now returns `null` in that specific empty case.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes

---
_This pull request was created with AI assistance._