### PR TITLE
fix: show disabled Run shortcut action instead of hiding it

### DIFF
--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { PRCard } from './PRCard'
 import { usePRStore } from '../../stores/prStore'
 import { useAuthStore } from '@/features/auth/stores/authStore'
+import { useBranchStore } from '@/features/branches/stores/branchStore'
 import { usePRDetails } from '../../queries/usePRDetails'
 import { useCheckContexts } from '../../queries/useCheckContexts'
 import type { PullRequest, ReviewState } from '@/types/github'
@@ -45,6 +46,7 @@ const pr: PullRequest = {
 beforeEach(() => {
   usePRStore.setState({ priorityIds: [], hiddenIds: [], openPRsInDonna: true })
   useAuthStore.setState({ user: { login: 'viewer', avatarUrl: '', name: 'Viewer' }, token: 'test' })
+  useBranchStore.setState({ localPaths: [] })
   mockUsePRDetails.mockReturnValue({ data: undefined } as never)
   mockUseCheckContexts.mockReturnValue({ checks: [], isLoading: false, refetch: vi.fn() } as never)
 })
@@ -340,6 +342,39 @@ describe('PRCard', () => {
     it('GIVEN mergeable MERGEABLE WHEN rendered THEN no Conflict badge', () => {
       renderCard(<PRCard pr={{ ...pr, mergeable: 'MERGEABLE' }} />)
       expect(screen.queryByText('Conflict')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('run shortcut action', () => {
+    it('GIVEN isAuthored=false THEN run shortcut action is not shown, regardless of local repos', () => {
+      useBranchStore.setState({ localPaths: ['/Users/me/code/repo'] })
+      renderCard(<PRCard pr={pr} isAuthored={false} />)
+      expect(screen.queryByRole('button', { name: /run shortcut/i })).not.toBeInTheDocument()
+    })
+
+    it('GIVEN isAuthored=true and no local repo matches THEN run shortcut action is shown but disabled with an explanatory title', () => {
+      useBranchStore.setState({ localPaths: [] })
+      renderCard(<PRCard pr={pr} isAuthored />)
+      const button = screen.getByRole('button', { name: /add this repo in the branches tab/i })
+      expect(button).toBeDisabled()
+    })
+
+    it('GIVEN isAuthored=true and a local repo matches THEN run shortcut action is shown enabled', () => {
+      useBranchStore.setState({ localPaths: ['/Users/me/code/repo'] })
+      renderCard(<PRCard pr={pr} isAuthored />)
+      const button = screen.getByRole('button', { name: 'Run shortcut' })
+      expect(button).not.toBeDisabled()
+    })
+
+    it('GIVEN isAuthored=true and no local repo matches WHEN the disabled action is clicked THEN the shortcuts modal does not open', async () => {
+      useBranchStore.setState({ localPaths: [] })
+      const user = userEvent.setup()
+      renderCard(<PRCard pr={pr} isAuthored />)
+      const button = screen.getByRole('button', { name: /add this repo in the branches tab/i })
+      await user.click(button)
+      expect(
+        screen.queryByText(`Shortcuts · ${pr.repository.nameWithOwner} #${pr.number}`)
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -19,6 +19,8 @@ type Props = {
   showHideAndStar?: boolean
 }
 
+const NO_LOCAL_REPO_TITLE = 'Add this repo in the Branches tab to run shortcuts'
+
 const reviewBadge: Record<
   ReviewState,
   { label: string; color: string; bg: string; icon: ReactElement }
@@ -221,7 +223,9 @@ export const PRCard = ({ pr, isAuthored = false, showHideAndStar = true }: Props
           prUrl={pr.url}
           prNumber={pr.number}
           showHideAndStar={showHideAndStar}
-          showRunShortcut={isAuthored && !!repoPath}
+          showRunShortcut={isAuthored}
+          runShortcutDisabled={isAuthored && !repoPath}
+          runShortcutTitle={repoPath ? 'Run shortcut' : NO_LOCAL_REPO_TITLE}
           onRunShortcut={() => setShortcutsOpen(true)}
           onOpenExternally={openExternally}
           showReviewInDonna={!openPRsInDonna}

--- a/src/features/pull-requests/components/PRCardActions/PRCardAction.tsx
+++ b/src/features/pull-requests/components/PRCardActions/PRCardAction.tsx
@@ -6,16 +6,22 @@ type Props = PropsWithChildren & {
   onClick: () => void
   title: string
   className: string
+  disabled?: boolean
 }
 
-export const PRCardAction = ({ children, title, className, onClick }: Props) => {
+export const PRCardAction = ({ children, title, className, onClick, disabled }: Props) => {
   const computedClassName = twMerge(
-    'p-1.5 rounded transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent] focus-visible:outline-none',
+    'p-1.5 rounded transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent] focus-visible:outline-none disabled:opacity-50 disabled:cursor-not-allowed',
     className
   )
 
   return (
-    <ButtonWithTooltip onClick={onClick} label={title} buttonClassName={computedClassName}>
+    <ButtonWithTooltip
+      onClick={onClick}
+      label={title}
+      buttonClassName={computedClassName}
+      disabled={disabled}
+    >
       {children}
     </ButtonWithTooltip>
   )

--- a/src/features/pull-requests/components/PRCardActions/PRCardActions.tsx
+++ b/src/features/pull-requests/components/PRCardActions/PRCardActions.tsx
@@ -11,6 +11,8 @@ type Props = {
   prNumber: number
   showHideAndStar: boolean
   showRunShortcut: boolean
+  runShortcutDisabled?: boolean
+  runShortcutTitle?: string
   onRunShortcut: () => void
   onOpenExternally: () => void
   showReviewInDonna: boolean
@@ -26,6 +28,8 @@ export const PRCardActions = ({
   togglePriority,
   showHideAndStar,
   showRunShortcut,
+  runShortcutDisabled = false,
+  runShortcutTitle = 'Run shortcut',
   onRunShortcut,
   onOpenExternally,
   showReviewInDonna,
@@ -65,7 +69,8 @@ export const PRCardActions = ({
       {showRunShortcut && (
         <PRCardAction
           onClick={onRunShortcut}
-          title="Run shortcut"
+          title={runShortcutTitle}
+          disabled={runShortcutDisabled}
           className="text-[var(--color-text-muted)] hover:text-[var(--color-accent)]"
         >
           <Terminal size={14} />

--- a/src/shared/components/ui/ButtonWithTooltip.tsx
+++ b/src/shared/components/ui/ButtonWithTooltip.tsx
@@ -5,6 +5,7 @@ type Props = PropsWithChildren & {
   onClick: () => void
   tooltipClassName?: string
   buttonClassName?: string
+  disabled?: boolean
 }
 
 export const ButtonWithTooltip = ({
@@ -13,11 +14,13 @@ export const ButtonWithTooltip = ({
   tooltipClassName,
   onClick,
   buttonClassName,
+  disabled,
 }: Props) => {
   return (
     <div className="relative group/tooltip">
       <button
         onClick={onClick}
+        disabled={disabled}
         aria-label={label}
         className={
           buttonClassName ??


### PR DESCRIPTION
## Summary
- Issue #190 had no repro steps. Investigation of `PRCard.tsx`/`PRCardActions.tsx`/`resolveLocalCheckout.ts` confirmed the likely cause: `showRunShortcut={isAuthored && !!repoPath}` meant the "Run shortcut" button only rendered when a locally-added repo (Branches tab) had a folder basename exactly matching the PR's repo name. On a fresh install, or any repo not yet added / added under a different folder name, the button was silently absent with zero explanation — the IPC wiring itself (preload → main → `gh pr comment`) was verified intact.
- Fix: the action is now always shown on authored PRs, but rendered disabled with an explanatory tooltip ("Add this repo in the Branches tab to run shortcuts") when no matching local repo is found, instead of disappearing.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (added regression cases in `PRCard.test.tsx`: authored+no-match → visible/disabled/titled, authored+match → visible/enabled, not authored → never shown, click while disabled doesn't open the modal)
- [x] `npm run build`

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)