### PR TITLE
feat: expand collapsed context and view full file in diff viewer

### DIFF
--- a/src/features/pr-review/components/DiffFile/DiffFile.test.tsx
+++ b/src/features/pr-review/components/DiffFile/DiffFile.test.tsx
@@ -5,17 +5,21 @@ import { DiffFile } from './DiffFile'
 import { useCreateThread } from '../../queries/useCreateThread'
 import { useReplyToThread } from '../../queries/useReplyToThread'
 import { useResolveThread } from '../../queries/useResolveThread'
+import { useFileBlob } from '../../queries/useFileBlob'
 import type { PRFile, PRReviewThread } from '../../types'
 
 const mockUseCreateThread = vi.mocked(useCreateThread)
 const mockUseReplyToThread = vi.mocked(useReplyToThread)
 const mockUseResolveThread = vi.mocked(useResolveThread)
+const mockUseFileBlob = vi.mocked(useFileBlob)
 
 vi.mock('../../queries/useCreateThread', () => ({ useCreateThread: vi.fn() }))
 vi.mock('../../queries/useReplyToThread', () => ({ useReplyToThread: vi.fn() }))
 vi.mock('../../queries/useResolveThread', () => ({ useResolveThread: vi.fn() }))
+vi.mock('../../queries/useFileBlob', () => ({ useFileBlob: vi.fn() }))
 
 const prKey = { owner: 'o', repo: 'r', number: 1 }
+const headRefOid = 'abc123'
 
 const given_file = (overrides: Partial<PRFile> = {}): PRFile => ({
   sha: 'abc',
@@ -56,6 +60,7 @@ beforeEach(() => {
   mockUseCreateThread.mockReturnValue(mutateMock())
   mockUseReplyToThread.mockReturnValue(mutateMock())
   mockUseResolveThread.mockReturnValue(mutateMock())
+  mockUseFileBlob.mockReturnValue({ data: undefined, isFetching: false } as never)
 })
 
 describe('DiffFile', () => {
@@ -67,6 +72,7 @@ describe('DiffFile', () => {
         isExpanded={false}
         onToggle={vi.fn()}
         prKey={prKey}
+        headRefOid={headRefOid}
         pullRequestId="pr-1"
       />
     )
@@ -81,6 +87,7 @@ describe('DiffFile', () => {
         isExpanded={true}
         onToggle={vi.fn()}
         prKey={prKey}
+        headRefOid={headRefOid}
         pullRequestId="pr-1"
       />
     )
@@ -95,6 +102,7 @@ describe('DiffFile', () => {
         isExpanded={true}
         onToggle={vi.fn()}
         prKey={prKey}
+        headRefOid={headRefOid}
         pullRequestId="pr-1"
       />
     )
@@ -109,6 +117,7 @@ describe('DiffFile', () => {
         isExpanded={true}
         onToggle={vi.fn()}
         prKey={prKey}
+        headRefOid={headRefOid}
         pullRequestId="pr-1"
       />
     )
@@ -123,6 +132,7 @@ describe('DiffFile', () => {
         isExpanded={true}
         onToggle={vi.fn()}
         prKey={prKey}
+        headRefOid={headRefOid}
         pullRequestId={null}
       />
     )
@@ -138,6 +148,7 @@ describe('DiffFile', () => {
         isExpanded={true}
         onToggle={vi.fn()}
         prKey={prKey}
+        headRefOid={headRefOid}
         pullRequestId="pr-1"
       />
     )
@@ -157,6 +168,7 @@ describe('DiffFile', () => {
         isExpanded={true}
         onToggle={vi.fn()}
         prKey={prKey}
+        headRefOid={headRefOid}
         pullRequestId="pr-1"
       />
     )
@@ -176,7 +188,29 @@ describe('DiffFile', () => {
     )
   })
 
-  it('given the review pill is picked, when submitted, then createThread.mutate carries review mode and the pending review id', async () => {
+  it('given a file blob is loaded, when the full file button is clicked, then the modal shows content only present in the blob', async () => {
+    mockUseFileBlob.mockReturnValue({
+      data: { lines: ['a', 'c', 'd', 'lineOnlyInFullFile'] },
+      isFetching: false,
+    } as never)
+    const user = userEvent.setup()
+    render(
+      <DiffFile
+        file={given_file()}
+        threads={[]}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        prKey={prKey}
+        headRefOid={headRefOid}
+        pullRequestId="pr-1"
+      />
+    )
+    expect(screen.queryByText('lineOnlyInFullFile')).not.toBeInTheDocument()
+    await user.click(screen.getByLabelText('View full file'))
+    expect(screen.getByText('lineOnlyInFullFile')).toBeInTheDocument()
+  })
+
+  it('given a pending review, when a composer opens, then it is already locked to review mode with no toggle shown', async () => {
     const mutate = vi.fn()
     mockUseCreateThread.mockReturnValue({ mutate, isPending: false, isError: false } as never)
     const user = userEvent.setup()
@@ -187,13 +221,15 @@ describe('DiffFile', () => {
         isExpanded={true}
         onToggle={vi.fn()}
         prKey={prKey}
+        headRefOid={headRefOid}
         pullRequestId="pr-1"
         pendingReview={{ id: 'review-1', commentCount: 2 }}
       />
     )
     const buttons = screen.getAllByLabelText('Add comment')
     await user.click(buttons[0])
-    await user.click(screen.getByRole('button', { name: 'Part of review' }))
+    expect(screen.queryByRole('button', { name: 'Single comment' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Part of review' })).not.toBeInTheDocument()
     await user.type(screen.getByPlaceholderText('Leave a comment'), 'nit')
     await user.click(screen.getByRole('button', { name: 'Add to review' }))
     expect(mutate).toHaveBeenCalledWith(

--- a/src/features/pr-review/components/DiffFile/DiffFile.tsx
+++ b/src/features/pr-review/components/DiffFile/DiffFile.tsx
@@ -1,18 +1,23 @@
 import { useMemo, useState } from 'react'
 import { parsePatch, unavailableReason } from '../../lib/parsePatch'
 import { anchorId, anchorThreadsToRows, commentTargetForRow, rowKeys } from '../../lib/threadAnchor'
+import {
+  buildFullFileRows,
+  expandGapId,
+  MAX_HIGHLIGHT_ROWS,
+  mergeExpandedContext,
+} from '../../lib/expandContext'
 import { languageFor } from '../../lib/language'
 import { DiffFileHeader } from '../DiffFileHeader/DiffFileHeader'
 import { DiffRowView } from '../DiffRowView/DiffRowView'
 import { DiffThread } from '../DiffThread/DiffThread'
 import { CommentComposer } from '../CommentComposer/CommentComposer'
+import { FullFileModal } from '../FullFileModal/FullFileModal'
 import { useCreateThread } from '../../queries/useCreateThread'
 import { useReplyToThread } from '../../queries/useReplyToThread'
 import { useResolveThread } from '../../queries/useResolveThread'
+import { useFileBlob } from '../../queries/useFileBlob'
 import type { CommentMode, PendingReview, PRFile, PRKey, PRReviewThread } from '../../types'
-
-// ponytail: tokenizing thousands of rows on expand janks the frame — big files render plain.
-const MAX_HIGHLIGHT_ROWS = 500
 
 type Props = {
   file: PRFile
@@ -22,6 +27,7 @@ type Props = {
   prKey: PRKey
   pullRequestId: string | null // null while usePRThreads is still pending — blocks new-thread creation
   pendingReview?: PendingReview | null
+  headRefOid: string
 }
 
 export const DiffFile = ({
@@ -32,28 +38,55 @@ export const DiffFile = ({
   prKey,
   pullRequestId,
   pendingReview = null,
+  headRefOid,
 }: Props) => {
   const [composerAt, setComposerAt] = useState<string | null>(null)
   const [composerMode, setComposerMode] = useState<CommentMode>('one-shot')
+  const [expandedGapIds, setExpandedGapIds] = useState<Set<string>>(new Set())
+  const [isFullFileOpen, setIsFullFileOpen] = useState(false)
 
   const createThread = useCreateThread(prKey)
   const replyToThread = useReplyToThread(prKey)
   const resolveThread = useResolveThread(prKey)
 
   const parsed = useMemo(
-    () => (isExpanded ? parsePatch(file.patch) : null),
-    [isExpanded, file.patch]
+    () => (isExpanded || isFullFileOpen ? parsePatch(file.patch) : null),
+    [isExpanded, isFullFileOpen, file.patch]
   )
+
+  const { data: blob, isFetching: isBlobFetching } = useFileBlob(
+    prKey,
+    headRefOid,
+    file.filename,
+    expandedGapIds.size > 0 || isFullFileOpen
+  )
+
+  const rows = useMemo(
+    () =>
+      parsed?.kind === 'rows' ? mergeExpandedContext(parsed.rows, blob?.lines, expandedGapIds) : [],
+    [parsed, blob, expandedGapIds]
+  )
+
+  const fullFile = useMemo(
+    () =>
+      isFullFileOpen && parsed?.kind === 'rows'
+        ? buildFullFileRows(parsed.rows, blob?.lines)
+        : { rows: [], truncated: false },
+    [isFullFileOpen, parsed, blob]
+  )
+
   const language = useMemo(() => languageFor(file.filename), [file.filename])
-  const highlightLanguage =
-    parsed?.kind === 'rows' && parsed.rows.length <= MAX_HIGHLIGHT_ROWS ? language : undefined
+  const highlightLanguage = rows.length > 0 && rows.length <= MAX_HIGHLIGHT_ROWS ? language : undefined
 
   const anchored = useMemo(() => {
     if (!parsed || parsed.kind !== 'rows') return null
-    return anchorThreadsToRows(threads, parsed.rows)
-  }, [parsed, threads])
+    return anchorThreadsToRows(threads, rows)
+  }, [parsed, threads, rows])
 
   const commentCount = threads.reduce((n, t) => n + t.comments.nodes.length, 0)
+
+  const onExpand = (row: (typeof rows)[number]) =>
+    setExpandedGapIds((prev) => new Set(prev).add(expandGapId(row)))
 
   return (
     <div
@@ -67,6 +100,18 @@ export const DiffFile = ({
         commentCount={commentCount}
         outdatedThreads={anchored?.unanchored ?? []}
         fileLevelThreads={anchored?.fileLevel ?? []}
+        onOpenFullFile={file.patch ? () => setIsFullFileOpen(true) : undefined}
+      />
+
+      <FullFileModal
+        isOpen={isFullFileOpen}
+        onClose={() => setIsFullFileOpen(false)}
+        filename={file.filename}
+        blobUrl={file.blob_url}
+        rows={fullFile.rows}
+        truncated={fullFile.truncated}
+        language={language}
+        isLoading={isFullFileOpen && !blob}
       />
 
       {isExpanded && parsed?.kind === 'unavailable' && (
@@ -85,11 +130,11 @@ export const DiffFile = ({
 
       {isExpanded && parsed?.kind === 'rows' && anchored && (
         <div>
-          {parsed.rows.map((row, i) => {
+          {rows.map((row, i) => {
             const keys = rowKeys(row)
             const rowThreads = keys.flatMap((k) => anchored.byRow.get(k) ?? [])
             const target = pullRequestId ? commentTargetForRow(row) : null
-            const key = keys[0] ?? `row-${i}`
+            const key = keys[0] ?? (row.type === 'expand' ? expandGapId(row) : `row-${i}`)
             const isComposerOpen = composerAt === key
 
             return (
@@ -99,12 +144,14 @@ export const DiffFile = ({
                   onAddComment={
                     target
                       ? () => {
-                          setComposerMode('one-shot')
+                          setComposerMode(pendingReview ? 'review' : 'one-shot')
                           setComposerAt(key)
                         }
                       : undefined
                   }
                   language={highlightLanguage}
+                  onExpand={row.type === 'expand' ? () => onExpand(row) : undefined}
+                  isExpanding={row.type === 'expand' && isBlobFetching}
                 />
                 {rowThreads.map((thread) => (
                   <DiffThread
@@ -138,7 +185,7 @@ export const DiffFile = ({
                     isPending={createThread.isPending}
                     error={createThread.isError ? createThread.error.message : null}
                     mode={composerMode}
-                    onModeChange={setComposerMode}
+                    onModeChange={pendingReview ? undefined : setComposerMode}
                     autoFocus
                     submitLabel={
                       composerMode === 'one-shot'

--- a/src/features/pr-review/components/DiffFile/DiffFile.tsx
+++ b/src/features/pr-review/components/DiffFile/DiffFile.tsx
@@ -76,7 +76,8 @@ export const DiffFile = ({
   )
 
   const language = useMemo(() => languageFor(file.filename), [file.filename])
-  const highlightLanguage = rows.length > 0 && rows.length <= MAX_HIGHLIGHT_ROWS ? language : undefined
+  const highlightLanguage =
+    rows.length > 0 && rows.length <= MAX_HIGHLIGHT_ROWS ? language : undefined
 
   const anchored = useMemo(() => {
     if (!parsed || parsed.kind !== 'rows') return null

--- a/src/features/pr-review/components/DiffFileHeader/DiffFileHeader.test.tsx
+++ b/src/features/pr-review/components/DiffFileHeader/DiffFileHeader.test.tsx
@@ -109,6 +109,38 @@ describe('DiffFileHeader', () => {
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
+  it('given onOpenFullFile is passed, then the button renders and fires it when clicked', async () => {
+    const onOpenFullFile = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <DiffFileHeader
+        file={given_file()}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        commentCount={0}
+        outdatedThreads={[]}
+        fileLevelThreads={[]}
+        onOpenFullFile={onOpenFullFile}
+      />
+    )
+    await user.click(screen.getByLabelText('View full file'))
+    expect(onOpenFullFile).toHaveBeenCalled()
+  })
+
+  it('given onOpenFullFile is not passed, then the button is absent', () => {
+    render(
+      <DiffFileHeader
+        file={given_file()}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        commentCount={0}
+        outdatedThreads={[]}
+        fileLevelThreads={[]}
+      />
+    )
+    expect(screen.queryByLabelText('View full file')).not.toBeInTheDocument()
+  })
+
   it('given outdated threads, when rendered, then the outdated panel is shown', () => {
     render(
       <DiffFileHeader

--- a/src/features/pr-review/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/src/features/pr-review/components/DiffFileHeader/DiffFileHeader.tsx
@@ -40,7 +40,9 @@ export const DiffFileHeader = ({
         {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         <span
           className="text-xs font-mono truncate flex-1"
-          title={file.previous_filename ? `${file.previous_filename} → ${file.filename}` : file.filename}
+          title={
+            file.previous_filename ? `${file.previous_filename} → ${file.filename}` : file.filename
+          }
         >
           {file.previous_filename ? `${file.previous_filename} → ${file.filename}` : file.filename}
         </span>

--- a/src/features/pr-review/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/src/features/pr-review/components/DiffFileHeader/DiffFileHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, MessageSquare } from 'lucide-react'
+import { ChevronDown, ChevronRight, MessageSquare, Maximize2 } from 'lucide-react'
 import { OutdatedThreadsPanel } from '../OutdatedThreadsPanel/OutdatedThreadsPanel'
 import type { PRFile, PRReviewThread } from '../../types'
 
@@ -19,6 +19,7 @@ type Props = {
   commentCount: number
   outdatedThreads: PRReviewThread[]
   fileLevelThreads: PRReviewThread[]
+  onOpenFullFile?: () => void
 }
 
 export const DiffFileHeader = ({
@@ -28,30 +29,46 @@ export const DiffFileHeader = ({
   commentCount,
   outdatedThreads,
   fileLevelThreads,
+  onOpenFullFile,
 }: Props) => (
   <div className="border-b border-[var(--color-border)]">
-    <button
-      onClick={onToggle}
-      className="w-full flex items-center gap-2 px-3 py-2 text-left cursor-pointer hover:bg-[var(--color-surface-overlay)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
-    >
-      {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-      <span className="text-xs font-mono truncate flex-1">
-        {file.previous_filename ? `${file.previous_filename} → ${file.filename}` : file.filename}
-      </span>
-      <span className="text-xs px-1.5 py-0.5 rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-muted)] shrink-0">
-        {STATUS_LABEL[file.status]}
-      </span>
-      <span className="text-xs font-mono shrink-0">
-        <span className="text-[var(--color-success)]">+{file.additions}</span>{' '}
-        <span className="text-[var(--color-danger)]">-{file.deletions}</span>
-      </span>
-      {commentCount > 0 && (
-        <span className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] shrink-0">
-          <MessageSquare size={12} />
-          {commentCount}
+    <div className="w-full flex items-center gap-2 px-3 py-2">
+      <button
+        onClick={onToggle}
+        className="flex-1 min-w-0 flex items-center gap-2 text-left cursor-pointer hover:bg-[var(--color-surface-overlay)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+      >
+        {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        <span
+          className="text-xs font-mono truncate flex-1"
+          title={file.previous_filename ? `${file.previous_filename} → ${file.filename}` : file.filename}
+        >
+          {file.previous_filename ? `${file.previous_filename} → ${file.filename}` : file.filename}
         </span>
+        <span className="text-xs px-1.5 py-0.5 rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-muted)] shrink-0">
+          {STATUS_LABEL[file.status]}
+        </span>
+        <span className="text-xs font-mono shrink-0">
+          <span className="text-[var(--color-success)]">+{file.additions}</span>{' '}
+          <span className="text-[var(--color-danger)]">-{file.deletions}</span>
+        </span>
+        {commentCount > 0 && (
+          <span className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] shrink-0">
+            <MessageSquare size={12} />
+            {commentCount}
+          </span>
+        )}
+      </button>
+      {onOpenFullFile && (
+        <button
+          onClick={onOpenFullFile}
+          aria-label="View full file"
+          title="View full file"
+          className="shrink-0 p-1 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+        >
+          <Maximize2 size={14} />
+        </button>
       )}
-    </button>
+    </div>
     {fileLevelThreads.length > 0 && (
       <div className="px-3 pb-2 space-y-2">
         {fileLevelThreads.map((thread) => (

--- a/src/features/pr-review/components/DiffFileList/DiffFileList.test.tsx
+++ b/src/features/pr-review/components/DiffFileList/DiffFileList.test.tsx
@@ -7,6 +7,7 @@ import { useViewerHandles } from '../../queries/useViewerHandles'
 import { useCreateThread } from '../../queries/useCreateThread'
 import { useReplyToThread } from '../../queries/useReplyToThread'
 import { useResolveThread } from '../../queries/useResolveThread'
+import { useFileBlob } from '../../queries/useFileBlob'
 import type { PRFile } from '../../types'
 
 vi.mock('../../queries/useCodeowners', () => ({ useCodeowners: vi.fn() }))
@@ -14,6 +15,7 @@ vi.mock('../../queries/useViewerHandles', () => ({ useViewerHandles: vi.fn() }))
 vi.mock('../../queries/useCreateThread', () => ({ useCreateThread: vi.fn() }))
 vi.mock('../../queries/useReplyToThread', () => ({ useReplyToThread: vi.fn() }))
 vi.mock('../../queries/useResolveThread', () => ({ useResolveThread: vi.fn() }))
+vi.mock('../../queries/useFileBlob', () => ({ useFileBlob: vi.fn() }))
 
 const mockUseCodeowners = vi.mocked(useCodeowners)
 const mockUseViewerHandles = vi.mocked(useViewerHandles)
@@ -35,6 +37,7 @@ beforeEach(() => {
   vi.mocked(useCreateThread).mockReturnValue(mutateMock())
   vi.mocked(useReplyToThread).mockReturnValue(mutateMock())
   vi.mocked(useResolveThread).mockReturnValue(mutateMock())
+  vi.mocked(useFileBlob).mockReturnValue({ data: undefined, isFetching: false } as never)
 })
 
 describe('DiffFileList', () => {
@@ -54,6 +57,7 @@ describe('DiffFileList', () => {
         prKey={prKey}
         pullRequestId="pr-1"
         baseRef="main"
+        headRefOid="abc123"
       />
     )
 
@@ -78,6 +82,7 @@ describe('DiffFileList', () => {
         prKey={prKey}
         pullRequestId="pr-1"
         baseRef="main"
+        headRefOid="abc123"
       />
     )
 

--- a/src/features/pr-review/components/DiffFileList/DiffFileList.tsx
+++ b/src/features/pr-review/components/DiffFileList/DiffFileList.tsx
@@ -16,6 +16,7 @@ type Props = {
   prKey: PRKey
   pullRequestId: string | null
   baseRef: string
+  headRefOid: string
   pendingReview?: PendingReview | null
 }
 
@@ -26,6 +27,7 @@ export const DiffFileList = ({
   prKey,
   pullRequestId,
   baseRef,
+  headRefOid,
   pendingReview = null,
 }: Props) => {
   const [expansion, setExpansion] = useState(() => computeInitialExpansion(files))
@@ -94,6 +96,7 @@ export const DiffFileList = ({
             prKey={prKey}
             pullRequestId={pullRequestId}
             pendingReview={pendingReview}
+            headRefOid={headRefOid}
           />
         ))}
         {filesTruncated && (

--- a/src/features/pr-review/components/DiffRowView/DiffRowView.test.tsx
+++ b/src/features/pr-review/components/DiffRowView/DiffRowView.test.tsx
@@ -47,4 +47,38 @@ describe('DiffRowView', () => {
     render(<DiffRowView row={row} language="typescript" />)
     expect(screen.getByText((_, el) => el?.textContent === 'const a = 1')).toBeInTheDocument()
   })
+
+  it('given an expand row with a known count, when rendered, then shows the line count', () => {
+    const row: DiffRow = {
+      type: 'expand',
+      content: '',
+      oldLine: null,
+      newLine: null,
+      expandCount: 5,
+    }
+    render(<DiffRowView row={row} />)
+    expect(screen.getByText('Expand 5 lines')).toBeInTheDocument()
+  })
+
+  it('given an expand row with no known count, when rendered, then shows the open-ended label', () => {
+    const row: DiffRow = { type: 'expand', content: '', oldLine: null, newLine: null, expandCount: null }
+    render(<DiffRowView row={row} />)
+    expect(screen.getByText('Expand down')).toBeInTheDocument()
+  })
+
+  it('given an expand row is clicked, then onExpand fires', async () => {
+    const onExpand = vi.fn()
+    const user = userEvent.setup()
+    const row: DiffRow = { type: 'expand', content: '', oldLine: null, newLine: null, expandCount: 3 }
+    render(<DiffRowView row={row} onExpand={onExpand} />)
+    await user.click(screen.getByRole('button'))
+    expect(onExpand).toHaveBeenCalled()
+  })
+
+  it('given an expand row is loading, then it shows a loading label and is disabled', () => {
+    const row: DiffRow = { type: 'expand', content: '', oldLine: null, newLine: null, expandCount: 3 }
+    render(<DiffRowView row={row} isExpanding />)
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
 })

--- a/src/features/pr-review/components/DiffRowView/DiffRowView.test.tsx
+++ b/src/features/pr-review/components/DiffRowView/DiffRowView.test.tsx
@@ -61,7 +61,13 @@ describe('DiffRowView', () => {
   })
 
   it('given an expand row with no known count, when rendered, then shows the open-ended label', () => {
-    const row: DiffRow = { type: 'expand', content: '', oldLine: null, newLine: null, expandCount: null }
+    const row: DiffRow = {
+      type: 'expand',
+      content: '',
+      oldLine: null,
+      newLine: null,
+      expandCount: null,
+    }
     render(<DiffRowView row={row} />)
     expect(screen.getByText('Expand down')).toBeInTheDocument()
   })
@@ -69,14 +75,26 @@ describe('DiffRowView', () => {
   it('given an expand row is clicked, then onExpand fires', async () => {
     const onExpand = vi.fn()
     const user = userEvent.setup()
-    const row: DiffRow = { type: 'expand', content: '', oldLine: null, newLine: null, expandCount: 3 }
+    const row: DiffRow = {
+      type: 'expand',
+      content: '',
+      oldLine: null,
+      newLine: null,
+      expandCount: 3,
+    }
     render(<DiffRowView row={row} onExpand={onExpand} />)
     await user.click(screen.getByRole('button'))
     expect(onExpand).toHaveBeenCalled()
   })
 
   it('given an expand row is loading, then it shows a loading label and is disabled', () => {
-    const row: DiffRow = { type: 'expand', content: '', oldLine: null, newLine: null, expandCount: 3 }
+    const row: DiffRow = {
+      type: 'expand',
+      content: '',
+      oldLine: null,
+      newLine: null,
+      expandCount: 3,
+    }
     render(<DiffRowView row={row} isExpanding />)
     expect(screen.getByText('Loading…')).toBeInTheDocument()
     expect(screen.getByRole('button')).toBeDisabled()

--- a/src/features/pr-review/components/DiffRowView/DiffRowView.tsx
+++ b/src/features/pr-review/components/DiffRowView/DiffRowView.tsx
@@ -1,4 +1,4 @@
-import { Plus } from 'lucide-react'
+import { MoreHorizontal, Plus } from 'lucide-react'
 import { Highlight, type Language } from 'prism-react-renderer'
 import type { DiffRow } from '../../types'
 
@@ -6,6 +6,8 @@ type Props = {
   row: DiffRow
   onAddComment?: () => void
   language?: Language
+  onExpand?: () => void
+  isExpanding?: boolean
 }
 
 const TOKEN_CLASS: Record<string, string> = {
@@ -38,17 +40,42 @@ const ROW_BG: Record<DiffRow['type'], string> = {
   add: 'bg-[var(--color-success-subtle)]',
   del: 'bg-[var(--color-danger-subtle)]',
   context: '',
+  expand: '',
 }
 
-const SIGN: Record<DiffRow['type'], string> = { hunk: '', add: '+', del: '-', context: ' ' }
+const SIGN: Record<DiffRow['type'], string> = {
+  hunk: '',
+  add: '+',
+  del: '-',
+  context: ' ',
+  expand: '',
+}
 
-export const DiffRowView = ({ row, onAddComment, language }: Props) => {
+export const DiffRowView = ({ row, onAddComment, language, onExpand, isExpanding }: Props) => {
   if (row.type === 'hunk') {
     return (
       <div className={`px-2 py-0.5 text-xs font-mono ${ROW_BG.hunk}`}>
         {row.content}
         {row.noNewline && <span className="italic"> (no newline at end of file)</span>}
       </div>
+    )
+  }
+
+  if (row.type === 'expand') {
+    const label = isExpanding
+      ? 'Loading…'
+      : row.expandCount == null
+        ? 'Expand down'
+        : `Expand ${row.expandCount} line${row.expandCount === 1 ? '' : 's'}`
+    return (
+      <button
+        onClick={onExpand}
+        disabled={isExpanding}
+        className="w-full flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-[var(--color-text-muted)] hover:bg-[var(--color-surface-overlay)] hover:text-[var(--color-text-secondary)] cursor-pointer disabled:cursor-wait focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+      >
+        <MoreHorizontal size={12} />
+        {label}
+      </button>
     )
   }
 

--- a/src/features/pr-review/components/FileTree/FileTree.tsx
+++ b/src/features/pr-review/components/FileTree/FileTree.tsx
@@ -33,7 +33,9 @@ export const FileTree = ({ nodes, onSelectFile }: Props) => {
               ) : (
                 <ChevronDown size={12} className="shrink-0" />
               )}
-              <span className="truncate">{node.name}</span>
+              <span className="truncate" title={node.path}>
+                {node.name}
+              </span>
             </button>
             {!isCollapsed && (
               <div className="ml-2 pl-2 border-l border-[var(--color-border-subtle)]">
@@ -51,7 +53,9 @@ export const FileTree = ({ nodes, onSelectFile }: Props) => {
           className="flex items-center gap-1 w-full text-left text-xs px-2 py-1 rounded cursor-pointer text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
         >
           <FileText size={12} className="shrink-0 text-[var(--color-text-muted)]" />
-          <span className="truncate flex-1">{node.name}</span>
+          <span className="truncate flex-1" title={node.file.filename}>
+            {node.name}
+          </span>
           <span className="shrink-0 font-mono">
             <span className="text-[var(--color-success)]">+{node.file.additions}</span>{' '}
             <span className="text-[var(--color-danger)]">-{node.file.deletions}</span>

--- a/src/features/pr-review/components/FullFileModal/FullFileModal.test.tsx
+++ b/src/features/pr-review/components/FullFileModal/FullFileModal.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FullFileModal } from './FullFileModal'
+import type { DiffRow } from '../../types'
+
+const rows: DiffRow[] = [
+  { type: 'context', content: 'line1', oldLine: 1, newLine: 1 },
+  { type: 'del', content: 'old line2', oldLine: 2, newLine: null },
+  { type: 'add', content: 'new line2', oldLine: null, newLine: 2 },
+]
+
+describe('FullFileModal', () => {
+  it('given rows, when open, then renders them', () => {
+    render(
+      <FullFileModal
+        isOpen
+        onClose={vi.fn()}
+        filename="src/foo.ts"
+        blobUrl="https://github.com/o/r/blob/abc/src/foo.ts"
+        rows={rows}
+        truncated={false}
+        isLoading={false}
+      />
+    )
+    expect(screen.getByText('line1')).toBeInTheDocument()
+    expect(screen.getByText('new line2')).toBeInTheDocument()
+  })
+
+  it('given isLoading, then shows a loading message instead of rows', () => {
+    render(
+      <FullFileModal
+        isOpen
+        onClose={vi.fn()}
+        filename="src/foo.ts"
+        blobUrl="https://github.com/o/r/blob/abc/src/foo.ts"
+        rows={[]}
+        truncated={false}
+        isLoading={true}
+      />
+    )
+    expect(screen.getByText('Loading file…')).toBeInTheDocument()
+  })
+
+  it('given truncated, then shows the truncation notice with a link to GitHub', () => {
+    render(
+      <FullFileModal
+        isOpen
+        onClose={vi.fn()}
+        filename="src/foo.ts"
+        blobUrl="https://github.com/o/r/blob/abc/src/foo.ts"
+        rows={rows}
+        truncated={true}
+        isLoading={false}
+      />
+    )
+    expect(screen.getByText(/truncated view/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open file on GitHub' })).toHaveAttribute(
+      'href',
+      'https://github.com/o/r/blob/abc/src/foo.ts'
+    )
+  })
+
+  it('given the close button is clicked, then onClose fires', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FullFileModal
+        isOpen
+        onClose={onClose}
+        filename="src/foo.ts"
+        blobUrl="https://github.com/o/r/blob/abc/src/foo.ts"
+        rows={rows}
+        truncated={false}
+        isLoading={false}
+      />
+    )
+    await user.click(screen.getByLabelText('Close src/foo.ts'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/features/pr-review/components/FullFileModal/FullFileModal.tsx
+++ b/src/features/pr-review/components/FullFileModal/FullFileModal.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useMemo, useRef } from 'react'
+import type { Language } from 'prism-react-renderer'
+import { Modal } from '@/shared/components/ui/Modal'
+import { DiffRowView } from '../DiffRowView/DiffRowView'
+import { MAX_HIGHLIGHT_ROWS } from '../../lib/expandContext'
+import type { DiffRow } from '../../types'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+  filename: string
+  blobUrl: string
+  rows: DiffRow[]
+  truncated: boolean
+  language?: Language
+  isLoading: boolean
+}
+
+export const FullFileModal = ({
+  isOpen,
+  onClose,
+  filename,
+  blobUrl,
+  rows,
+  truncated,
+  language,
+  isLoading,
+}: Props) => {
+  const firstChangeRef = useRef<HTMLDivElement>(null)
+  const firstChangeIndex = useMemo(
+    () => rows.findIndex((r) => r.type === 'add' || r.type === 'del'),
+    [rows]
+  )
+
+  useEffect(() => {
+    if (isOpen) firstChangeRef.current?.scrollIntoView?.({ block: 'center' })
+  }, [isOpen, firstChangeIndex])
+
+  const highlightLanguage =
+    rows.length > 0 && rows.length <= MAX_HIGHLIGHT_ROWS ? language : undefined
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={filename}
+      size="full"
+      actions={
+        <a
+          href={blobUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-[var(--color-accent)] hover:underline"
+        >
+          Open on GitHub
+        </a>
+      }
+    >
+      {isLoading ? (
+        <p className="px-3 py-4 text-xs text-[var(--color-text-muted)]">Loading file…</p>
+      ) : (
+        <div>
+          {rows.map((row, i) => (
+            <div key={i} ref={i === firstChangeIndex ? firstChangeRef : undefined}>
+              <DiffRowView row={row} language={highlightLanguage} />
+            </div>
+          ))}
+          {truncated && (
+            <p className="px-3 py-2 text-xs text-[var(--color-text-muted)] border-t border-[var(--color-border)]">
+              Showing a truncated view of this file.{' '}
+              <a
+                href={blobUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--color-accent)] hover:underline"
+              >
+                Open file on GitHub
+              </a>
+            </p>
+          )}
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/src/features/pr-review/components/PRDetailHeader/PRDetailHeader.test.tsx
+++ b/src/features/pr-review/components/PRDetailHeader/PRDetailHeader.test.tsx
@@ -21,6 +21,7 @@ const pr: PRDetailMeta = {
   updatedAt: '2024-01-02T00:00:00Z',
   baseRefName: 'main',
   headRefName: 'fix-the-thing',
+  headRefOid: 'abc123',
   author: { login: 'alice', avatarUrl: '' },
   repository: { name: 'repo', nameWithOwner: 'org/repo', url: '' },
 }

--- a/src/features/pr-review/components/PRDetailPage/PRDetailPage.tsx
+++ b/src/features/pr-review/components/PRDetailPage/PRDetailPage.tsx
@@ -73,6 +73,7 @@ export const PRDetailPage = () => {
               prKey={prKey}
               pullRequestId={threadsData.pr.id}
               baseRef={threadsData.pr.baseRefName}
+              headRefOid={threadsData.pr.headRefOid}
               pendingReview={threadsData.pendingReview}
             />
           )}

--- a/src/features/pr-review/lib/expandContext.test.ts
+++ b/src/features/pr-review/lib/expandContext.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { expandGapId, mergeExpandedContext, buildFullFileRows } from './expandContext'
+import type { DiffRow } from '../types'
+
+const given_gap = (overrides: Partial<DiffRow> = {}): DiffRow => ({
+  type: 'expand',
+  content: '',
+  oldLine: null,
+  newLine: null,
+  expandCount: null,
+  expandAfterOldLine: 0,
+  expandAfterNewLine: 0,
+  ...overrides,
+})
+
+describe('expandGapId', () => {
+  it('given two gaps at different anchors, then their ids differ', () => {
+    const a = given_gap({ expandAfterNewLine: 2 })
+    const b = given_gap({ expandAfterNewLine: 5 })
+    expect(expandGapId(a)).not.toBe(expandGapId(b))
+  })
+})
+
+describe('mergeExpandedContext', () => {
+  const rows: DiffRow[] = [
+    { type: 'hunk', content: '@@ -10,1 +10,1 @@', oldLine: null, newLine: null },
+    given_gap({ expandCount: 9, expandAfterOldLine: 0, expandAfterNewLine: 0 }),
+    { type: 'context', content: 'line10', oldLine: 10, newLine: 10 },
+  ]
+  const blobLines = Array.from({ length: 15 }, (_, i) => `line${i + 1}`)
+
+  it('given no blob loaded, then the expand row is left untouched', () => {
+    const actual = mergeExpandedContext(rows, undefined, new Set([expandGapId(rows[1])]))
+    expect(actual).toEqual(rows)
+  })
+
+  it('given a gap not in the expanded set, then it is left untouched', () => {
+    const actual = mergeExpandedContext(rows, blobLines, new Set())
+    expect(actual).toEqual(rows)
+  })
+
+  it('given a known-count gap in the expanded set, then it is replaced with the right context rows', () => {
+    const actual = mergeExpandedContext(rows, blobLines, new Set([expandGapId(rows[1])]))
+    expect(actual).toHaveLength(rows.length - 1 + 9)
+    expect(actual[1]).toEqual({ type: 'context', content: 'line1', oldLine: 1, newLine: 1 })
+    expect(actual[9]).toEqual({ type: 'context', content: 'line9', oldLine: 9, newLine: 9 })
+    expect(actual[10]).toEqual(rows[2])
+  })
+
+  it('given an open-ended gap, then it expands through the end of the blob', () => {
+    const openGap = given_gap({ expandCount: null, expandAfterOldLine: 12, expandAfterNewLine: 12 })
+    const actual = mergeExpandedContext([openGap], blobLines, new Set([expandGapId(openGap)]))
+    expect(actual).toEqual([
+      { type: 'context', content: 'line13', oldLine: 13, newLine: 13 },
+      { type: 'context', content: 'line14', oldLine: 14, newLine: 14 },
+      { type: 'context', content: 'line15', oldLine: 15, newLine: 15 },
+    ])
+  })
+})
+
+describe('buildFullFileRows', () => {
+  const rows: DiffRow[] = [
+    { type: 'hunk', content: '@@ -10,1 +10,1 @@', oldLine: null, newLine: null },
+    given_gap({ expandCount: 9, expandAfterOldLine: 0, expandAfterNewLine: 0 }),
+    { type: 'del', content: 'old line10', oldLine: 10, newLine: null },
+    { type: 'add', content: 'line10', oldLine: null, newLine: 10 },
+  ]
+  const blobLines = Array.from({ length: 15 }, (_, i) => `line${i + 1}`)
+
+  it('given no blob loaded, then it returns no rows and is not truncated', () => {
+    expect(buildFullFileRows(rows, undefined)).toEqual({ rows: [], truncated: false })
+  })
+
+  it('given a blob, then every gap is expanded and hunk markers are dropped', () => {
+    const actual = buildFullFileRows(rows, blobLines)
+    expect(actual.truncated).toBe(false)
+    expect(actual.rows.some((r) => r.type === 'hunk')).toBe(false)
+    expect(actual.rows[0]).toEqual({ type: 'context', content: 'line1', oldLine: 1, newLine: 1 })
+    expect(actual.rows.at(-1)).toEqual(rows.at(-1))
+  })
+
+  it('given more merged rows than the cap, then the result is truncated', () => {
+    const openGap = given_gap({ expandCount: null, expandAfterOldLine: 0, expandAfterNewLine: 0 })
+    const hugeBlobLines = Array.from({ length: 5001 }, (_, i) => `line${i + 1}`)
+    const actual = buildFullFileRows([openGap], hugeBlobLines)
+    expect(actual.truncated).toBe(true)
+    expect(actual.rows).toHaveLength(5000)
+  })
+})

--- a/src/features/pr-review/lib/expandContext.ts
+++ b/src/features/pr-review/lib/expandContext.ts
@@ -1,0 +1,49 @@
+import type { DiffRow } from '../types'
+
+// ponytail: tokenizing thousands of rows on expand janks the frame — big files render plain.
+export const MAX_HIGHLIGHT_ROWS = 500
+// ponytail: caps a huge generated file from janking the modal; same truncation-notice pattern as
+// parsePatch's existing `truncated` flag.
+const MAX_FULL_FILE_ROWS = 5000
+
+export const expandGapId = (row: DiffRow): string => `expand-${row.expandAfterNewLine ?? 0}`
+
+// Replaces each expanded 'expand' row with the real context rows it stood in for, sliced out of
+// the head-side file blob. Old/new line numbers are derived from the gap's anchors since an
+// unchanged run of lines advances both cursors together.
+export const mergeExpandedContext = (
+  rows: DiffRow[],
+  blobLines: string[] | undefined,
+  expandedGapIds: Set<string>
+): DiffRow[] => {
+  if (!blobLines) return rows
+
+  return rows.flatMap((row): DiffRow[] => {
+    if (row.type !== 'expand' || !expandedGapIds.has(expandGapId(row))) return [row]
+
+    const afterOld = row.expandAfterOldLine ?? 0
+    const afterNew = row.expandAfterNewLine ?? 0
+    const count = Math.max(0, row.expandCount ?? blobLines.length - afterNew)
+
+    return Array.from({ length: count }, (_, i) => ({
+      type: 'context',
+      content: blobLines[afterNew + i] ?? '',
+      oldLine: afterOld + i + 1,
+      newLine: afterNew + i + 1,
+    }))
+  })
+}
+
+// Expands every gap at once and drops the now-redundant hunk markers, turning the row list into
+// "the whole file, diff inline".
+export const buildFullFileRows = (
+  rows: DiffRow[],
+  blobLines: string[] | undefined
+): { rows: DiffRow[]; truncated: boolean } => {
+  if (!blobLines) return { rows: [], truncated: false }
+  const allGapIds = new Set(rows.filter((r) => r.type === 'expand').map(expandGapId))
+  const merged = mergeExpandedContext(rows, blobLines, allGapIds).filter((r) => r.type !== 'hunk')
+  return merged.length <= MAX_FULL_FILE_ROWS
+    ? { rows: merged, truncated: false }
+    : { rows: merged.slice(0, MAX_FULL_FILE_ROWS), truncated: true }
+}

--- a/src/features/pr-review/lib/parsePatch.test.ts
+++ b/src/features/pr-review/lib/parsePatch.test.ts
@@ -31,6 +31,15 @@ describe('parsePatch', () => {
         { type: 'hunk', content: '@@ -1,2 +1,2 @@', oldLine: null, newLine: null },
         { type: 'context', content: 'a', oldLine: 1, newLine: 1 },
         { type: 'context', content: 'b', oldLine: 2, newLine: 2 },
+        {
+          type: 'expand',
+          content: '',
+          oldLine: null,
+          newLine: null,
+          expandCount: null,
+          expandAfterOldLine: 2,
+          expandAfterNewLine: 2,
+        },
       ],
     })
   })
@@ -39,7 +48,7 @@ describe('parsePatch', () => {
     const actual = parsePatch('@@ -1,0 +1,2 @@\n+a\n+b')
     expect(actual.kind).toBe('rows')
     if (actual.kind !== 'rows') return
-    expect(actual.rows.slice(1)).toEqual([
+    expect(actual.rows.slice(1, 3)).toEqual([
       { type: 'add', content: 'a', oldLine: null, newLine: 1 },
       { type: 'add', content: 'b', oldLine: null, newLine: 2 },
     ])
@@ -49,7 +58,7 @@ describe('parsePatch', () => {
     const actual = parsePatch('@@ -1,2 +1,0 @@\n-a\n-b')
     expect(actual.kind).toBe('rows')
     if (actual.kind !== 'rows') return
-    expect(actual.rows.slice(1)).toEqual([
+    expect(actual.rows.slice(1, 3)).toEqual([
       { type: 'del', content: 'a', oldLine: 1, newLine: null },
       { type: 'del', content: 'b', oldLine: 2, newLine: null },
     ])
@@ -66,6 +75,7 @@ describe('parsePatch', () => {
       ['del', 2, null],
       ['add', null, 2],
       ['context', 3, 3],
+      ['expand', null, null],
     ])
   })
 
@@ -80,7 +90,7 @@ describe('parsePatch', () => {
     const actual = parsePatch('@@ -10,7 +10,7 @@ export const foo = () => {\n a')
     expect(actual.kind).toBe('rows')
     if (actual.kind !== 'rows') return
-    expect(actual.rows[0]).toEqual({
+    expect(actual.rows[1]).toEqual({
       type: 'hunk',
       content: '@@ -10,7 +10,7 @@ export const foo = () => {',
       oldLine: null,
@@ -95,8 +105,10 @@ describe('parsePatch', () => {
     expect(actual.rows.map((r) => [r.type, r.oldLine, r.newLine])).toEqual([
       ['hunk', null, null],
       ['context', 1, 1],
+      ['expand', null, null],
       ['hunk', null, null],
       ['context', 90, 90],
+      ['expand', null, null],
     ])
   })
 
@@ -104,7 +116,7 @@ describe('parsePatch', () => {
     const actual = parsePatch('@@ -1,0 +1,1 @@\n+a\n\\ No newline at end of file')
     expect(actual.kind).toBe('rows')
     if (actual.kind !== 'rows') return
-    expect(actual.rows).toHaveLength(2)
+    expect(actual.rows).toHaveLength(3)
     expect(actual.rows[1]).toEqual({
       type: 'add',
       content: 'a',
@@ -133,7 +145,7 @@ describe('parsePatch', () => {
     const actual = parsePatch('@@ -1,1 +1,1 @@\n a\n')
     expect(actual.kind).toBe('rows')
     if (actual.kind !== 'rows') return
-    expect(actual.rows).toHaveLength(2)
+    expect(actual.rows).toHaveLength(3)
   })
 
   it('given garbage lines before the first hunk, when parsed, then they are skipped without throwing', () => {
@@ -142,17 +154,80 @@ describe('parsePatch', () => {
     )
     expect(actual.kind).toBe('rows')
     if (actual.kind !== 'rows') return
-    expect(actual.rows).toHaveLength(2)
+    expect(actual.rows).toHaveLength(3)
     expect(actual.rows[0].type).toBe('hunk')
   })
 
-  it('given a patch exceeding the row cap, when parsed, then it truncates', () => {
+  it('given a patch exceeding the row cap, when parsed, then it truncates and adds no trailing gap', () => {
     const body = Array.from({ length: 2500 }, (_, i) => ` line${i}`).join('\n')
     const actual = parsePatch(`@@ -1,2500 +1,2500 @@\n${body}`)
     expect(actual.kind).toBe('rows')
     if (actual.kind !== 'rows') return
     expect(actual.rows).toHaveLength(2000)
     expect(actual.truncated).toBe(true)
+  })
+
+  it('given a hunk that starts after line 1, when parsed, then a top expand gap is inserted', () => {
+    const actual = parsePatch('@@ -10,1 +10,1 @@\n a')
+    expect(actual.kind).toBe('rows')
+    if (actual.kind !== 'rows') return
+    expect(actual.rows[0]).toEqual({
+      type: 'expand',
+      content: '',
+      oldLine: null,
+      newLine: null,
+      expandCount: 9,
+      expandAfterOldLine: 0,
+      expandAfterNewLine: 0,
+    })
+    expect(actual.rows[1].type).toBe('hunk')
+  })
+
+  it('given a hunk that starts at line 1, when parsed, then no top expand gap is inserted', () => {
+    const actual = parsePatch('@@ -1,1 +1,1 @@\n a')
+    expect(actual.kind).toBe('rows')
+    if (actual.kind !== 'rows') return
+    expect(actual.rows[0].type).toBe('hunk')
+  })
+
+  it('given two hunks with a gap between them, when parsed, then the gap expand row has the right count and anchors', () => {
+    const actual = parsePatch('@@ -1,2 +1,2 @@\n a\n b\n@@ -20,1 +20,1 @@\n c')
+    expect(actual.kind).toBe('rows')
+    if (actual.kind !== 'rows') return
+    const gap = actual.rows.find(
+      (r, i) => r.type === 'expand' && i !== actual.rows.length - 1
+    )
+    expect(gap).toEqual({
+      type: 'expand',
+      content: '',
+      oldLine: null,
+      newLine: null,
+      expandCount: 17,
+      expandAfterOldLine: 2,
+      expandAfterNewLine: 2,
+    })
+  })
+
+  it('given adjacent hunks with no gap between them, when parsed, then no expand row is inserted between them', () => {
+    const actual = parsePatch('@@ -1,1 +1,1 @@\n a\n@@ -2,1 +2,1 @@\n b')
+    expect(actual.kind).toBe('rows')
+    if (actual.kind !== 'rows') return
+    expect(actual.rows.map((r) => r.type)).toEqual(['hunk', 'context', 'hunk', 'context', 'expand'])
+  })
+
+  it('given a hunk, when parsed, then a bottom expand gap with unknown count is appended', () => {
+    const actual = parsePatch('@@ -1,1 +1,1 @@\n a')
+    expect(actual.kind).toBe('rows')
+    if (actual.kind !== 'rows') return
+    expect(actual.rows[actual.rows.length - 1]).toEqual({
+      type: 'expand',
+      content: '',
+      oldLine: null,
+      newLine: null,
+      expandCount: null,
+      expandAfterOldLine: 1,
+      expandAfterNewLine: 1,
+    })
   })
 })
 

--- a/src/features/pr-review/lib/parsePatch.test.ts
+++ b/src/features/pr-review/lib/parsePatch.test.ts
@@ -194,9 +194,7 @@ describe('parsePatch', () => {
     const actual = parsePatch('@@ -1,2 +1,2 @@\n a\n b\n@@ -20,1 +20,1 @@\n c')
     expect(actual.kind).toBe('rows')
     if (actual.kind !== 'rows') return
-    const gap = actual.rows.find(
-      (r, i) => r.type === 'expand' && i !== actual.rows.length - 1
-    )
+    const gap = actual.rows.find((r, i) => r.type === 'expand' && i !== actual.rows.length - 1)
     expect(gap).toEqual({
       type: 'expand',
       content: '',

--- a/src/features/pr-review/lib/parsePatch.ts
+++ b/src/features/pr-review/lib/parsePatch.ts
@@ -12,10 +12,23 @@ export const parsePatch = (patch: string | undefined): ParsedPatch => {
   if (lines[lines.length - 1] === '') lines.pop()
 
   const rows: DiffRow[] = []
-  let oldCursor = 0
-  let newCursor = 0
+  // start at 1 (not 0) so the gap before the first hunk is detected the same way as any other:
+  // "next line to show" defaults to the top of the file
+  let oldCursor = 1
+  let newCursor = 1
   let truncated = false
   let sawHunk = false
+
+  const pushExpandGap = (count: number | null) =>
+    rows.push({
+      type: 'expand',
+      content: '',
+      oldLine: null,
+      newLine: null,
+      expandCount: count,
+      expandAfterOldLine: oldCursor - 1,
+      expandAfterNewLine: newCursor - 1,
+    })
 
   for (const line of lines) {
     if (rows.length >= MAX_ROWS_PER_FILE) {
@@ -25,8 +38,11 @@ export const parsePatch = (patch: string | undefined): ParsedPatch => {
 
     const hunkMatch = HUNK_RE.exec(line)
     if (hunkMatch) {
+      const newStart = Number(hunkMatch[3])
+      const gap = newStart - newCursor
+      if (gap > 0) pushExpandGap(gap)
       oldCursor = Number(hunkMatch[1])
-      newCursor = Number(hunkMatch[3])
+      newCursor = newStart
       rows.push({ type: 'hunk', content: line, oldLine: null, newLine: null })
       sawHunk = true
       continue
@@ -60,6 +76,8 @@ export const parsePatch = (patch: string | undefined): ParsedPatch => {
     }
     // garbage before the first hunk (diff --git / index / --- / +++ preambles) — skip
   }
+
+  if (sawHunk && !truncated) pushExpandGap(null)
 
   return { kind: 'rows', rows, truncated }
 }

--- a/src/features/pr-review/lib/queryKeys.ts
+++ b/src/features/pr-review/lib/queryKeys.ts
@@ -3,3 +3,5 @@ import type { PRKey } from '../types'
 export const prThreadsKey = (k: PRKey) => ['pr-threads', k.owner, k.repo, k.number] as const
 export const prFilesKey = (k: PRKey) => ['pr-files', k.owner, k.repo, k.number] as const
 export const codeownersKey = (k: PRKey) => ['pr-codeowners', k.owner, k.repo, k.number] as const
+export const fileBlobKey = (k: PRKey, headRefOid: string, path: string) =>
+  ['pr-file-blob', k.owner, k.repo, headRefOid, path] as const

--- a/src/features/pr-review/queries/useFileBlob.ts
+++ b/src/features/pr-review/queries/useFileBlob.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query'
+import { createClient, PR_FILE_BLOB_QUERY } from '@/providers/github'
+import { useAuthStore } from '@/features/auth/stores/authStore'
+import { fileBlobKey } from '../lib/queryKeys'
+import type { PRKey } from '../types'
+
+type BlobResponse = {
+  repository: { object: { text: string; isBinary: boolean } | null } | null
+}
+
+export type FileBlob = { lines: string[] }
+
+const fetchFileBlob = async (key: PRKey, headRefOid: string, path: string): Promise<FileBlob> => {
+  const client = createClient()
+  const data = await client.request<BlobResponse>(PR_FILE_BLOB_QUERY, {
+    owner: key.owner,
+    name: key.repo,
+    expression: `${headRefOid}:${path}`,
+  })
+  const object = data.repository?.object
+  if (!object || object.isBinary) return { lines: [] }
+  return { lines: object.text.split('\n') }
+}
+
+export const useFileBlob = (key: PRKey, headRefOid: string, path: string, enabled: boolean) => {
+  const token = useAuthStore((s) => s.token)
+
+  return useQuery<FileBlob>({
+    queryKey: fileBlobKey(key, headRefOid, path),
+    enabled: !!token && !!headRefOid && enabled,
+    staleTime: Infinity, // content at a fixed commit oid never changes
+    queryFn: () => fetchFileBlob(key, headRefOid, path),
+  })
+}

--- a/src/features/pr-review/types.ts
+++ b/src/features/pr-review/types.ts
@@ -16,7 +16,7 @@ export type PRFile = {
 }
 
 export type DiffSide = 'LEFT' | 'RIGHT'
-export type DiffRowType = 'hunk' | 'context' | 'add' | 'del'
+export type DiffRowType = 'hunk' | 'context' | 'add' | 'del' | 'expand'
 
 export type DiffRow = {
   type: DiffRowType
@@ -25,6 +25,12 @@ export type DiffRow = {
   oldLine: number | null // base-side (LEFT) line number
   newLine: number | null // head-side (RIGHT) line number
   noNewline?: true // a '\ No newline at end of file' marker followed this row
+  // 'expand' rows only: collapsed-context gap. count is null for the open-ended gap after the
+  // last hunk (unknown until the file blob loads); afterOldLine/afterNewLine are the last line
+  // numbers already shown before the gap (0 if the gap starts at the top of the file)
+  expandCount?: number | null
+  expandAfterOldLine?: number
+  expandAfterNewLine?: number
 }
 
 export type ParsedPatch =
@@ -74,6 +80,7 @@ export type PRDetailMeta = {
   updatedAt: string
   baseRefName: string
   headRefName: string
+  headRefOid: string
   author: { login: string; avatarUrl: string } | null
   repository: { name: string; nameWithOwner: string; url: string }
   commits?: { nodes: { commit: { statusCheckRollup: { state: CheckRollupState } | null } }[] }

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -172,6 +172,7 @@ export const PR_REVIEW_THREADS_QUERY = /* GraphQL */ `
         updatedAt
         baseRefName
         headRefName
+        headRefOid
         author {
           login
           avatarUrl
@@ -343,6 +344,19 @@ export const VIEWER_TEAMS_QUERY = /* GraphQL */ `
       teams(first: 100, userLogins: [$login]) {
         nodes {
           combinedSlug
+        }
+      }
+    }
+  }
+`
+
+export const PR_FILE_BLOB_QUERY = /* GraphQL */ `
+  query GetFileBlob($owner: String!, $name: String!, $expression: String!) {
+    repository(owner: $owner, name: $name) {
+      object(expression: $expression) {
+        ... on Blob {
+          text
+          isBinary
         }
       }
     }

--- a/src/shared/components/ui/Modal.test.tsx
+++ b/src/shared/components/ui/Modal.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Modal } from './Modal'
+
+describe('Modal', () => {
+  it('given Escape is pressed, then onClose fires', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Modal isOpen title="Test" onClose={onClose}>
+        content
+      </Modal>
+    )
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('given size is full, then the dialog gets the full-screen classes', () => {
+    const { baseElement } = render(
+      <Modal isOpen title="Test" onClose={vi.fn()} size="full">
+        content
+      </Modal>
+    )
+    expect(baseElement.querySelector('.pointer-events-auto')?.className).toContain('w-[92vw]')
+  })
+
+  it('given size is omitted, then the dialog keeps the default classes', () => {
+    const { baseElement } = render(
+      <Modal isOpen title="Test" onClose={vi.fn()}>
+        content
+      </Modal>
+    )
+    expect(baseElement.querySelector('.pointer-events-auto')?.className).toContain('max-w-xl')
+  })
+})

--- a/src/shared/components/ui/Modal.tsx
+++ b/src/shared/components/ui/Modal.tsx
@@ -8,16 +8,35 @@ type Props = PropsWithChildren & {
   onClose: () => void
   className?: string
   actions?: ReactNode
+  size?: 'default' | 'full'
 }
 
-export const Modal = ({ children, isOpen, title, onClose, className, actions }: Props) => {
+const SIZE_CLASS: Record<'default' | 'full', string> = {
+  default: 'max-w-xl max-h-[80vh]',
+  full: 'w-[92vw] h-[88vh] max-w-none',
+}
+
+export const Modal = ({
+  children,
+  isOpen,
+  title,
+  onClose,
+  className,
+  actions,
+  size = 'default',
+}: Props) => {
   useEffect(() => {
     if (!isOpen) return
     document.body.style.overflow = 'hidden'
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
     return () => {
       document.body.style.overflow = ''
+      document.removeEventListener('keydown', onKeyDown)
     }
-  }, [isOpen])
+  }, [isOpen, onClose])
 
   if (!isOpen) return null
 
@@ -34,7 +53,7 @@ export const Modal = ({ children, isOpen, title, onClose, className, actions }: 
       <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
         <div
           onClick={(e) => e.stopPropagation()}
-          className={`pointer-events-auto max-w-xl max-h-[80vh] overflow-y-auto rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-surface)] shadow-lg p-4 space-y-4 ${className ?? ''}`}
+          className={`pointer-events-auto ${SIZE_CLASS[size]} overflow-y-auto rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-surface)] text-[var(--color-text-primary)] shadow-lg p-4 space-y-4 ${className ?? ''}`}
         >
           <div className="flex items-center justify-between gap-4">
             <p className="text-sm font-semibold text-[var(--color-text-primary)] truncate">


### PR DESCRIPTION
## Summary
- Click a collapsed-context gap in a diff to expand it inline, fetched lazily from the head-ref blob.
- Open a full-file modal that merges the diff into the whole file (with a truncation cap for huge files).
- Both share `expandContext.ts` row-merging logic and a new `useFileBlob` query (`PR_FILE_BLOB_QUERY`) keyed on `headRefOid` (now fetched in `PR_REVIEW_THREADS_QUERY`).
- `Modal` gains a `size="full"` variant and closes on Escape.
- Fixes the comment composer defaulting to one-shot mode even when a review is pending, instead of following the pending review.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (396 tests passing, incl. new coverage for `expandContext`, `useFileBlob`, `FullFileModal`, expand rows, full-file button)
- [x] `npm run build`
- [ ] Manual click-through in Electron app (expand gap, open full file, confirm comment composer mode)