### PR TITLE
feat: show drafts by default in My PRs tab

### DIFF
--- a/src/features/pull-requests/stores/prStore.test.ts
+++ b/src/features/pull-requests/stores/prStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { usePRStore } from './prStore'
 
 beforeEach(() => {
@@ -162,6 +162,15 @@ describe('prStore', () => {
   it('dismissDonnaPRViewHint sets the dismissed flag', () => {
     usePRStore.getState().dismissDonnaPRViewHint()
     expect(usePRStore.getState().donnaPRViewHintDismissed).toBe(true)
+  })
+
+  it('authored view defaults showDrafts to true, other sections default to false', async () => {
+    localStorage.clear()
+    vi.resetModules()
+    const { usePRStore: freshStore } = await import('./prStore')
+    expect(freshStore.getState().viewFilters.authored.showDrafts).toBe(true)
+    expect(freshStore.getState().viewFilters['review-requested'].showDrafts).toBe(false)
+    expect(freshStore.getState().viewFilters.mentioned.showDrafts).toBe(false)
   })
 
   it('persisted merge restores openPRsInDonna and donnaPRViewHintDismissed', () => {

--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -57,7 +57,7 @@ const defaultGlobalFilters: GlobalFilters = {
 
 const defaultViewFiltersAll: Record<PRSection, ViewFilters> = {
   'review-requested': { ...defaultViewFilters },
-  authored: { ...defaultViewFilters },
+  authored: { ...defaultViewFilters, showDrafts: true },
   mentioned: { ...defaultViewFilters },
 }
 


### PR DESCRIPTION
## Summary
- `authored` view now defaults `showDrafts` to `true` so draft PRs you opened aren't hidden by default in the "My PRs" tab.
- `review-requested` and `mentioned` views are unaffected.

## Test plan
- [x] `npm run test:run` (existing suite, no behavior asserted on defaults changed)
- [ ] Manually verify: fresh localStorage, open "My PRs" tab, confirm a draft PR is visible without toggling "Drafts"

🤖 Generated with [Claude Code](https://claude.com/claude-code)