### PR TITLE
feat: notify on new review requests independently of the active tab

### DIFF
--- a/src/containers/DashboardPage.tsx
+++ b/src/containers/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { LogOut, Moon, Sun } from 'lucide-react'
 import { useAuthStore } from '@/features/auth/exports'
-import { usePRStore, PRDashboard } from '@/features/pull-requests/exports'
+import { usePRStore, PRDashboard, usePRNotifications } from '@/features/pull-requests/exports'
 import { useTheme } from '@/shared/hooks/useTheme'
 import { useFeatures } from '@/shared/features'
 import { BranchDashboard } from '@/features/branches/exports'
@@ -15,6 +15,7 @@ export const DashboardPage = () => {
   const showBanner = latestVersion && isNewer(latestVersion, __APP_VERSION__)
   const { theme, toggle } = useTheme()
   const features = useFeatures()
+  usePRNotifications()
 
   return (
     <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)] flex flex-col">

--- a/src/features/pull-requests/exports.ts
+++ b/src/features/pull-requests/exports.ts
@@ -1,4 +1,5 @@
 export { usePRStore } from './stores/prStore'
 export { usePullRequests } from './queries/useGitHubPRs'
 export { useCheckContexts } from './queries/useCheckContexts'
+export { usePRNotifications } from './queries/usePRNotifications'
 export { PRDashboard } from './components/PRDashboard/PRDashboard'

--- a/src/features/pull-requests/lib/prNotifications.test.ts
+++ b/src/features/pull-requests/lib/prNotifications.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { computeNewIds } from './prNotifications'
+
+describe('computeNewIds', () => {
+  it('seeds silently on first run instead of reporting all ids as new', () => {
+    const actual = computeNewIds(['a', 'b'], null)
+    expect(actual).toEqual({ newIds: [], nextSeenIds: ['a', 'b'] })
+  })
+
+  it('reports only ids absent from the previous snapshot', () => {
+    const actual = computeNewIds(['a', 'b', 'c'], ['a', 'b'])
+    expect(actual).toEqual({ newIds: ['c'], nextSeenIds: ['a', 'b', 'c'] })
+  })
+
+  it('reports no new ids when nothing changed', () => {
+    const actual = computeNewIds(['a', 'b'], ['a', 'b'])
+    expect(actual).toEqual({ newIds: [], nextSeenIds: ['a', 'b'] })
+  })
+
+  it('drops ids that disappeared (closed/merged) from the next snapshot', () => {
+    const actual = computeNewIds(['b'], ['a', 'b'])
+    expect(actual).toEqual({ newIds: [], nextSeenIds: ['b'] })
+  })
+})

--- a/src/features/pull-requests/lib/prNotifications.ts
+++ b/src/features/pull-requests/lib/prNotifications.ts
@@ -1,0 +1,22 @@
+const SEEN_IDS_KEY = 'donna-notified-review-request-ids'
+
+// Diffs freshly-fetched review-request PR ids against previously seen ones.
+// `seenIds === null` means "never checked before" — seed silently instead of
+// notifying for every pre-existing PR on first run.
+export const computeNewIds = (
+  fetchedIds: string[],
+  seenIds: string[] | null
+): { newIds: string[]; nextSeenIds: string[] } => {
+  if (seenIds === null) return { newIds: [], nextSeenIds: fetchedIds }
+  const seen = new Set(seenIds)
+  return { newIds: fetchedIds.filter((id) => !seen.has(id)), nextSeenIds: fetchedIds }
+}
+
+export const loadSeenIds = (): string[] | null => {
+  const raw = localStorage.getItem(SEEN_IDS_KEY)
+  return raw ? (JSON.parse(raw) as string[]) : null
+}
+
+export const saveSeenIds = (ids: string[]) => {
+  localStorage.setItem(SEEN_IDS_KEY, JSON.stringify(ids))
+}

--- a/src/features/pull-requests/queries/usePRNotifications.ts
+++ b/src/features/pull-requests/queries/usePRNotifications.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { createClient, PR_LIST_QUERY } from '@/providers/github'
+import { useAuthStore } from '@/features/auth/stores/authStore'
+import { buildSearchQuery } from '../lib/prUtils'
+import { computeNewIds, loadSeenIds, saveSeenIds } from '../lib/prNotifications'
+import type { PullRequest } from '@/types/github'
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000
+
+type SearchPage = {
+  search: { nodes: PullRequest[] }
+}
+
+// Polls "review requested" independently of whichever section/view is on
+// screen, so a review request surfaces even while looking at "My PRs" or
+// the Branches tab. Mount once at the app shell level.
+export const usePRNotifications = () => {
+  const token = useAuthStore((s) => s.token)
+  const user = useAuthStore((s) => s.user)
+  const permissionRequested = useRef(false)
+
+  useEffect(() => {
+    if (permissionRequested.current || typeof Notification === 'undefined') return
+    permissionRequested.current = true
+    if (Notification.permission === 'default') void Notification.requestPermission()
+  }, [])
+
+  const searchQuery = buildSearchQuery('review-requested', user?.login ?? '')
+
+  useQuery({
+    queryKey: ['pr-notifications', user?.login],
+    enabled: !!token && !!user && typeof Notification !== 'undefined',
+    staleTime: 0,
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      const data = await createClient(token!).request<SearchPage>(PR_LIST_QUERY, {
+        searchQuery,
+        cursor: null,
+      })
+      const prs = data.search.nodes
+      const { newIds, nextSeenIds } = computeNewIds(
+        prs.map((pr) => pr.id),
+        loadSeenIds()
+      )
+      saveSeenIds(nextSeenIds)
+      if (Notification.permission === 'granted') {
+        const byId = new Map(prs.map((pr) => [pr.id, pr]))
+        for (const id of newIds) {
+          const pr = byId.get(id)!
+          const notification = new Notification(`Review requested: ${pr.title}`, {
+            body: `${pr.repository.nameWithOwner} #${pr.number} by ${pr.author?.login}`,
+          })
+          notification.onclick = () => window.open(pr.url, '_blank', 'noopener,noreferrer')
+        }
+      }
+      return prs
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- `usePullRequests` only polls whichever section/view is currently on screen, so a review request could sit unnoticed while looking at "My PRs" or the Branches tab.
- Add a standalone `usePRNotifications` hook (mounted once at `DashboardPage`, so it survives tab switches) that independently polls `review-requested:<login>` every 5 minutes and fires an OS `Notification` for PRs it hasn't seen before.
- First run seeds the "seen" set silently instead of firing a notification storm for every pre-existing review request; seen ids persist in `localStorage` (same pattern as `useTheme`) so restarts don't re-notify.
- Clicking a notification opens the PR in the browser.
- Works in both Electron and the web build — no platform gating needed, `Notification` is available in both.

## Test plan
- [x] `npm run test:run` — new `prNotifications.test.ts` covers first-run seeding, new-id detection, no-op, and closed/merged PRs dropping out of the snapshot
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: grant notification permission, get a review request, confirm a native notification fires while on a different tab