### PR TITLE
fix: prevent crash when filter state has undefined properties

### DIFF
--- a/src/features/pull-requests/stores/prStore.ts
+++ b/src/features/pull-requests/stores/prStore.ts
@@ -203,10 +203,17 @@ export const usePRStore = create<PRStore>()(
           ...(p.section && validSections.has(p.section) ? { section: p.section } : {}),
           globalFilters: { ...current.globalFilters, ...(p.globalFilters ?? {}) },
           viewFilters: Object.fromEntries(
-            (Object.keys(current.viewFilters) as PRSection[]).map((s) => [
-              s,
-              { ...current.viewFilters[s], ...(p.viewFilters?.[s] ?? {}) },
-            ])
+            (Object.keys(current.viewFilters) as PRSection[]).map((s) => {
+              const persisted = p.viewFilters?.[s] ?? {}
+              return [
+                s,
+                {
+                  repos: persisted.repos ?? current.viewFilters[s].repos ?? [],
+                  showDrafts: persisted.showDrafts ?? current.viewFilters[s].showDrafts ?? false,
+                  search: persisted.search ?? current.viewFilters[s].search ?? '',
+                },
+              ]
+            })
           ) as Record<PRSection, ViewFilters>,
           priorityIds: p.priorityIds ?? current.priorityIds,
           hiddenIds: p.hiddenIds ?? current.hiddenIds,


### PR DESCRIPTION
## Summary
When upgrading with old localStorage data, persisted `viewFilters` for a section could have missing properties (`repos`, `showDrafts`, `search`). The merge function would spread incomplete objects, leaving those properties undefined. This caused `applyFilters` to crash when calling `.includes()` on the undefined `repos` array.

## Root Cause
In `prStore.ts` merge function, the spread operation `...(p.viewFilters?.[s] ?? {})` doesn't guarantee all properties exist on the resulting object. Upgrading users with partial persisted state would hit undefined property access.

## Solution
Explicitly handle each property with proper fallbacks, ensuring all `ViewFilters` have complete, defined properties.

## Test Plan
- [x] Verify crash no longer occurs when using filters
- [x] localStorage upgrade with old format works without crashes

🤖 Generated with Claude Code