### PR TITLE
fix: allow force-deleting unmerged branches

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -121,16 +121,13 @@ ipcMain.handle('branches:switchToDefault', async (_e, repoPath: string) => {
   }
 })
 
-ipcMain.handle(
-  'branches:delete',
-  async (_e, repoPath: string, branch: string, force = false) => {
-    try {
-      await execFileAsync('git', ['-C', repoPath, 'branch', force ? '-D' : '-d', branch])
-    } catch (e) {
-      throw gitError(e)
-    }
+ipcMain.handle('branches:delete', async (_e, repoPath: string, branch: string, force = false) => {
+  try {
+    await execFileAsync('git', ['-C', repoPath, 'branch', force ? '-D' : '-d', branch])
+  } catch (e) {
+    throw gitError(e)
   }
-)
+})
 
 ipcMain.handle(
   'worktrees:remove',

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -121,13 +121,16 @@ ipcMain.handle('branches:switchToDefault', async (_e, repoPath: string) => {
   }
 })
 
-ipcMain.handle('branches:delete', async (_e, repoPath: string, branch: string) => {
-  try {
-    await execFileAsync('git', ['-C', repoPath, 'branch', '-d', branch])
-  } catch (e) {
-    throw gitError(e)
+ipcMain.handle(
+  'branches:delete',
+  async (_e, repoPath: string, branch: string, force = false) => {
+    try {
+      await execFileAsync('git', ['-C', repoPath, 'branch', force ? '-D' : '-d', branch])
+    } catch (e) {
+      throw gitError(e)
+    }
   }
-})
+)
 
 ipcMain.handle(
   'worktrees:remove',

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -10,8 +10,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   branches: {
     list: (repoPath: string): Promise<import('../src/features/branches/types').Branch[]> =>
       ipcRenderer.invoke('branches:list', repoPath),
-    delete: (repoPath: string, branch: string): Promise<void> =>
-      ipcRenderer.invoke('branches:delete', repoPath, branch),
+    delete: (repoPath: string, branch: string, force = false): Promise<void> =>
+      ipcRenderer.invoke('branches:delete', repoPath, branch, force),
     switchToDefault: (repoPath: string): Promise<void> =>
       ipcRenderer.invoke('branches:switchToDefault', repoPath),
   },

--- a/src/features/branches/components/BranchList/BranchCard/BranchCard.tsx
+++ b/src/features/branches/components/BranchList/BranchCard/BranchCard.tsx
@@ -29,18 +29,30 @@ export const BranchCard = ({
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [isRemoving, setIsRemoving] = useState(false)
 
-  const deleteBranch = async () => {
-    const message = isCurrentBranch
-      ? `Delete branch "${branch}"?\n\nYou're currently on this branch — git will switch to main first.`
-      : `Delete branch "${branch}"?\nThe branch must be fully merged.`
-    if (!window.confirm(message)) return
+  const deleteBranch = async (force = false) => {
+    if (!force) {
+      const message = isCurrentBranch
+        ? `Delete branch "${branch}"?\n\nYou're currently on this branch — git will switch to main first.`
+        : `Delete branch "${branch}"?\nThe branch must be fully merged.`
+      if (!window.confirm(message)) return
+    }
     setIsMenuOpen(false)
     try {
       if (isCurrentBranch) await window.electronAPI!.branches.switchToDefault(repoPath)
-      await window.electronAPI!.branches.delete(repoPath, branch)
+      await window.electronAPI!.branches.delete(repoPath, branch, force)
       onDeleted()
     } catch (e) {
-      setDeleteError((e as Error).message)
+      const message = (e as Error).message
+      if (!force && message.includes('not fully merged')) {
+        const confirmForce = window.confirm(
+          `⚠️ "${branch}" is not fully merged.\n\nForce-deleting will permanently discard any commits that only exist on this branch.\n\nAre you sure?`
+        )
+        if (confirmForce) {
+          await deleteBranch(true)
+          return
+        }
+      }
+      setDeleteError(message)
     }
   }
 
@@ -140,7 +152,7 @@ export const BranchCard = ({
                       </button>
                     ) : (
                       <button
-                        onClick={deleteBranch}
+                        onClick={() => deleteBranch()}
                         className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--color-danger)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
                       >
                         <Trash2 size={12} />

--- a/src/features/branches/components/BranchList/BranchList.test.tsx
+++ b/src/features/branches/components/BranchList/BranchList.test.tsx
@@ -161,12 +161,12 @@ describe('BranchCard — regular branch', () => {
     expect(screen.getByText('Delete branch')).toBeInTheDocument()
   })
 
-  it('GIVEN user confirms WHEN Delete branch clicked THEN calls branches.delete', async () => {
+  it('GIVEN user confirms WHEN Delete branch clicked THEN calls branches.delete without force', async () => {
     const user = userEvent.setup()
     const { onDeleted } = card()
     await user.click(screen.getByTitle('More actions'))
     await user.click(screen.getByText('Delete branch'))
-    expect(mockDelete).toHaveBeenCalledWith('/repos/my-repo', 'feat/my-feature')
+    expect(mockDelete).toHaveBeenCalledWith('/repos/my-repo', 'feat/my-feature', false)
     await waitFor(() => expect(onDeleted).toHaveBeenCalled())
   })
 
@@ -179,13 +179,48 @@ describe('BranchCard — regular branch', () => {
     expect(mockDelete).not.toHaveBeenCalled()
   })
 
-  it('GIVEN delete fails WHEN Delete branch clicked THEN shows error inline', async () => {
-    mockDelete.mockRejectedValueOnce(new Error('branch not fully merged'))
+  it('GIVEN delete fails with an unrelated error WHEN Delete branch clicked THEN shows error inline and does not retry', async () => {
+    mockDelete.mockRejectedValueOnce(new Error('permission denied'))
     const user = userEvent.setup()
     card()
     await user.click(screen.getByTitle('More actions'))
     await user.click(screen.getByText('Delete branch'))
-    await waitFor(() => expect(screen.getByText('branch not fully merged')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('permission denied')).toBeInTheDocument())
+    expect(mockDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('GIVEN delete fails because branch is not fully merged WHEN user confirms force-delete THEN retries with force=true and succeeds', async () => {
+    mockDelete.mockRejectedValueOnce(
+      new Error("error: The branch 'feat/my-feature' is not fully merged.")
+    )
+    const user = userEvent.setup()
+    const { onDeleted } = card()
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Delete branch'))
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledTimes(2))
+    expect(mockDelete).toHaveBeenNthCalledWith(1, '/repos/my-repo', 'feat/my-feature', false)
+    expect(mockDelete).toHaveBeenNthCalledWith(2, '/repos/my-repo', 'feat/my-feature', true)
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled())
+    expect(screen.queryByText(/is not fully merged/)).not.toBeInTheDocument()
+  })
+
+  it('GIVEN delete fails because branch is not fully merged WHEN user cancels force-delete THEN shows the error inline and does not retry', async () => {
+    mockDelete.mockRejectedValueOnce(
+      new Error("error: The branch 'feat/my-feature' is not fully merged.")
+    )
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    confirmSpy.mockReturnValueOnce(true) // initial "Delete branch?" dialog
+    confirmSpy.mockReturnValueOnce(false) // force-delete warning dialog
+    const user = userEvent.setup()
+    card()
+    await user.click(screen.getByTitle('More actions'))
+    await user.click(screen.getByText('Delete branch'))
+    await waitFor(() =>
+      expect(
+        screen.getByText("error: The branch 'feat/my-feature' is not fully merged.")
+      ).toBeInTheDocument()
+    )
+    expect(mockDelete).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -205,7 +240,7 @@ describe('BranchCard — current branch', () => {
     await user.click(screen.getByTitle('More actions'))
     await user.click(screen.getByText('Delete branch'))
     expect(mockSwitchToDefault).toHaveBeenCalledWith('/repos/my-repo')
-    expect(mockDelete).toHaveBeenCalledWith('/repos/my-repo', 'feat/my-feature')
+    expect(mockDelete).toHaveBeenCalledWith('/repos/my-repo', 'feat/my-feature', false)
     await waitFor(() => expect(onDeleted).toHaveBeenCalled())
   })
 })

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -12,7 +12,7 @@ interface Window {
     }
     branches: {
       list: (repoPath: string) => Promise<import('../features/branches/types').Branch[]>
-      delete: (repoPath: string, branch: string) => Promise<void>
+      delete: (repoPath: string, branch: string, force?: boolean) => Promise<void>
       switchToDefault: (repoPath: string) => Promise<void>
     }
     worktrees: {


### PR DESCRIPTION
## Summary
- `branches:delete` always ran `git branch -d`, so deleting a branch that wasn't fully merged failed with a raw, unhelpful Electron IPC error and left the user stuck with no way to actually delete it.
- Adds a `force` option through the IPC handler → preload → `BranchCard`; on a "not fully merged" failure, the user is warned and offered a force-delete (`git branch -D`) retry, mirroring the existing `removeWorktree` force-retry pattern.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (added regression coverage in `BranchList.test.tsx` for: default delete passes `force: false`, not-fully-merged retry-and-succeed, retry-declined path)
- [x] `npm run build`

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)