### PR TITLE
feat(pull-requests): replace open-externally link with copy checkout command

### DIFF
--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -95,6 +95,15 @@ describe('PRCard', () => {
     expect(screen.queryByRole('button', { name: 'Mark as top priority' })).not.toBeInTheDocument()
   })
 
+  it('copy checkout command button click copies gh pr checkout command to clipboard', async () => {
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue()
+    const user = userEvent.setup()
+    render(<PRCard pr={pr} />)
+    await user.click(screen.getByRole('button', { name: 'Copy checkout command' }))
+    expect(writeText).toHaveBeenCalledWith(`gh pr checkout ${pr.number}`)
+    writeText.mockRestore()
+  })
+
   describe('clicking the card', () => {
     it('GIVEN card body clicked THEN opens the PR in a new tab', async () => {
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
@@ -103,6 +112,17 @@ describe('PRCard', () => {
       await user.click(screen.getByText('org/repo'))
       expect(openSpy).toHaveBeenCalledWith(pr.url, '_blank', 'noopener,noreferrer')
       openSpy.mockRestore()
+    })
+
+    it('GIVEN copy checkout command button clicked THEN does not also open the PR', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue()
+      const user = userEvent.setup()
+      render(<PRCard pr={pr} />)
+      await user.click(screen.getByRole('button', { name: 'Copy checkout command' }))
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+      writeText.mockRestore()
     })
 
     it('GIVEN star button clicked THEN does not also open the PR', async () => {

--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -280,6 +280,7 @@ export const PRCard = ({ pr, isAuthored = false, showHideAndStar = true }: Props
           togglePriority={handleTogglePriority}
           isPriority={isPriority}
           prUrl={pr.url}
+          prNumber={pr.number}
           showHideAndStar={showHideAndStar}
           showRunShortcut={isAuthored && !!repoPath}
           onRunShortcut={() => setShortcutsOpen(true)}

--- a/src/features/pull-requests/components/PRCardActions/PRCardActions.tsx
+++ b/src/features/pull-requests/components/PRCardActions/PRCardActions.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Eye, EyeOff, Link2, Star, Terminal } from 'lucide-react'
+import { Eye, EyeOff, GitBranch, Link2, Star, Terminal } from 'lucide-react'
 import { PRCardAction } from '@/features/pull-requests/components/PRCardActions/PRCardAction.tsx'
 import { CopyWithFeedback } from '@/shared/components/CopyWithFeedback/CopyWithFeedback.tsx'
 
@@ -8,6 +8,7 @@ type Props = {
   togglePriority: () => void
   isPriority: boolean
   prUrl: string
+  prNumber: number
   showHideAndStar: boolean
   showRunShortcut: boolean
   onRunShortcut: () => void
@@ -17,6 +18,7 @@ export const PRCardActions = ({
   isHidden,
   isPriority,
   prUrl,
+  prNumber,
   toggleHide,
   togglePriority,
   showHideAndStar,
@@ -69,14 +71,12 @@ export const PRCardActions = ({
         icon={<Link2 size={14} />}
         buttonClassName="p-1.5 rounded text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
       />
-      <a
-        href={prUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="p-1.5 rounded text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
-      >
-        <ExternalLink size={14} />
-      </a>
+      <CopyWithFeedback
+        text={`gh pr checkout ${prNumber}`}
+        label="Copy checkout command"
+        icon={<GitBranch size={14} />}
+        buttonClassName="p-1.5 rounded text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+      />
     </div>
   )
 }


### PR DESCRIPTION
## What

Replaces the "open externally" link icon in `PRCardActions` with a "Copy checkout command" button that copies `gh pr checkout <number>` to the clipboard.

## Why

The app delegates all GitHub calls to the local `gh` CLI (no token stored, no web app anymore). Opening the PR in a browser is less useful in that workflow than being able to check it out locally in one command.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes

---
_This pull request was created with AI assistance._