### PR TITLE
feat: add contribution links to encourage feature requests and bug reports

### DIFF
--- a/src/features/branches/components/BranchList/BranchList.tsx
+++ b/src/features/branches/components/BranchList/BranchList.tsx
@@ -2,6 +2,7 @@ import { useQueries } from '@tanstack/react-query'
 import { FolderPlus, RefreshCw, X } from 'lucide-react'
 import { useEffect, useMemo } from 'react'
 import { usePullRequests } from '@/features/pull-requests/exports'
+import { ContributeLinks } from '@/shared/components/ContributeLinks/ContributeLinks.tsx'
 import { useBranchStore } from '../../stores/branchStore'
 import type { Branch, Worktree } from '../../types'
 import type { PullRequest } from '@/types/github'
@@ -205,6 +206,10 @@ export const BranchList = () => {
             </button>
           )
         })}
+      </div>
+
+      <div className="flex justify-end gap-4 text-xs">
+        <ContributeLinks />
       </div>
 
       <div className="space-y-2">

--- a/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.tsx
+++ b/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.tsx
@@ -1,3 +1,4 @@
+import { ContributeLinks } from '@/shared/components/ContributeLinks/ContributeLinks.tsx'
 import { usePRStore, type PRSection } from '../../stores/prStore'
 
 const SECTIONS: { id: PRSection; label: string }[] = [
@@ -28,6 +29,9 @@ export const PRSectionsTabs = () => {
           </button>
         ))}
       </nav>
+      <div className="mt-6 pt-3 border-t border-[var(--color-border)] space-y-1.5 px-3">
+        <ContributeLinks />
+      </div>
     </aside>
   )
 }

--- a/src/shared/components/ContributeLinks/ContributeLinks.tsx
+++ b/src/shared/components/ContributeLinks/ContributeLinks.tsx
@@ -1,0 +1,30 @@
+import { Bug, Lightbulb } from 'lucide-react'
+
+const LINK_CLASSES =
+  'flex items-center gap-1.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors'
+
+export const ContributeLinks = () => {
+  return (
+    <>
+      <p className="text-xs text-[var(--color-text-muted)]">Donna is open source. Make it yours.</p>
+      <a
+        href="https://github.com/adelbeke/donna/issues/new?template=feature_request.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={LINK_CLASSES}
+      >
+        <Lightbulb size={13} />
+        Propose a feature
+      </a>
+      <a
+        href="https://github.com/adelbeke/donna/issues/new?template=bug_report.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={LINK_CLASSES}
+      >
+        <Bug size={13} />
+        Report a bug
+      </a>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Donna is open source but had no in-app path to opening a GitHub issue, even though `.github/ISSUE_TEMPLATE/feature_request.md` and `bug_report.md` already exist.
- Adds a shared `ContributeLinks` component (two plain links, "Propose a feature" / "Report a bug", each pre-templated via `?template=`) plus a short tagline ("Donna is open source. Make it yours.").
- Placed where it's actually seen: below the section tabs in the PRs sidebar, and in a header row in the Branches view.

## Test plan
- [x] `npm run lint` — no new issues
- [x] `tsc -b` — no errors
- [x] `npm run build` — succeeds
- [ ] Manually click both links in each view to confirm the right GitHub issue template opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)