### PR TITLE
feat: show reviewed PRs in third tab instead of mentions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ CI (`.github/workflows/ci.yml`) runs `lint`, `test:run`, then `build` on every P
 ## Main Features
 
 **Pull Requests view** (`prs`) — three sections selected via the `PRSectionsTabs` sidebar tabs, each a different GitHub search (`buildSearchQuery`):
-- **Review requested** / **My PRs** (authored) / **Mentioned**.
+- **Review requested** / **My PRs** (authored) / **Reviewed**.
 - Per-PR actions on each `PRCard`: **star** (top-priority, pinned above the list and persisted), **hide** (dims + filtered out unless "Hidden" toggle is on), **copy PR link**, open externally.
 - **Mute authors**: free-form patterns (e.g. `dependabot`) that filter out their PRs.
 - Filters: by repository/org (checkboxes in the `SettingsModal` gear-icon popover, shown only when >1 repo loaded), title search (above the list), show/hide **drafts**, show/hide **hidden** (`VisibilityToggles` in the list header).
@@ -116,7 +116,7 @@ Two layers, deliberately separated:
 
 `usePullRequests` (`src/features/pull-requests/queries/useGitHubPRs.ts`) is the core read path:
 
-1. `buildSearchQuery(section, login)` turns the active section (`review-requested` / `authored` / `mentioned`) into a GitHub search string.
+1. `buildSearchQuery(section, login)` turns the active section (`review-requested` / `authored` / `reviewed`) into a GitHub search string.
 2. `useInfiniteQuery` pages the GraphQL `search` via `PR_LIST_QUERY` (20/page, capped at `MAX_PAGES = 10`), sorted `sort:updated-desc`. Pages auto-fetch sequentially via a `useEffect`; `PRListHeader` shows a spinner while `isFetchingNextPage`. The list query returns only lightweight fields — `reviews`, `reviewRequests`, `commits`, and `mergeable` are **not** fetched here.
 3. Each node is enriched in-memory with `isTopPriority`, `isHidden`.
 4. `applyFilters` (`src/features/pull-requests/lib/prFilters.ts`) drops drafts/hidden/repo/author/search misses.

--- a/src/features/pull-requests/components/PRList/PRList.test.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.test.tsx
@@ -46,11 +46,11 @@ const mockStoreFilters = () => {
       viewFilters: {
         'review-requested': { repos: [], showDrafts: false, search: '' },
         authored: { repos: [], showDrafts: false, search: '' },
-        mentioned: { repos: [], showDrafts: false, search: '' },
+        reviewed: { repos: [], showDrafts: false, search: '' },
       },
       priorityIds: [],
       hiddenIds: [],
-      knownRepos: { 'review-requested': [], authored: [], mentioned: [] },
+      knownRepos: { 'review-requested': [], authored: [], reviewed: [] },
       setKnownRepos: vi.fn(),
       notificationHintDismissed: true,
       dismissNotificationHint: vi.fn(),

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -12,7 +12,7 @@ import { isOverContextSwitchThreshold } from '../../lib/prUtils'
 const sectionLabels: Record<string, string> = {
   'review-requested': 'Review requested',
   authored: 'My pull requests',
-  mentioned: 'Mentioned',
+  reviewed: 'Reviewed',
 }
 
 export const PRList = () => {

--- a/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.test.tsx
+++ b/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.test.tsx
@@ -30,11 +30,21 @@ beforeEach(() => {
 })
 
 describe('PRSectionsTabs — section tabs', () => {
-  it('renders all three section tabs', () => {
+  it('renders all three section tabs in order: My PRs, Review requested, Reviewed', () => {
     renderWithClient()
-    expect(screen.getByText('Review requested')).toBeInTheDocument()
-    expect(screen.getByText('My PRs')).toBeInTheDocument()
-    expect(screen.getByText('Mentioned')).toBeInTheDocument()
+    const buttons = screen.getAllByRole('button')
+    const myPRsBtn = screen.getByText('My PRs')
+    const reviewRequestedBtn = screen.getByText('Review requested')
+    const reviewedBtn = screen.getByText('Reviewed')
+    expect(myPRsBtn).toBeInTheDocument()
+    expect(reviewRequestedBtn).toBeInTheDocument()
+    expect(reviewedBtn).toBeInTheDocument()
+    // Verify order
+    const myPRsIndex = buttons.indexOf(myPRsBtn as HTMLButtonElement)
+    const reviewRequestedIndex = buttons.indexOf(reviewRequestedBtn as HTMLButtonElement)
+    const reviewedIndex = buttons.indexOf(reviewedBtn as HTMLButtonElement)
+    expect(myPRsIndex).toBeLessThan(reviewRequestedIndex)
+    expect(reviewRequestedIndex).toBeLessThan(reviewedIndex)
   })
 
   it('active section tab has accent styling', () => {

--- a/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.tsx
+++ b/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.tsx
@@ -2,9 +2,9 @@ import { ContributeLinks } from '@/shared/components/ContributeLinks/ContributeL
 import { usePRStore, type PRSection } from '../../stores/prStore'
 
 const SECTIONS: { id: PRSection; label: string }[] = [
-  { id: 'review-requested', label: 'Review requested' },
   { id: 'authored', label: 'My PRs' },
-  { id: 'mentioned', label: 'Mentioned' },
+  { id: 'review-requested', label: 'Review requested' },
+  { id: 'reviewed', label: 'Reviewed' },
 ]
 
 export const PRSectionsTabs = () => {

--- a/src/features/pull-requests/lib/prUtils.test.ts
+++ b/src/features/pull-requests/lib/prUtils.test.ts
@@ -43,9 +43,10 @@ describe('buildSearchQuery', () => {
     expect(actual).toContain('author:alice')
   })
 
-  it('GIVEN mentioned section WHEN called THEN includes mentions filter', () => {
-    const actual = buildSearchQuery('mentioned', 'alice')
-    expect(actual).toContain('mentions:alice')
+  it('GIVEN reviewed section WHEN called THEN includes reviewed-by filter and excludes own PRs', () => {
+    const actual = buildSearchQuery('reviewed', 'alice')
+    expect(actual).toContain('reviewed-by:alice')
+    expect(actual).toContain('-author:alice')
   })
 
   it('GIVEN unknown section WHEN called THEN falls back to review-requested', () => {

--- a/src/features/pull-requests/lib/prUtils.ts
+++ b/src/features/pull-requests/lib/prUtils.ts
@@ -25,8 +25,8 @@ export const buildSearchQuery = (section: string, login: string): string => {
       return `${base} review-requested:${login}`
     case 'authored':
       return `${base} author:${login}`
-    case 'mentioned':
-      return `${base} mentions:${login}`
+    case 'reviewed':
+      return `${base} reviewed-by:${login} -author:${login}`
     default:
       return `${base} review-requested:${login}`
   }

--- a/src/features/pull-requests/queries/useGitHubPRs.test.tsx
+++ b/src/features/pull-requests/queries/useGitHubPRs.test.tsx
@@ -154,11 +154,11 @@ describe('usePullRequests auto-select on new repo discovery', () => {
       viewFilters: {
         'review-requested': { repos: [], showDrafts: false, search: '' },
         authored: { repos: [], showDrafts: false, search: '' },
-        mentioned: { repos: [], showDrafts: false, search: '' },
+        reviewed: { repos: [], showDrafts: false, search: '' },
       },
       priorityIds: [],
       hiddenIds: [],
-      knownRepos: { 'review-requested': [], authored: [], mentioned: [] },
+      knownRepos: { 'review-requested': [], authored: [], reviewed: [] },
     })
     useAuthStore.setState({ token: null, user: null })
   })
@@ -176,7 +176,7 @@ describe('usePullRequests auto-select on new repo discovery', () => {
       knownRepos: {
         'review-requested': ['acme/repo-a', 'acme/repo-b'],
         authored: [],
-        mentioned: [],
+        reviewed: [],
       },
     })
     usePRStore.getState().setViewFilters('review-requested', {
@@ -200,7 +200,7 @@ describe('usePullRequests auto-select on new repo discovery', () => {
       knownRepos: {
         'review-requested': ['acme/repo-a', 'acme/repo-b'],
         authored: [],
-        mentioned: [],
+        reviewed: [],
       },
     })
     usePRStore.getState().setViewFilters('review-requested', { repos: ['acme/repo-a'] })
@@ -231,7 +231,7 @@ describe('usePullRequests auto-select on new repo discovery', () => {
     setupAuth()
     usePRStore.setState({
       globalFilters: { hiddenAuthors: [], hiddenRepos: ['acme/repo-c'], showHidden: false },
-      knownRepos: { 'review-requested': ['acme/repo-a'], authored: [], mentioned: [] },
+      knownRepos: { 'review-requested': ['acme/repo-a'], authored: [], reviewed: [] },
     })
     usePRStore.getState().setViewFilters('review-requested', { repos: ['acme/repo-a'] })
     const graphql = vi.fn().mockResolvedValue(mockSearchResponse(['acme/repo-a', 'acme/repo-c']))

--- a/src/features/pull-requests/stores/prStore.test.ts
+++ b/src/features/pull-requests/stores/prStore.test.ts
@@ -8,11 +8,11 @@ beforeEach(() => {
     viewFilters: {
       'review-requested': { repos: [], showDrafts: false, search: '' },
       authored: { repos: [], showDrafts: false, search: '' },
-      mentioned: { repos: [], showDrafts: false, search: '' },
+      reviewed: { repos: [], showDrafts: false, search: '' },
     },
     priorityIds: [],
     hiddenIds: [],
-    knownRepos: { 'review-requested': [], authored: [], mentioned: [] },
+    knownRepos: { 'review-requested': [], authored: [], reviewed: [] },
   })
 })
 
@@ -127,13 +127,13 @@ describe('prStore', () => {
     const { knownRepos } = usePRStore.getState()
     expect(knownRepos['review-requested']).toEqual(['org/repo-a'])
     expect(knownRepos.authored).toEqual([])
-    expect(knownRepos.mentioned).toEqual([])
+    expect(knownRepos.reviewed).toEqual([])
   })
 
   it('persisted merge restores knownRepos', () => {
     const persisted = {
       globalFilters: { hiddenAuthors: [], hiddenRepos: [], showHidden: false },
-      knownRepos: { 'review-requested': ['org/repo-a'], authored: [], mentioned: [] },
+      knownRepos: { 'review-requested': ['org/repo-a'], authored: [], reviewed: [] },
     }
     const { merge } = usePRStore.persist.getOptions()
     const merged = merge!(persisted, usePRStore.getState())
@@ -170,7 +170,7 @@ describe('prStore', () => {
     const { usePRStore: freshStore } = await import('./prStore')
     expect(freshStore.getState().viewFilters.authored.showDrafts).toBe(true)
     expect(freshStore.getState().viewFilters['review-requested'].showDrafts).toBe(false)
-    expect(freshStore.getState().viewFilters.mentioned.showDrafts).toBe(false)
+    expect(freshStore.getState().viewFilters.reviewed.showDrafts).toBe(false)
   })
 
   it('persisted merge restores openPRsInDonna and donnaPRViewHintDismissed', () => {

--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-export type PRSection = 'review-requested' | 'authored' | 'mentioned'
+export type PRSection = 'review-requested' | 'authored' | 'reviewed'
 
 export type GlobalFilters = {
   hiddenAuthors: string[]
@@ -58,13 +58,13 @@ const defaultGlobalFilters: GlobalFilters = {
 const defaultViewFiltersAll: Record<PRSection, ViewFilters> = {
   'review-requested': { ...defaultViewFilters },
   authored: { ...defaultViewFilters, showDrafts: true },
-  mentioned: { ...defaultViewFilters },
+  reviewed: { ...defaultViewFilters },
 }
 
 const defaultKnownReposAll: Record<PRSection, string[]> = {
   'review-requested': [],
   authored: [],
-  mentioned: [],
+  reviewed: [],
 }
 
 export const usePRStore = create<PRStore>()(
@@ -197,7 +197,7 @@ export const usePRStore = create<PRStore>()(
               p.donnaPRViewHintDismissed ?? current.donnaPRViewHintDismissed,
           }
         }
-        const validSections = new Set<string>(['review-requested', 'authored', 'mentioned'])
+        const validSections = new Set<string>(['review-requested', 'authored', 'reviewed'])
         return {
           ...current,
           ...(p.section && validSections.has(p.section) ? { section: p.section } : {}),


### PR DESCRIPTION
## What

Replace the "Mentioned" tab with a "Reviewed" tab that shows PRs you have reviewed, using the `reviewed-by:` GitHub search and excluding authored PRs.

## Why

The "Mentioned" tab showed posts where your username appeared anywhere, which is too broad. The "Reviewed" tab provides more meaningful context — it shows work you've already contributed feedback to.

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes