### PR TITLE
feat: add context-switching warning banner for authored PRs

### DIFF
--- a/src/features/pull-requests/components/ContextSwitchWarningBanner/ContextSwitchWarningBanner.test.tsx
+++ b/src/features/pull-requests/components/ContextSwitchWarningBanner/ContextSwitchWarningBanner.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ContextSwitchWarningBanner } from './ContextSwitchWarningBanner'
+
+describe('ContextSwitchWarningBanner', () => {
+  it('GIVEN count and threshold WHEN rendered THEN shows both values', () => {
+    render(<ContextSwitchWarningBanner count={6} threshold={4} />)
+    expect(
+      screen.getByText(/6 open PRs — heavy context-switching risk \(warning threshold: 4\)/)
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/pull-requests/components/ContextSwitchWarningBanner/ContextSwitchWarningBanner.tsx
+++ b/src/features/pull-requests/components/ContextSwitchWarningBanner/ContextSwitchWarningBanner.tsx
@@ -1,0 +1,9 @@
+type Props = { count: number; threshold: number }
+
+export const ContextSwitchWarningBanner = ({ count, threshold }: Props) => (
+  <div className="mb-3 w-full flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--color-warning-subtle)] border border-[var(--color-warning)] text-[var(--color-warning)] text-xs">
+    <strong>
+      {count} open PRs — heavy context-switching risk (warning threshold: {threshold})
+    </strong>
+  </div>
+)

--- a/src/features/pull-requests/components/PRList/PRList.test.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.test.tsx
@@ -51,6 +51,8 @@ const mockStoreFilters = () => {
       hiddenIds: [],
       notificationHintDismissed: true,
       dismissNotificationHint: vi.fn(),
+      contextSwitchThreshold: 4,
+      setContextSwitchThreshold: vi.fn(),
       setSection: vi.fn(),
       setGlobalFilters: vi.fn(),
       setViewFilters: vi.fn(),

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -6,6 +6,8 @@ import { PRListHeader } from '@/features/pull-requests/components/PRListHeader/P
 import { useFocusRefresh } from '../../hooks/useFocusRefresh'
 import { NewPRsBadge } from '../NewPRsBadge/NewPRsBadge'
 import { NotificationHint } from '../NotificationHint/NotificationHint'
+import { ContextSwitchWarningBanner } from '../ContextSwitchWarningBanner/ContextSwitchWarningBanner'
+import { isOverContextSwitchThreshold } from '../../lib/prUtils'
 
 const sectionLabels: Record<string, string> = {
   'review-requested': 'Review requested',
@@ -30,6 +32,7 @@ export const PRList = () => {
   const viewFilters = usePRStore((s) => s.viewFilters)
   const notificationHintDismissed = usePRStore((s) => s.notificationHintDismissed)
   const dismissNotificationHint = usePRStore((s) => s.dismissNotificationHint)
+  const contextSwitchThreshold = usePRStore((s) => s.contextSwitchThreshold)
   const queryClient = useQueryClient()
 
   // Checks/details are fetched per-PR (usePRDetails/useCheckContexts) and won't
@@ -70,6 +73,11 @@ export const PRList = () => {
         isFetching={isFetching}
         isLoadingMore={isFetchingNextPage}
       />
+
+      {section === 'authored' &&
+        isOverContextSwitchThreshold(allPRs.length, contextSwitchThreshold) && (
+          <ContextSwitchWarningBanner count={allPRs.length} threshold={contextSwitchThreshold} />
+        )}
 
       {newCount > 0 && <NewPRsBadge count={newCount} onDismiss={dismiss} />}
 

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.test.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.test.tsx
@@ -11,13 +11,41 @@ vi.mock('../../queries/useGitHubPRs', () => ({
 const mockUsePullRequests = vi.mocked(usePullRequests)
 
 describe('SettingsModal', () => {
-  it('GIVEN authored section with a single repo WHEN rendered THEN renders nothing', () => {
+  it('GIVEN authored section with a single repo WHEN rendered THEN still shows the settings button (context-switch threshold is global)', () => {
     usePRStore.setState({ section: 'authored' })
     mockUsePullRequests.mockReturnValue({ repos: ['org/repo'] } as never)
 
-    const { container } = render(<SettingsModal />)
+    render(<SettingsModal />)
 
-    expect(container).toBeEmptyDOMElement()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('GIVEN a contextSwitchThreshold in the store WHEN opened THEN the input reflects it and updates the store on change', () => {
+    usePRStore.setState({ section: 'authored', contextSwitchThreshold: 4 })
+    mockUsePullRequests.mockReturnValue({ repos: ['org/repo'] } as never)
+
+    render(<SettingsModal />)
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    const input = screen.getByLabelText(/context-switching warning threshold/i) as HTMLInputElement
+
+    expect(input.value).toBe('4')
+
+    fireEvent.change(input, { target: { value: '2' } })
+
+    expect(usePRStore.getState().contextSwitchThreshold).toBe(2)
+  })
+
+  it('GIVEN the threshold input WHEN entering 0 THEN the store clamps to 1', () => {
+    usePRStore.setState({ section: 'authored', contextSwitchThreshold: 4 })
+    mockUsePullRequests.mockReturnValue({ repos: ['org/repo'] } as never)
+
+    render(<SettingsModal />)
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    const input = screen.getByLabelText(/context-switching warning threshold/i) as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: '0' } })
+
+    expect(usePRStore.getState().contextSwitchThreshold).toBe(1)
   })
 
   it('GIVEN authored section with multiple repos WHEN rendered THEN shows the settings button', () => {

--- a/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
+++ b/src/features/pull-requests/components/SettingsModal/SettingsModal.tsx
@@ -19,10 +19,11 @@ export const SettingsModal = () => {
   const removeHiddenAuthor = usePRStore((s) => s.removeHiddenAuthor)
   const addHiddenRepo = usePRStore((s) => s.addHiddenRepo)
   const removeHiddenRepo = usePRStore((s) => s.removeHiddenRepo)
+  const contextSwitchThreshold = usePRStore((s) => s.contextSwitchThreshold)
+  const setContextSwitchThreshold = usePRStore((s) => s.setContextSwitchThreshold)
   const { repos = [] } = usePullRequests()
 
   const currentView = viewFilters[section]
-  const hasContent = repos.length > 1 || section !== 'authored'
   const visibleRepos = repos.filter(
     (r) => !globalFilters.hiddenRepos.some((h) => isRepoMatchedBy(r, h))
   )
@@ -74,8 +75,6 @@ export const SettingsModal = () => {
     }
   }
 
-  if (!hasContent) return null
-
   return (
     <>
       <ButtonWithTooltip
@@ -93,6 +92,23 @@ export const SettingsModal = () => {
       </ButtonWithTooltip>
 
       <Modal isOpen={open} title={'Settings'} onClose={() => setOpen(false)} className="min-w-1/2">
+        <div>
+          <label
+            htmlFor="context-switch-threshold"
+            className="block text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2"
+          >
+            Context-switching warning threshold (open authored PRs)
+          </label>
+          <input
+            id="context-switch-threshold"
+            type="number"
+            min={1}
+            value={contextSwitchThreshold}
+            onChange={(e) => setContextSwitchThreshold(Math.max(1, Number(e.target.value) || 1))}
+            className="w-full text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] bg-[var(--color-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+          />
+        </div>
+
         {orgs.length > 1 && (
           <div>
             <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2">

--- a/src/features/pull-requests/lib/prUtils.test.ts
+++ b/src/features/pull-requests/lib/prUtils.test.ts
@@ -6,6 +6,7 @@ import {
   deriveCheckState,
   deriveMyReviewState,
   dedupeChecks,
+  isOverContextSwitchThreshold,
 } from './prUtils'
 
 const makePR = (overrides: Partial<PullRequest> = {}): PullRequest => {
@@ -152,6 +153,20 @@ describe('dedupeChecks', () => {
     const run = checkRun('build')
     const status = statusContext('build', 'SUCCESS')
     expect(dedupeChecks([run, status])).toEqual([run, status])
+  })
+})
+
+describe('isOverContextSwitchThreshold', () => {
+  it('GIVEN count under threshold WHEN called THEN returns false', () => {
+    expect(isOverContextSwitchThreshold(3, 4)).toBe(false)
+  })
+
+  it('GIVEN count exactly at threshold WHEN called THEN returns false', () => {
+    expect(isOverContextSwitchThreshold(4, 4)).toBe(false)
+  })
+
+  it('GIVEN count over threshold WHEN called THEN returns true', () => {
+    expect(isOverContextSwitchThreshold(5, 4)).toBe(true)
   })
 })
 

--- a/src/features/pull-requests/lib/prUtils.ts
+++ b/src/features/pull-requests/lib/prUtils.ts
@@ -92,6 +92,11 @@ export const dedupeChecks = (
   return [...byKey.values()]
 }
 
+export const isOverContextSwitchThreshold = (
+  authoredOpenCount: number,
+  threshold: number
+): boolean => authoredOpenCount > threshold
+
 export const sortAndPartition = (
   prs: PullRequest[],
   priorityIds: string[]

--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -23,6 +23,7 @@ export type PRStore = {
   priorityIds: string[]
   hiddenIds: string[]
   notificationHintDismissed: boolean
+  contextSwitchThreshold: number
   setView: (v: 'prs' | 'branches') => void
   setSection: (s: PRSection) => void
   setGlobalFilters: (partial: Partial<GlobalFilters>) => void
@@ -34,6 +35,7 @@ export type PRStore = {
   togglePriority: (id: string) => void
   toggleHide: (id: string) => void
   dismissNotificationHint: () => void
+  setContextSwitchThreshold: (n: number) => void
   resetFilters: () => void
 }
 
@@ -65,6 +67,7 @@ export const usePRStore = create<PRStore>()(
       priorityIds: [],
       hiddenIds: [],
       notificationHintDismissed: false,
+      contextSwitchThreshold: 4,
       setView: (v) => set({ view: v }),
       setSection: (s) => set({ section: s }),
       setGlobalFilters: (partial) =>
@@ -122,6 +125,7 @@ export const usePRStore = create<PRStore>()(
             : [...state.hiddenIds, id],
         })),
       dismissNotificationHint: () => set({ notificationHintDismissed: true }),
+      setContextSwitchThreshold: (n) => set({ contextSwitchThreshold: n }),
       resetFilters: () =>
         set((state) => ({
           viewFilters: {
@@ -170,6 +174,7 @@ export const usePRStore = create<PRStore>()(
             hiddenIds: p.hiddenIds ?? current.hiddenIds,
             notificationHintDismissed:
               p.notificationHintDismissed ?? current.notificationHintDismissed,
+            contextSwitchThreshold: p.contextSwitchThreshold ?? current.contextSwitchThreshold,
           }
         }
         const validSections = new Set<string>(['review-requested', 'authored', 'mentioned'])
@@ -188,6 +193,7 @@ export const usePRStore = create<PRStore>()(
           hiddenIds: p.hiddenIds ?? current.hiddenIds,
           notificationHintDismissed:
             p.notificationHintDismissed ?? current.notificationHintDismissed,
+          contextSwitchThreshold: p.contextSwitchThreshold ?? current.contextSwitchThreshold,
         }
       },
     }


### PR DESCRIPTION
## Summary
- Closes #145. Too many open authored PRs in parallel hurts focus, so this adds a configurable warning threshold (default 4) and a banner in "My PRs" when the count of open authored PRs exceeds it.
- New `contextSwitchThreshold`/`setContextSwitchThreshold` in `prStore` (persisted).
- New pure helper `isOverContextSwitchThreshold` in `prUtils.ts`.
- New `ContextSwitchWarningBanner` component, rendered in `PRList` for the `authored` section, styled with the existing warning color tokens.
- New number input in `SettingsModal` (global, not gated by section), clamped to a minimum of 1.

## Test plan
- [x] `npm run test:run` — 177 tests pass
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [ ] Manual: lower threshold to 1 in Settings, confirm banner appears/disappears in "My PRs" as the authored open PR count crosses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)