### PR TITLE
feat: distribute Donna via Homebrew cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,26 @@ jobs:
           files: artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update Homebrew tap
+        run: |
+          VERSION="${{ needs.bump.outputs.version }}"
+          SHA_INTEL=$(sha256sum "artifacts/Donna-${VERSION}.dmg" | awk '{print $1}')
+          SHA_ARM64=$(sha256sum "artifacts/Donna-${VERSION}-arm64.dmg" | awk '{print $1}')
+
+          git clone "https://x-access-token:${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/adelbeke/homebrew-donna.git" tap
+          sed -e "s/__VERSION__/${VERSION}/g" -e "s/__SHA_ARM64__/${SHA_ARM64}/g" -e "s/__SHA_INTEL__/${SHA_INTEL}/g" \
+            homebrew/donna.rb.template > tap/Casks/donna.rb
+
+          cd tap
+          git config user.email "${{ secrets.GIT_USER_EMAIL }}"
+          git config user.name "${{ secrets.GIT_USER_NAME }}"
+          if git diff --quiet; then
+            echo "No cask changes, skipping"
+          else
+            git add Casks/donna.rb
+            git commit -m "chore: update donna to v$VERSION"
+            git push
+          fi
 
   cleanup:
     needs: [bump, build, release]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Your GitHub companion — track PRs, manage branches and worktrees, all from a n
 
 ## Install
 
-Download the latest `.dmg` from [Releases](https://github.com/adelbeke/donna/releases), mount it, drag Donna to Applications.
+```bash
+brew install --cask adelbeke/donna/donna
+```
+
+Or download the latest `.dmg` from [Releases](https://github.com/adelbeke/donna/releases), mount it, drag Donna to Applications.
 
 ## Features
 

--- a/homebrew/donna.rb.template
+++ b/homebrew/donna.rb.template
@@ -1,0 +1,23 @@
+cask "donna" do
+  arch arm: "arm64"
+
+  version "__VERSION__"
+  sha256 arm:   "__SHA_ARM64__",
+         intel: "__SHA_INTEL__"
+
+  url "https://github.com/adelbeke/donna/releases/download/v#{version}/Donna-#{version}#{"-arm64" if arch == "arm64"}.dmg"
+  name "Donna"
+  desc "GitHub PR dashboard — filter, prioritise, track review status"
+  homepage "https://github.com/adelbeke/donna"
+
+  auto_updates true
+  depends_on :macos
+
+  app "Donna.app"
+
+  zap trash: [
+    "~/Library/Application Support/Donna",
+    "~/Library/Preferences/com.dbkable.donna.plist",
+    "~/Library/Saved Application State/com.dbkable.donna.savedState",
+  ]
+end


### PR DESCRIPTION
## Summary
- Adds `homebrew/donna.rb.template`, synced by CI into a personal tap (`adelbeke/homebrew-donna`) on every release, so `brew install --cask adelbeke/donna/donna` picks up the correct version + sha256 automatically instead of hand-editing them (closes #146).
- Extends the `release` job in `release.yml` with a step that computes sha256 for both dmg assets, clones the tap with a new `HOMEBREW_TAP_TOKEN` secret, substitutes the template, and pushes if the cask actually changed (mirrors the `git diff --quiet` pattern in `ci.yml`).
- README gets a one-line `brew install` instruction.

## Notes
- Tap repo `adelbeke/homebrew-donna` already exists and is seeded with the v1.10.0 cask (dry-run verified against the real release assets: `brew audit`/`brew style` pass clean, `brew install` correctly resolves the URL and sha256).
- `HOMEBREW_TAP_TOKEN` (fine-grained PAT, `Contents: Read and write`, scoped to `homebrew-donna` only) is already added as a repo secret.
- OTA (`electron-updater`) is unaffected — the cask has `auto_updates true`, which tells Homebrew the app self-updates, so `brew upgrade --cask` skips it by default and doesn't race with the in-app updater.

## Test plan
- [x] `npm run lint` / `npm run test:run` pass
- [x] Cask template dry-run locally against real v1.10.0 dmg assets (`brew audit --cask`, `brew style --cask`, `brew install --cask` all pass)
- [ ] After merge: trigger `Release` workflow once, confirm `Casks/donna.rb` in the tap updates with the new version/shas