### PR TITLE
feat: add org-level filter to the settings modal

### DIFF
--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.test.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { SettingsModal } from './SettingsModal'
 import { usePRStore } from '../../stores/prStore'
 import { usePullRequests } from '../../queries/useGitHubPRs'
@@ -36,5 +36,61 @@ describe('SettingsModal', () => {
     render(<SettingsModal />)
 
     expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('GIVEN repos from multiple orgs WHEN clicking an org chip THEN selects all repos of that org', () => {
+    usePRStore.setState({ section: 'review-requested' })
+    mockUsePullRequests.mockReturnValue({
+      repos: ['acme/repo-a', 'acme/repo-b', 'other/repo-c'],
+    } as never)
+
+    render(<SettingsModal />)
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    fireEvent.click(screen.getByText('acme'))
+
+    expect(usePRStore.getState().viewFilters['review-requested'].repos).toEqual([
+      'acme/repo-a',
+      'acme/repo-b',
+    ])
+  })
+
+  it('GIVEN an org fully selected WHEN clicking its chip again THEN deselects all repos of that org', () => {
+    usePRStore.setState({ section: 'review-requested' })
+    usePRStore.getState().setViewFilters('review-requested', {
+      repos: ['acme/repo-a', 'acme/repo-b'],
+    })
+    mockUsePullRequests.mockReturnValue({
+      repos: ['acme/repo-a', 'acme/repo-b', 'other/repo-c'],
+    } as never)
+
+    render(<SettingsModal />)
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    fireEvent.click(screen.getByText('acme'))
+
+    expect(usePRStore.getState().viewFilters['review-requested'].repos).toEqual([])
+  })
+
+  it('GIVEN an org selected via chip WHEN unchecking one of its repos THEN keeps the rest of the org selected', () => {
+    usePRStore.setState({ section: 'review-requested' })
+    mockUsePullRequests.mockReturnValue({
+      repos: ['acme/repo-a', 'acme/repo-b', 'other/repo-c'],
+    } as never)
+
+    render(<SettingsModal />)
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    fireEvent.click(screen.getByText('acme'))
+    fireEvent.click(screen.getByText('repo-a'))
+
+    expect(usePRStore.getState().viewFilters['review-requested'].repos).toEqual(['acme/repo-b'])
+  })
+
+  it('GIVEN repos from a single org WHEN rendered THEN does not show an organization filter', () => {
+    usePRStore.setState({ section: 'review-requested' })
+    mockUsePullRequests.mockReturnValue({ repos: ['acme/repo-a', 'acme/repo-b'] } as never)
+
+    render(<SettingsModal />)
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+
+    expect(screen.queryByText('Organization')).not.toBeInTheDocument()
   })
 })

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -134,27 +134,27 @@ export const SettingsModal = () => {
             </div>
             <div className="space-y-0.5 max-h-48 overflow-y-auto">
               {visibleRepos.map((repo) => {
-                  const selected = currentView.repos.includes(repo)
-                  return (
-                    <label
-                      key={repo}
-                      className={`flex items-center gap-2 px-1 py-1 rounded cursor-pointer group
+                const selected = currentView.repos.includes(repo)
+                return (
+                  <label
+                    key={repo}
+                    className={`flex items-center gap-2 px-1 py-1 rounded cursor-pointer group
                             ${selected ? 'bg-[var(--color-accent-subtle)]' : 'hover:bg-[var(--color-surface-overlay)]'}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selected}
+                      onChange={() => toggleRepo(repo)}
+                      className="accent-[var(--color-accent)] cursor-pointer"
+                    />
+                    <span
+                      className={`text-xs truncate ${selected ? 'text-[var(--color-text-primary)] font-medium' : 'text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]'}`}
                     >
-                      <input
-                        type="checkbox"
-                        checked={selected}
-                        onChange={() => toggleRepo(repo)}
-                        className="accent-[var(--color-accent)] cursor-pointer"
-                      />
-                      <span
-                        className={`text-xs truncate ${selected ? 'text-[var(--color-text-primary)] font-medium' : 'text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]'}`}
-                      >
-                        {repo.split('/')[1]}
-                      </span>
-                    </label>
-                  )
-                })}
+                      {repo.split('/')[1]}
+                    </span>
+                  </label>
+                )
+              })}
             </div>
           </div>
         )}

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -23,6 +23,10 @@ export const SettingsModal = () => {
 
   const currentView = viewFilters[section]
   const hasContent = repos.length > 1 || section !== 'authored'
+  const visibleRepos = repos.filter(
+    (r) => !globalFilters.hiddenRepos.some((h) => isRepoMatchedBy(r, h))
+  )
+  const orgs = [...new Set(visibleRepos.map((r) => r.split('/')[0]))]
 
   const activeCount =
     currentView.repos.length +
@@ -35,6 +39,16 @@ export const SettingsModal = () => {
       repos: currentView.repos.includes(repo)
         ? currentView.repos.filter((r) => r !== repo)
         : [...currentView.repos, repo],
+    })
+  }
+
+  const toggleOrg = (org: string) => {
+    const orgRepos = visibleRepos.filter((r) => r.split('/')[0] === org)
+    const allSelected = orgRepos.every((r) => currentView.repos.includes(r))
+    setViewFilters(section, {
+      repos: allSelected
+        ? currentView.repos.filter((r) => !orgRepos.includes(r))
+        : [...new Set([...currentView.repos, ...orgRepos])],
     })
   }
 
@@ -79,6 +93,30 @@ export const SettingsModal = () => {
       </ButtonWithTooltip>
 
       <Modal isOpen={open} title={'Settings'} onClose={() => setOpen(false)} className="min-w-1/2">
+        {orgs.length > 1 && (
+          <div>
+            <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2">
+              Organization
+            </p>
+            <div className="flex flex-wrap gap-1 mb-3">
+              {orgs.map((org) => {
+                const orgRepos = visibleRepos.filter((r) => r.split('/')[0] === org)
+                const selected = orgRepos.every((r) => currentView.repos.includes(r))
+                return (
+                  <button
+                    key={org}
+                    onClick={() => toggleOrg(org)}
+                    className={`text-xs px-2 py-0.5 rounded-full cursor-pointer transition-colors
+                          ${selected ? 'bg-[var(--color-accent)] text-white' : 'bg-[var(--color-surface-overlay)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'}`}
+                  >
+                    {org}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
         {repos.length > 1 && (
           <div>
             <div className="flex items-center justify-between mb-2">
@@ -95,9 +133,7 @@ export const SettingsModal = () => {
               )}
             </div>
             <div className="space-y-0.5 max-h-48 overflow-y-auto">
-              {repos
-                .filter((r) => !globalFilters.hiddenRepos.some((h) => isRepoMatchedBy(r, h)))
-                .map((repo) => {
+              {visibleRepos.map((repo) => {
                   const selected = currentView.repos.includes(repo)
                   return (
                     <label


### PR DESCRIPTION
## Summary
- Adds an "Organization" chip row above the repo checkboxes in the Settings modal, so users with repos spanning multiple GitHub orgs (e.g. personal + `doctolib/*`) can filter by org instead of picking repos one by one.
- Clicking an org chip toggles all of that org's repos into/out of the existing per-section repo allow-list (`viewFilters[section].repos`) — no new store field, so it composes naturally with individual repo checkboxes and the existing "Hidden repos" deny-list.
- Only rendered when repos span more than one org (mirrors the existing `repos.length > 1` guard for the repo list itself).

Closes #110

## Test plan
- [x] `npm run test:run` — 178/178 pass, including new cases: select/deselect all repos of an org, combining org selection with unchecking one repo, hidden when only one org.
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run lint` clean (pre-existing unrelated warnings only)
- [ ] Manual check in a real multi-org account (couldn't drive a real browser session in this environment — verified via component tests exercising real DOM/click handlers instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)