### PR TITLE
fix: make the entire PR card clickable to open the PR

### DIFF
--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -95,6 +95,26 @@ describe('PRCard', () => {
     expect(screen.queryByRole('button', { name: 'Mark as top priority' })).not.toBeInTheDocument()
   })
 
+  describe('clicking the card', () => {
+    it('GIVEN card body clicked THEN opens the PR in a new tab', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const user = userEvent.setup()
+      render(<PRCard pr={pr} />)
+      await user.click(screen.getByText('org/repo'))
+      expect(openSpy).toHaveBeenCalledWith(pr.url, '_blank', 'noopener,noreferrer')
+      openSpy.mockRestore()
+    })
+
+    it('GIVEN star button clicked THEN does not also open the PR', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const user = userEvent.setup()
+      render(<PRCard pr={pr} />)
+      await user.click(screen.getByRole('button', { name: 'Mark as top priority' }))
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+  })
+
   describe('PRChecksModal rollup state footer', () => {
     const greenCheck = {
       __typename: 'CheckRun' as const,

--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -128,10 +128,13 @@ export const PRCard = ({ pr, isAuthored = false, showHideAndStar = true }: Props
     togglePriority(pr.id)
   }
 
+  const openPR = () => window.open(pr.url, '_blank', 'noopener,noreferrer')
+
   return (
     <div
+      onClick={openPR}
       className={`
-        group relative bg-[var(--color-surface-raised)] border rounded-lg p-4
+        group relative bg-[var(--color-surface-raised)] border rounded-lg p-4 cursor-pointer
         hover:border-[var(--color-accent)] hover:-translate-y-px
         shadow-[var(--shadow-card)] hover:shadow-[var(--shadow-card-hover)]
         transition-all duration-150
@@ -162,6 +165,7 @@ export const PRCard = ({ pr, isAuthored = false, showHideAndStar = true }: Props
               href={pr.url}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
               className="text-sm font-medium leading-snug line-clamp-2 transition-colors text-[var(--color-text-primary)] hover:text-[var(--color-accent)]"
             >
               {pr.title}
@@ -225,7 +229,7 @@ export const PRCard = ({ pr, isAuthored = false, showHideAndStar = true }: Props
 
               {/* CI checks badge */}
               {ciBadge && (
-                <div className="relative">
+                <div className="relative" onClick={(e) => e.stopPropagation()}>
                   <button
                     onClick={() => setChecksOpen((o) => !o)}
                     className={`flex items-center gap-1 text-xs px-1.5 py-0.5 rounded cursor-pointer ${ciBadge.color} ${ciBadge.bg}`}

--- a/src/features/pull-requests/components/PRCardActions/PRCardAction.tsx
+++ b/src/features/pull-requests/components/PRCardActions/PRCardAction.tsx
@@ -8,13 +8,10 @@ type Props = PropsWithChildren & {
   className: string
 }
 
-export const OPACITY_CLASSNAME = 'lg:opacity-0 md:opacity-100 lg:group-hover:opacity-100'
-
 export const PRCardAction = ({ children, title, className, onClick }: Props) => {
   const computedClassName = twMerge(
     'p-1.5 rounded transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent] focus-visible:outline-none',
-    className,
-    OPACITY_CLASSNAME
+    className
   )
 
   return (

--- a/src/features/pull-requests/components/PRCardActions/PRCardActions.tsx
+++ b/src/features/pull-requests/components/PRCardActions/PRCardActions.tsx
@@ -1,8 +1,5 @@
 import { ExternalLink, Eye, EyeOff, Link2, Star } from 'lucide-react'
-import {
-  OPACITY_CLASSNAME,
-  PRCardAction,
-} from '@/features/pull-requests/components/PRCardActions/PRCardAction.tsx'
+import { PRCardAction } from '@/features/pull-requests/components/PRCardActions/PRCardAction.tsx'
 import { CopyWithFeedback } from '@/shared/components/CopyWithFeedback/CopyWithFeedback.tsx'
 
 type Props = {
@@ -23,7 +20,10 @@ export const PRCardActions = ({
   showHideAndStar,
 }: Props) => {
   return (
-    <div className="flex items-center gap-1 shrink-0 flex-col lg:flex-row">
+    <div
+      className="flex items-center gap-1 shrink-0 flex-col lg:flex-row"
+      onClick={(e) => e.stopPropagation()}
+    >
       {showHideAndStar && (
         <>
           <PRCardAction
@@ -54,13 +54,13 @@ export const PRCardActions = ({
         text={prUrl}
         label="Copy PR link"
         icon={<Link2 size={14} />}
-        buttonClassName={`p-1.5 rounded text-[var(--color-text-muted)] ${OPACITY_CLASSNAME} hover:text-[var(--color-accent)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none`}
+        buttonClassName="p-1.5 rounded text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
       />
       <a
         href={prUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className={`p-1.5 rounded text-[var(--color-text-muted)] ${OPACITY_CLASSNAME} hover:text-[var(--color-accent)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none`}
+        className="p-1.5 rounded text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
       >
         <ExternalLink size={14} />
       </a>


### PR DESCRIPTION
## Summary
- Card body now opens the PR externally on click (title link and CI-checks badge stop propagation to keep their own behavior).
- Action buttons (copy, hide, star, external link) are always visible instead of hover-revealed.

## Test plan
- [x] `npm run test:run` — 172 passing, including new tests: card-body click opens the PR, star-button click does not also open it.
- [x] `npm run lint`
- [x] `npm run build`

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)