### PR TITLE
feat: show a merge queue badge on PR cards

### DIFF
--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -348,17 +348,17 @@ describe('PRCard', () => {
   describe('merge queue badge', () => {
     it('GIVEN isInMergeQueue true WHEN rendered THEN shows Merge queue badge', () => {
       renderCard(<PRCard pr={{ ...pr, isInMergeQueue: true }} />)
-      expect(screen.getByText('Merge queue')).toBeInTheDocument()
+      expect(screen.getByText('In merge queue')).toBeInTheDocument()
     })
 
     it('GIVEN isInMergeQueue false WHEN rendered THEN no Merge queue badge', () => {
       renderCard(<PRCard pr={{ ...pr, isInMergeQueue: false }} />)
-      expect(screen.queryByText('Merge queue')).not.toBeInTheDocument()
+      expect(screen.queryByText('In merge queue')).not.toBeInTheDocument()
     })
 
     it('GIVEN isInMergeQueue undefined WHEN rendered THEN no Merge queue badge', () => {
       renderCard(<PRCard pr={pr} />)
-      expect(screen.queryByText('Merge queue')).not.toBeInTheDocument()
+      expect(screen.queryByText('In merge queue')).not.toBeInTheDocument()
     })
   })
 

--- a/src/features/pull-requests/components/PRCard/PRCard.test.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.test.tsx
@@ -345,6 +345,23 @@ describe('PRCard', () => {
     })
   })
 
+  describe('merge queue badge', () => {
+    it('GIVEN isInMergeQueue true WHEN rendered THEN shows Merge queue badge', () => {
+      renderCard(<PRCard pr={{ ...pr, isInMergeQueue: true }} />)
+      expect(screen.getByText('Merge queue')).toBeInTheDocument()
+    })
+
+    it('GIVEN isInMergeQueue false WHEN rendered THEN no Merge queue badge', () => {
+      renderCard(<PRCard pr={{ ...pr, isInMergeQueue: false }} />)
+      expect(screen.queryByText('Merge queue')).not.toBeInTheDocument()
+    })
+
+    it('GIVEN isInMergeQueue undefined WHEN rendered THEN no Merge queue badge', () => {
+      renderCard(<PRCard pr={pr} />)
+      expect(screen.queryByText('Merge queue')).not.toBeInTheDocument()
+    })
+  })
+
   describe('run shortcut action', () => {
     it('GIVEN isAuthored=false THEN run shortcut action is not shown, regardless of local repos', () => {
       useBranchStore.setState({ localPaths: ['/Users/me/code/repo'] })

--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -215,7 +215,7 @@ export const PRCard = ({
               {showMergeQueue && (
                 <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded text-[var(--color-accent)] bg-[var(--color-accent-subtle)]">
                   <ListOrdered size={11} />
-                  Merge queue
+                  In merge queue
                 </span>
               )}
             </div>

--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactElement } from 'react'
 import { useNavigate } from 'react-router'
-import { GitMerge, MessageSquare, Check, AlertCircle, FileCode } from 'lucide-react'
+import { GitMerge, MessageSquare, Check, AlertCircle, FileCode, ListOrdered } from 'lucide-react'
 import type { PullRequest, ReviewState } from '@/types/github'
 import { usePRStore } from '../../stores/prStore'
 import { useAuthStore } from '@/features/auth/stores/authStore'
@@ -81,6 +81,7 @@ export const PRCard = ({
   const badge = !isAuthored && myReviewState ? reviewBadge[myReviewState] : null
   const checkState = deriveCheckState(merged)
   const showConflict = merged.mergeable === 'CONFLICTING'
+  const showMergeQueue = merged.isInMergeQueue === true
 
   const handleHide = () => {
     toggleHide(pr.id)
@@ -207,6 +208,14 @@ export const PRCard = ({
                 <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded text-[var(--color-warning)] bg-[var(--color-warning-subtle)]">
                   <AlertCircle size={11} />
                   Conflict
+                </span>
+              )}
+
+              {/* Merge queue badge */}
+              {showMergeQueue && (
+                <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded text-[var(--color-accent)] bg-[var(--color-accent-subtle)]">
+                  <ListOrdered size={11} />
+                  Merge queue
                 </span>
               )}
             </div>

--- a/src/features/pull-requests/queries/usePRDetails.ts
+++ b/src/features/pull-requests/queries/usePRDetails.ts
@@ -4,7 +4,10 @@ import { useAuthStore } from '@/features/auth/stores/authStore'
 import type { PullRequest } from '@/types/github'
 
 type NodeResult = {
-  node: Pick<PullRequest, 'id' | 'mergeable' | 'commits' | 'reviewRequests' | 'reviews'>
+  node: Pick<
+    PullRequest,
+    'id' | 'mergeable' | 'isInMergeQueue' | 'commits' | 'reviewRequests' | 'reviews'
+  >
 }
 
 export const usePRDetails = (prId: string) => {

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -84,6 +84,7 @@ export const PR_DETAILS_SINGLE_QUERY = /* GraphQL */ `
       ... on PullRequest {
         id
         mergeable
+        isInMergeQueue
         commits(last: 1) {
           nodes {
             commit {

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -70,6 +70,7 @@ export type PullRequest = {
   additions: number
   deletions: number
   mergeable?: MergeableState
+  isInMergeQueue?: boolean
   commits?: {
     nodes: {
       commit: {


### PR DESCRIPTION
## Summary
- Fetches `isInMergeQueue` alongside the other lazily-loaded per-PR details (same pattern as `mergeable`).
- Shows a "Merge queue" badge on the PR card, next to the Conflict badge, when GitHub has queued the PR to merge.

Closes #197

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)