### PR TITLE
fix: clarify hide/star as Donna-only, scope to Review requested

### DIFF
--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -75,7 +75,7 @@ describe('PRCard', () => {
   it('star button click toggles priority in store', async () => {
     const user = userEvent.setup()
     render(<PRCard pr={pr} />)
-    const starBtn = screen.getByTitle('Mark as top priority')
+    const starBtn = screen.getByRole('button', { name: 'Mark as top priority' })
     await user.click(starBtn)
     expect(usePRStore.getState().priorityIds).toContain('pr-42')
   })
@@ -84,9 +84,15 @@ describe('PRCard', () => {
     const user = userEvent.setup()
     usePRStore.setState({ priorityIds: ['pr-42'] })
     render(<PRCard pr={pr} />)
-    const starBtn = screen.getByTitle('Remove priority')
+    const starBtn = screen.getByRole('button', { name: 'Remove priority' })
     await user.click(starBtn)
     expect(usePRStore.getState().priorityIds).not.toContain('pr-42')
+  })
+
+  it('GIVEN showHideAndStar=false WHEN rendered THEN hide and star buttons are not shown', () => {
+    render(<PRCard pr={pr} showHideAndStar={false} />)
+    expect(screen.queryByRole('button', { name: 'Hide PR (Donna only)' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Mark as top priority' })).not.toBeInTheDocument()
   })
 
   describe('PRChecksModal rollup state footer', () => {

--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -23,6 +23,7 @@ import { PRCardActions } from '@/features/pull-requests/components/PRCardActions
 type Props = {
   pr: PullRequest
   isAuthored?: boolean
+  showHideAndStar?: boolean
 }
 
 const ciStateBadge: Record<
@@ -97,7 +98,7 @@ const reviewBadge: Record<
   },
 }
 
-export const PRCard = ({ pr, isAuthored = false }: Props) => {
+export const PRCard = ({ pr, isAuthored = false, showHideAndStar = true }: Props) => {
   const [checksOpen, setChecksOpen] = useState(false)
   const togglePriority = usePRStore((s) => s.togglePriority)
   const toggleHide = usePRStore((s) => s.toggleHide)
@@ -270,6 +271,7 @@ export const PRCard = ({ pr, isAuthored = false }: Props) => {
           togglePriority={handleTogglePriority}
           isPriority={isPriority}
           prUrl={pr.url}
+          showHideAndStar={showHideAndStar}
         />
       </div>
     </div>

--- a/src/features/pull-requests/components/PRCardActions/PRCardAction.tsx
+++ b/src/features/pull-requests/components/PRCardActions/PRCardAction.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react'
 import { twMerge } from 'tailwind-merge'
+import { ButtonWithTooltip } from '@/shared/components/ui/ButtonWithTooltip'
 
 type Props = PropsWithChildren & {
   onClick: () => void
@@ -17,8 +18,8 @@ export const PRCardAction = ({ children, title, className, onClick }: Props) => 
   )
 
   return (
-    <button onClick={onClick} title={title} className={computedClassName}>
+    <ButtonWithTooltip onClick={onClick} label={title} buttonClassName={computedClassName}>
       {children}
-    </button>
+    </ButtonWithTooltip>
   )
 }

--- a/src/features/pull-requests/components/PRCardActions/PRCardActions.tsx
+++ b/src/features/pull-requests/components/PRCardActions/PRCardActions.tsx
@@ -11,6 +11,7 @@ type Props = {
   togglePriority: () => void
   isPriority: boolean
   prUrl: string
+  showHideAndStar: boolean
 }
 
 export const PRCardActions = ({
@@ -19,31 +20,36 @@ export const PRCardActions = ({
   prUrl,
   toggleHide,
   togglePriority,
+  showHideAndStar,
 }: Props) => {
   return (
     <div className="flex items-center gap-1 shrink-0 flex-col lg:flex-row">
-      <PRCardAction
-        onClick={toggleHide}
-        title={isHidden ? 'Unhide PR' : 'Hide PR'}
-        className={
-          isHidden
-            ? 'text-[var(--color-warning)]'
-            : 'text-[var(--color-text-muted)] hover:text-[var(--color-warning)]'
-        }
-      >
-        {isHidden ? <Eye size={14} /> : <EyeOff size={14} />}
-      </PRCardAction>
-      <PRCardAction
-        onClick={togglePriority}
-        title={isPriority ? 'Remove priority' : 'Mark as top priority'}
-        className={
-          isPriority
-            ? 'text-[var(--color-priority)]'
-            : 'text-[var(--color-text-muted)] hover:text-[var(--color-priority)]'
-        }
-      >
-        <Star size={14} fill={isPriority ? 'currentColor' : 'none'} />
-      </PRCardAction>
+      {showHideAndStar && (
+        <>
+          <PRCardAction
+            onClick={toggleHide}
+            title={isHidden ? 'Unhide PR (Donna only)' : 'Hide PR (Donna only)'}
+            className={
+              isHidden
+                ? 'text-[var(--color-warning)]'
+                : 'text-[var(--color-text-muted)] hover:text-[var(--color-warning)]'
+            }
+          >
+            {isHidden ? <Eye size={14} /> : <EyeOff size={14} />}
+          </PRCardAction>
+          <PRCardAction
+            onClick={togglePriority}
+            title={isPriority ? 'Remove priority' : 'Mark as top priority'}
+            className={
+              isPriority
+                ? 'text-[var(--color-priority)]'
+                : 'text-[var(--color-text-muted)] hover:text-[var(--color-priority)]'
+            }
+          >
+            <Star size={14} fill={isPriority ? 'currentColor' : 'none'} />
+          </PRCardAction>
+        </>
+      )}
       <CopyWithFeedback
         text={prUrl}
         label="Copy PR link"

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -101,7 +101,12 @@ export const PRList = () => {
           </p>
           <div className="space-y-2">
             {displayedPriorityPRs.map((pr) => (
-              <PRCard key={pr.id} pr={pr} isAuthored={section === 'authored'} />
+              <PRCard
+                key={pr.id}
+                pr={pr}
+                isAuthored={section === 'authored'}
+                showHideAndStar={section === 'review-requested'}
+              />
             ))}
           </div>
         </div>
@@ -110,7 +115,12 @@ export const PRList = () => {
       {!isLoading && !error && displayedPRs.length > 0 && (
         <div className="space-y-2">
           {displayedPRs.map((pr) => (
-            <PRCard key={pr.id} pr={pr} isAuthored={section === 'authored'} />
+            <PRCard
+              key={pr.id}
+              pr={pr}
+              isAuthored={section === 'authored'}
+              showHideAndStar={section === 'review-requested'}
+            />
           ))}
         </div>
       )}

--- a/src/shared/components/ui/ButtonWithTooltip.tsx
+++ b/src/shared/components/ui/ButtonWithTooltip.tsx
@@ -18,6 +18,7 @@ export const ButtonWithTooltip = ({
     <div className="relative group/tooltip">
       <button
         onClick={onClick}
+        aria-label={label}
         className={
           buttonClassName ??
           'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer'


### PR DESCRIPTION
## Summary
- Fixes #109: hide/star tooltips now read "Hide PR (Donna only)" / "Unhide PR (Donna only)" so it's explicit these actions never touch GitHub.
- Switched `PRCardAction` to reuse the existing `ButtonWithTooltip` component (already used by Copy/Settings) instead of the native `title` attribute — the native tooltip has a hover delay and was easy to miss, this one is instant and consistent with the rest of the app.
- Hide/star only make sense while triaging incoming review requests, so they're now only shown on the "Review requested" section (hidden on Authored/Mentioned).

## Test plan
- [x] `npm run test:run` (169 passed, added a regression test for `showHideAndStar=false`)
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)