### PR TITLE
fix: check for app updates more aggressively

### DIFF
--- a/src/features/updates/queries/useUpdateCheck.ts
+++ b/src/features/updates/queries/useUpdateCheck.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+
 export const isNewer = (latest: string, current: string) => {
   const a = latest.replace(/^v/, '').split('.').map(Number)
   const b = current.replace(/^v/, '').split('.').map(Number)
@@ -22,6 +24,9 @@ export const useUpdateCheck = () => {
       }
     },
     staleTime: 60 * 60 * 1000,
+    refetchInterval: UPDATE_CHECK_INTERVAL_MS,
+    // ponytail: 'always' bypasses staleTime so a focus check is never skipped as "still fresh"
+    refetchOnWindowFocus: 'always',
     enabled: !!window.electronAPI,
   })
 }


### PR DESCRIPTION
## Summary
- The update check previously only ran once on app mount (`refetchOnWindowFocus` is globally disabled at the QueryClient level), so a user could sit on a stale build indefinitely.
- Add a 6h `refetchInterval` and force a refetch on window focus (`refetchOnWindowFocus: 'always'`, bypassing `staleTime`) so the update banner surfaces sooner.

## Test plan
- [x] `npm run test:run` — existing `useUpdateCheck` tests pass
- [x] `npm run lint`