### PR TITLE
feat: add CODEOWNERS to auto-assign reviewer on PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @adelbeke


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` so @adelbeke is auto-requested as reviewer on every PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)