### PR TITLE
fix: review ownership badge tooltip not showing on hover

### DIFF
--- a/src/features/pull-requests/components/PRCard/PRCard.tsx
+++ b/src/features/pull-requests/components/PRCard/PRCard.tsx
@@ -241,11 +241,14 @@ export const PRCard = ({
               {/* Review ownership badge */}
               {ownershipInfo && (
                 <span
-                  title={ownershipInfo.title}
-                  className={`flex items-center gap-1 text-xs px-1.5 py-0.5 rounded ${ownershipInfo.color} ${ownershipInfo.bg}`}
+                  className={`relative group/tooltip flex items-center gap-1 text-xs px-1.5 py-0.5 rounded ${ownershipInfo.color} ${ownershipInfo.bg}`}
                 >
                   {ownershipInfo.icon}
                   {ownershipInfo.label}
+                  {/* ponytail: native title tooltips get suppressed here since the whole card shifts on hover (hover:-translate-y-px), so use the app's CSS-driven tooltip pattern instead */}
+                  <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 rounded bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] font-normal whitespace-nowrap pointer-events-none opacity-0 group-hover/tooltip:opacity-100 transition-opacity z-10">
+                    {ownershipInfo.title}
+                  </span>
                 </span>
               )}
 


### PR DESCRIPTION
## Summary
- The review-ownership badge (Just you / Team / Shared) used a native `title` attribute for its tooltip, which never appeared: the card's `hover:-translate-y-px` transform shifts the badge under the cursor as soon as hover starts, resetting Chromium's native tooltip timer.
- Replaced it with the app's existing CSS `group-hover` tooltip pattern (already used in `ButtonWithTooltip`), which reacts to `:hover` state directly instead of a browser timer.

## Test plan
- [x] `npm run test:run -- src/features/pull-requests/components/PRCard/PRCard.test.tsx` (144 passed, unchanged assertions on badge label text)
- [ ] Manually hover the badge in `npm run dev:electron` to confirm the tooltip now shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)