### PR TITLE
fix: recompute hidden PR counter from current results

### DIFF
--- a/src/features/pull-requests/components/PRList/PRList.test.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.test.tsx
@@ -159,6 +159,58 @@ describe('PRList', () => {
     expect(screen.getByText(/of 500/)).toBeInTheDocument()
   })
 
+  it('GIVEN a hidden PR no longer present in fetched results (e.g. closed) THEN Hidden badge only counts hidden PRs still present', () => {
+    // hiddenIds is the all-time persisted list (2 entries), but only one of those PRs
+    // is still present in the current section's fetched results (allPRs) - the other
+    // was closed and dropped out of the GitHub search entirely.
+    mockUsePRStore.mockImplementation((selector) =>
+      selector({
+        section: 'review-requested',
+        globalFilters: { hiddenAuthors: [], hiddenRepos: [], showHidden: true },
+        viewFilters: {
+          'review-requested': { repos: [], showDrafts: false, search: '' },
+          authored: { repos: [], showDrafts: false, search: '' },
+          reviewed: { repos: [], showDrafts: false, search: '' },
+        },
+        priorityIds: [],
+        hiddenIds: ['1', '2'],
+        knownRepos: { 'review-requested': [], authored: [], reviewed: [] },
+        setKnownRepos: vi.fn(),
+        notificationHintDismissed: true,
+        dismissNotificationHint: vi.fn(),
+        contextSwitchThreshold: 4,
+        setContextSwitchThreshold: vi.fn(),
+        setSection: vi.fn(),
+        setGlobalFilters: vi.fn(),
+        setViewFilters: vi.fn(),
+        resetFilters: vi.fn(),
+        toggleHide: vi.fn(),
+        togglePriority: vi.fn(),
+        addHiddenAuthor: vi.fn(),
+        removeHiddenAuthor: vi.fn(),
+        addHiddenRepo: vi.fn(),
+        removeHiddenRepo: vi.fn(),
+        openPRsInDonna: true,
+        setOpenPRsInDonna: vi.fn(),
+        donnaPRViewHintDismissed: true,
+        dismissDonnaPRViewHint: vi.fn(),
+      })
+    )
+    const stillOpenHiddenPR = { ...makePR('1', 'Still open, hidden'), isHidden: true }
+    mockUsePullRequests.mockReturnValue({
+      ...defaultQuery,
+      data: [stillOpenHiddenPR],
+      priorityPRs: [],
+      allPRs: [stillOpenHiddenPR],
+      totalCount: 1,
+      loadedCount: 1,
+    } as never)
+
+    renderWithClient(<PRList />)
+
+    expect(screen.getByText('Hidden (1)')).toBeInTheDocument()
+  })
+
   it('GIVEN refresh button clicked THEN pr-details and pr-checks queries are invalidated', () => {
     const p = makePR('1', 'PR')
     mockUsePullRequests.mockReturnValue({

--- a/src/features/pull-requests/components/PRList/PRList.tsx
+++ b/src/features/pull-requests/components/PRList/PRList.tsx
@@ -61,6 +61,11 @@ export const PRList = () => {
     refetchAll()
   }
 
+  // Only counts hidden PRs still present in the current section's fetched results -
+  // `hiddenIds` in the store is an all-time list that never gets pruned (e.g. once a
+  // hidden PR is closed it drops out of allPRs but its id lingers in hiddenIds forever).
+  const hiddenCount = allPRs.filter((pr) => pr.isHidden).length
+
   return (
     <div className="flex-1 min-w-0">
       <PRListHeader
@@ -72,6 +77,7 @@ export const PRList = () => {
         refetch={handleRefetch}
         isFetching={isFetching}
         isLoadingMore={isFetchingNextPage}
+        hiddenCount={hiddenCount}
       />
 
       {section === 'authored' &&

--- a/src/features/pull-requests/components/PRListHeader/PRListHeader.tsx
+++ b/src/features/pull-requests/components/PRListHeader/PRListHeader.tsx
@@ -10,6 +10,7 @@ type Props = {
   refetch: () => void
   isFetching: boolean
   isLoadingMore?: boolean
+  hiddenCount: number
 }
 
 export const PRListHeader = ({
@@ -21,6 +22,7 @@ export const PRListHeader = ({
   refetch,
   isFetching,
   isLoadingMore,
+  hiddenCount,
 }: Props) => {
   return (
     <div className="flex flex-wrap items-center justify-between mb-4">
@@ -40,7 +42,7 @@ export const PRListHeader = ({
       </div>
 
       <div className="flex items-center gap-2">
-        <VisibilityToggles />
+        <VisibilityToggles hiddenCount={hiddenCount} />
         <button
           onClick={refetch}
           disabled={isFetching}

--- a/src/features/pull-requests/components/VisibilityToggles/VisibilityToggles.tsx
+++ b/src/features/pull-requests/components/VisibilityToggles/VisibilityToggles.tsx
@@ -1,12 +1,15 @@
 import { usePRStore } from '@/features/pull-requests/stores/prStore.ts'
 
-export const VisibilityToggles = () => {
+type Props = {
+  hiddenCount: number
+}
+
+export const VisibilityToggles = ({ hiddenCount }: Props) => {
   const section = usePRStore((s) => s.section)
   const globalFilters = usePRStore((s) => s.globalFilters)
   const setGlobalFilters = usePRStore((s) => s.setGlobalFilters)
   const viewFilters = usePRStore((s) => s.viewFilters)
   const setViewFilters = usePRStore((s) => s.setViewFilters)
-  const hiddenIds = usePRStore((s) => s.hiddenIds)
 
   const showDrafts = viewFilters[section].showDrafts
 
@@ -34,7 +37,7 @@ export const VisibilityToggles = () => {
               : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-overlay)]'
           }`}
       >
-        Hidden{hiddenIds.length > 0 && ` (${hiddenIds.length})`}
+        Hidden{hiddenCount > 0 && ` (${hiddenCount})`}
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- `hiddenIds` in `prStore` is an all-time, never-pruned list of hidden PR ids. The "Hidden (N)" badge rendered `hiddenIds.length` directly, so once a hidden PR closes and drops out of the GitHub search results, its id lingers forever and the counter never decrements.
- Derives the count from the current section's fetched results instead (`allPRs.filter(pr => pr.isHidden).length`), plumbed down through `PRList` → `PRListHeader` → `VisibilityToggles` as a prop. `hiddenIds` itself is left untouched — no pruning behavior added, out of scope for this fix.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (added regression case in `PRList.test.tsx`: PR hidden in `hiddenIds` but absent from `allPRs` no longer counts)
- [x] `npm run build`

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)