### PR TITLE
feat: explain search-based PR tracking vs GitHub notifications in-app

### DIFF
--- a/src/features/pull-requests/components/NotificationHint/NotificationHint.test.tsx
+++ b/src/features/pull-requests/components/NotificationHint/NotificationHint.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { NotificationHint } from './NotificationHint'
+
+describe('NotificationHint', () => {
+  it('calls onDismiss when the dismiss button is clicked', async () => {
+    const dismiss = vi.fn()
+    render(<NotificationHint onDismiss={dismiss} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(dismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/pull-requests/components/NotificationHint/NotificationHint.tsx
+++ b/src/features/pull-requests/components/NotificationHint/NotificationHint.tsx
@@ -6,8 +6,8 @@ export const NotificationHint = ({ onDismiss }: Props) => (
   <div className="mb-3 flex items-start gap-2 px-3 py-2 rounded-lg bg-[var(--color-surface-raised)] border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)]">
     <p className="flex-1">
       Donna lists open PRs matching a GitHub search, not your notification inbox — marking a
-      notification as done on GitHub won't remove it here. Use the <strong>hide</strong> action on
-      a PR card instead — it's stored locally in Donna and has no effect on GitHub.
+      notification as done on GitHub won't remove it here. Use the <strong>hide</strong> action on a
+      PR card instead — it's stored locally in Donna and has no effect on GitHub.
     </p>
     <button
       onClick={onDismiss}

--- a/src/features/pull-requests/components/NotificationHint/NotificationHint.tsx
+++ b/src/features/pull-requests/components/NotificationHint/NotificationHint.tsx
@@ -1,0 +1,20 @@
+import { X } from 'lucide-react'
+
+type Props = { onDismiss: () => void }
+
+export const NotificationHint = ({ onDismiss }: Props) => (
+  <div className="mb-3 flex items-start gap-2 px-3 py-2 rounded-lg bg-[var(--color-surface-raised)] border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)]">
+    <p className="flex-1">
+      Donna lists open PRs matching a GitHub search, not your notification inbox — marking a
+      notification as done on GitHub won't remove it here. Use the <strong>hide</strong> action on
+      a PR card instead — it's stored locally in Donna and has no effect on GitHub.
+    </p>
+    <button
+      onClick={onDismiss}
+      aria-label="Dismiss"
+      className="shrink-0 cursor-pointer text-[var(--color-text-secondary)] hover:text-[var(--color-text)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none rounded"
+    >
+      <X size={14} />
+    </button>
+  </div>
+)

--- a/src/features/pull-requests/components/PRList/PRList.test.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.test.tsx
@@ -49,6 +49,8 @@ const mockStoreFilters = () => {
       },
       priorityIds: [],
       hiddenIds: [],
+      notificationHintDismissed: true,
+      dismissNotificationHint: vi.fn(),
       setSection: vi.fn(),
       setGlobalFilters: vi.fn(),
       setViewFilters: vi.fn(),

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -5,6 +5,7 @@ import { PRCard } from '../PRCard/PRCard'
 import { PRListHeader } from '@/features/pull-requests/components/PRListHeader/PRListHeader.tsx'
 import { useFocusRefresh } from '../../hooks/useFocusRefresh'
 import { NewPRsBadge } from '../NewPRsBadge/NewPRsBadge'
+import { NotificationHint } from '../NotificationHint/NotificationHint'
 
 const sectionLabels: Record<string, string> = {
   'review-requested': 'Review requested',
@@ -27,6 +28,8 @@ export const PRList = () => {
   const section = usePRStore((s) => s.section)
   const globalFilters = usePRStore((s) => s.globalFilters)
   const viewFilters = usePRStore((s) => s.viewFilters)
+  const notificationHintDismissed = usePRStore((s) => s.notificationHintDismissed)
+  const dismissNotificationHint = usePRStore((s) => s.dismissNotificationHint)
   const queryClient = useQueryClient()
 
   // Checks/details are fetched per-PR (usePRDetails/useCheckContexts) and won't
@@ -69,6 +72,8 @@ export const PRList = () => {
       />
 
       {newCount > 0 && <NewPRsBadge count={newCount} onDismiss={dismiss} />}
+
+      {!notificationHintDismissed && <NotificationHint onDismiss={dismissNotificationHint} />}
 
       {isLoading && (
         <div className="space-y-3">

--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -168,7 +168,8 @@ export const usePRStore = create<PRStore>()(
             },
             priorityIds: p.priorityIds ?? current.priorityIds,
             hiddenIds: p.hiddenIds ?? current.hiddenIds,
-            notificationHintDismissed: p.notificationHintDismissed ?? current.notificationHintDismissed,
+            notificationHintDismissed:
+              p.notificationHintDismissed ?? current.notificationHintDismissed,
           }
         }
         const validSections = new Set<string>(['review-requested', 'authored', 'mentioned'])
@@ -185,7 +186,8 @@ export const usePRStore = create<PRStore>()(
           ) as Record<PRSection, ViewFilters>,
           priorityIds: p.priorityIds ?? current.priorityIds,
           hiddenIds: p.hiddenIds ?? current.hiddenIds,
-          notificationHintDismissed: p.notificationHintDismissed ?? current.notificationHintDismissed,
+          notificationHintDismissed:
+            p.notificationHintDismissed ?? current.notificationHintDismissed,
         }
       },
     }

--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -22,6 +22,7 @@ export type PRStore = {
   viewFilters: Record<PRSection, ViewFilters>
   priorityIds: string[]
   hiddenIds: string[]
+  notificationHintDismissed: boolean
   setView: (v: 'prs' | 'branches') => void
   setSection: (s: PRSection) => void
   setGlobalFilters: (partial: Partial<GlobalFilters>) => void
@@ -32,6 +33,7 @@ export type PRStore = {
   removeHiddenRepo: (repo: string) => void
   togglePriority: (id: string) => void
   toggleHide: (id: string) => void
+  dismissNotificationHint: () => void
   resetFilters: () => void
 }
 
@@ -62,6 +64,7 @@ export const usePRStore = create<PRStore>()(
       viewFilters: defaultViewFiltersAll,
       priorityIds: [],
       hiddenIds: [],
+      notificationHintDismissed: false,
       setView: (v) => set({ view: v }),
       setSection: (s) => set({ section: s }),
       setGlobalFilters: (partial) =>
@@ -118,6 +121,7 @@ export const usePRStore = create<PRStore>()(
             ? state.hiddenIds.filter((p) => p !== id)
             : [...state.hiddenIds, id],
         })),
+      dismissNotificationHint: () => set({ notificationHintDismissed: true }),
       resetFilters: () =>
         set((state) => ({
           viewFilters: {
@@ -164,6 +168,7 @@ export const usePRStore = create<PRStore>()(
             },
             priorityIds: p.priorityIds ?? current.priorityIds,
             hiddenIds: p.hiddenIds ?? current.hiddenIds,
+            notificationHintDismissed: p.notificationHintDismissed ?? current.notificationHintDismissed,
           }
         }
         const validSections = new Set<string>(['review-requested', 'authored', 'mentioned'])
@@ -180,6 +185,7 @@ export const usePRStore = create<PRStore>()(
           ) as Record<PRSection, ViewFilters>,
           priorityIds: p.priorityIds ?? current.priorityIds,
           hiddenIds: p.hiddenIds ?? current.hiddenIds,
+          notificationHintDismissed: p.notificationHintDismissed ?? current.notificationHintDismissed,
         }
       },
     }


### PR DESCRIPTION
## Summary
- Users managing their inbox via GitHub's "Mark as done" were surprised to still see those PRs in Donna, since it tracks open PRs via search, not notification state (see #111 — the notifications API has no queryable "done" state, so auto-hiding wasn't feasible).
- Adds a dismissible `NotificationHint` banner above the PR list explaining this, and clarifying that the `hide` action is local-only and has no effect on GitHub.
- Dismissal is persisted in `prStore` (`notificationHintDismissed`), consistent with the other UI-preference flags already living there.

Closes #114

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`