### PR TITLE
fix: recheck for updates on window focus

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -188,6 +188,14 @@ const createWindow = () => {
     return { action: 'deny' }
   })
 
+  // ponytail: checkForUpdates() only runs once at startup otherwise — a long-lived
+  // session never learns about releases published after launch until relaunched
+  win.on('focus', () => {
+    if (app.isPackaged && !updateDownloaded) {
+      autoUpdater.checkForUpdates()?.catch((err) => console.error('[updater]', err.message))
+    }
+  })
+
   if (!app.isPackaged) {
     const url = 'http://localhost:5173/donna/'
     win.webContents.on('did-fail-load', () => setTimeout(() => win.loadURL(url), 500))

--- a/src/containers/DashboardPage.tsx
+++ b/src/containers/DashboardPage.tsx
@@ -5,14 +5,13 @@ import { useTheme } from '@/shared/hooks/useTheme'
 import { useFeatures } from '@/shared/features'
 import { BranchDashboard } from '@/features/branches/exports'
 import { Footer } from '@/shared/components/Footer/Footer'
-import { useUpdateCheck, isNewer, UpdateBanner } from '@/features/updates/exports'
+import { useUpdateCheck, UpdateBanner } from '@/features/updates/exports'
 
 export const DashboardPage = () => {
   const { user, logout } = useAuthStore()
   // TODO: the view shouldn't be drove by the PR store feature
   const { view, setView } = usePRStore()
   const { data: latestVersion } = useUpdateCheck()
-  const showBanner = latestVersion && isNewer(latestVersion, __APP_VERSION__)
   const { theme, toggle } = useTheme()
   const features = useFeatures()
 
@@ -71,7 +70,7 @@ export const DashboardPage = () => {
         </div>
       </header>
 
-      {showBanner && <UpdateBanner version={latestVersion} />}
+      {latestVersion && <UpdateBanner version={latestVersion} />}
 
       {/* Main layout */}
       <main className="flex-1 max-w-6xl mx-auto px-6 py-8 w-full">

--- a/src/features/updates/components/UpdateBanner/UpdateBanner.test.tsx
+++ b/src/features/updates/components/UpdateBanner/UpdateBanner.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { UpdateBanner } from './UpdateBanner'
+
+afterEach(() => {
+  delete window.electronAPI
+})
+
+describe('UpdateBanner', () => {
+  it('renders nothing while no update has been downloaded', async () => {
+    window.electronAPI = {
+      updater: {
+        isUpdateDownloaded: vi.fn().mockResolvedValue(false),
+        onUpdateDownloaded: vi.fn(),
+        installUpdate: vi.fn(),
+      },
+    } as unknown as typeof window.electronAPI
+
+    const { container } = render(<UpdateBanner version="v1.2.3" />)
+
+    await waitFor(() => expect(window.electronAPI!.updater.isUpdateDownloaded).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the banner once an update was already downloaded before mount', async () => {
+    window.electronAPI = {
+      updater: {
+        isUpdateDownloaded: vi.fn().mockResolvedValue(true),
+        onUpdateDownloaded: vi.fn(),
+        installUpdate: vi.fn(),
+      },
+    } as unknown as typeof window.electronAPI
+
+    render(<UpdateBanner version="v1.2.3" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('Version v1.2.3 is available.')).toBeInTheDocument()
+    )
+  })
+
+  it('shows the banner when the update-downloaded event fires after mount', async () => {
+    let onDownloaded = () => {}
+    window.electronAPI = {
+      updater: {
+        isUpdateDownloaded: vi.fn().mockResolvedValue(false),
+        onUpdateDownloaded: vi.fn((cb: () => void) => {
+          onDownloaded = cb
+        }),
+        installUpdate: vi.fn(),
+      },
+    } as unknown as typeof window.electronAPI
+
+    render(<UpdateBanner version="v1.2.3" />)
+    expect(screen.queryByText(/is available/)).not.toBeInTheDocument()
+
+    act(() => onDownloaded())
+
+    await waitFor(() =>
+      expect(screen.getByText('Version v1.2.3 is available.')).toBeInTheDocument()
+    )
+  })
+
+  it('dismisses the banner when ✕ is clicked', async () => {
+    window.electronAPI = {
+      updater: {
+        isUpdateDownloaded: vi.fn().mockResolvedValue(true),
+        onUpdateDownloaded: vi.fn(),
+        installUpdate: vi.fn(),
+      },
+    } as unknown as typeof window.electronAPI
+
+    render(<UpdateBanner version="v1.2.3" />)
+    await waitFor(() =>
+      expect(screen.getByText('Version v1.2.3 is available.')).toBeInTheDocument()
+    )
+
+    await userEvent.click(screen.getByText('✕'))
+
+    expect(screen.queryByText(/is available/)).not.toBeInTheDocument()
+  })
+
+  it('installs the update when "Restart to install" is clicked', async () => {
+    const installUpdate = vi.fn()
+    window.electronAPI = {
+      updater: {
+        isUpdateDownloaded: vi.fn().mockResolvedValue(true),
+        onUpdateDownloaded: vi.fn(),
+        installUpdate,
+      },
+    } as unknown as typeof window.electronAPI
+
+    render(<UpdateBanner version="v1.2.3" />)
+    await waitFor(() => expect(screen.getByText('Restart to install')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('Restart to install'))
+
+    expect(installUpdate).toHaveBeenCalled()
+  })
+})

--- a/src/features/updates/queries/useUpdateCheck.test.tsx
+++ b/src/features/updates/queries/useUpdateCheck.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { isNewer } from './useUpdateCheck'
 
@@ -12,36 +11,5 @@ describe('isNewer', () => {
   it('returns false when current is same or ahead', () => {
     expect(isNewer('v0.1.0', '0.1.0')).toBe(false)
     expect(isNewer('v0.1.0', '0.2.0')).toBe(false)
-  })
-})
-
-// Inline minimal banner to avoid importing App-level deps
-const UpdateBanner = ({ version, onDismiss }: { version: string; onDismiss: () => void }) => {
-  return (
-    <div>
-      <span>Version {version} is available.</span>
-      <button onClick={onDismiss}>✕</button>
-    </div>
-  )
-}
-
-describe('UpdateBanner', () => {
-  it('renders the version', () => {
-    render(<UpdateBanner version="v1.2.3" onDismiss={() => {}} />)
-    expect(screen.getByText('Version v1.2.3 is available.')).toBeInTheDocument()
-  })
-
-  it('calls onDismiss when ✕ is clicked', () => {
-    let dismissed = false
-    render(
-      <UpdateBanner
-        version="v1.2.3"
-        onDismiss={() => {
-          dismissed = true
-        }}
-      />
-    )
-    fireEvent.click(screen.getByText('✕'))
-    expect(dismissed).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- `autoUpdater.checkForUpdates()` only ran once at app startup, so a long-lived session never learned about releases published after launch — only a full relaunch triggered a fresh check. It's now re-run whenever the window regains focus.
- Dropped the redundant `isNewer(latestVersion, __APP_VERSION__)` gate on mounting `UpdateBanner`: it duplicated the version check `autoUpdater` already does before downloading, and could keep the banner hidden even after a download completed if the GitHub releases poll hadn't caught up. `UpdateBanner`'s own `downloaded` state (from the Electron `update-downloaded` event) now fully controls visibility.

## Test plan
- [x] `npm run test:run` — 192 passed, including a new `UpdateBanner.test.tsx` covering hidden-by-default, already-downloaded-before-mount, downloaded-event-after-mount, dismiss, and install
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: install a build, publish a newer release, focus the window, confirm the banner appears without a relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)