### PR TITLE
feat: review-requested/assigned notification triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 build
 out
+release
 *.local
 .env
 .env*.local

--- a/electron/gh.ts
+++ b/electron/gh.ts
@@ -1,0 +1,23 @@
+import { spawn } from 'node:child_process'
+
+// ponytail: augment PATH so macOS .app bundles find gh via Homebrew/nix paths
+export const GH_PATH = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', process.env.PATH]
+  .filter(Boolean)
+  .join(':')
+
+export const runGh = (args: string[], stdinData?: string): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('gh', args, { env: { ...process.env, PATH: GH_PATH } })
+    let stdout = ''
+    let stderr = ''
+    proc.stdout.on('data', (d: Buffer) => (stdout += d.toString()))
+    proc.stderr.on('data', (d: Buffer) => (stderr += d.toString()))
+    proc.on('close', (code: number | null) => {
+      if (code === 0) resolve(stdout)
+      else reject(new Error(stderr || `gh exited with code ${code}`))
+    })
+    proc.on('error', reject)
+    if (stdinData) proc.stdin.write(stdinData)
+    proc.stdin.end()
+  })
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,34 +1,13 @@
 import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron'
 import { autoUpdater } from 'electron-updater'
-import { spawn, execFile } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
 import fs from 'node:fs'
+import { runGh, GH_PATH } from './gh'
 import { initNotifications } from './notifications'
 
 const execFileAsync = promisify(execFile)
-
-// ponytail: augment PATH so macOS .app bundles find gh via Homebrew/nix paths
-const GH_PATH = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', process.env.PATH]
-  .filter(Boolean)
-  .join(':')
-
-const runGh = (args: string[], stdinData?: string): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    const proc = spawn('gh', args, { env: { ...process.env, PATH: GH_PATH } })
-    let stdout = ''
-    let stderr = ''
-    proc.stdout.on('data', (d: Buffer) => (stdout += d.toString()))
-    proc.stderr.on('data', (d: Buffer) => (stderr += d.toString()))
-    proc.on('close', (code: number | null) => {
-      if (code === 0) resolve(stdout)
-      else reject(new Error(stderr || `gh exited with code ${code}`))
-    })
-    proc.on('error', reject)
-    if (stdinData) proc.stdin.write(stdinData)
-    proc.stdin.end()
-  })
-}
 
 ipcMain.handle('gh:installed', async () => {
   try {
@@ -210,7 +189,7 @@ const parseWorktrees = (output: string) => {
   }))
 }
 
-const createWindow = () => {
+export const createWindow = () => {
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
@@ -240,6 +219,8 @@ const createWindow = () => {
   } else {
     win.loadFile(path.join(__dirname, '../renderer/index.html'))
   }
+
+  return win
 }
 
 ipcMain.handle('dirs:filter-existing', async (_e, paths: string[]) => {

--- a/electron/notificationCopy.test.ts
+++ b/electron/notificationCopy.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { buildSearchQuery, diffNewIds, formatNewPRNotification } from './notificationCopy'
+import {
+  buildSearchQuery,
+  diffNewIds,
+  filterMuted,
+  formatNewPRNotification,
+  isRepoMatchedBy,
+} from './notificationCopy'
 import type { NewPRNode } from './notificationCopy'
 
 const givenPR = (overrides: Partial<NewPRNode> = {}): NewPRNode => ({
@@ -69,5 +75,40 @@ describe('formatNewPRNotification', () => {
     ]
     const result = formatNewPRNotification('assigned', nodes)
     expect(result).toEqual({ title: '2 new assignments', body: 'donna, api' })
+  })
+})
+
+describe('isRepoMatchedBy', () => {
+  it('matches an exact owner/repo pattern', () => {
+    expect(isRepoMatchedBy('acme/donna', 'acme/donna')).toBe(true)
+    expect(isRepoMatchedBy('acme/donna', 'acme/other')).toBe(false)
+  })
+
+  it('matches org-wide when the pattern has no slash', () => {
+    expect(isRepoMatchedBy('acme/donna', 'acme')).toBe(true)
+    expect(isRepoMatchedBy('other/donna', 'acme')).toBe(false)
+  })
+})
+
+describe('filterMuted', () => {
+  it('drops PRs from a muted author, case-insensitively', () => {
+    const nodes = [
+      givenPR({ author: { login: 'Dependabot' } }),
+      givenPR({ author: { login: 'octocat' } }),
+    ]
+    expect(filterMuted(nodes, ['dependabot'], [])).toEqual([nodes[1]])
+  })
+
+  it('drops PRs from a muted repo (org-wide pattern)', () => {
+    const nodes = [
+      givenPR({ repository: { nameWithOwner: 'acme/donna' } }),
+      givenPR({ repository: { nameWithOwner: 'other/donna' } }),
+    ]
+    expect(filterMuted(nodes, [], ['acme'])).toEqual([nodes[1]])
+  })
+
+  it('keeps PRs with no author untouched by author muting', () => {
+    const nodes = [givenPR({ author: null })]
+    expect(filterMuted(nodes, ['dependabot'], [])).toEqual(nodes)
   })
 })

--- a/electron/notificationCopy.test.ts
+++ b/electron/notificationCopy.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { buildSearchQuery, diffNewIds, formatNewPRNotification } from './notificationCopy'
+import type { NewPRNode } from './notificationCopy'
+
+const givenPR = (overrides: Partial<NewPRNode> = {}): NewPRNode => ({
+  number: 42,
+  title: 'Fix the thing',
+  author: { login: 'octocat' },
+  repository: { nameWithOwner: 'acme/donna' },
+  ...overrides,
+})
+
+describe('buildSearchQuery', () => {
+  it('builds a review-requested search for the given login', () => {
+    expect(buildSearchQuery('review-requested', 'octocat')).toBe(
+      'is:open is:pr archived:false sort:updated-desc review-requested:octocat'
+    )
+  })
+
+  it('builds an assigned search excluding PRs authored by the login', () => {
+    expect(buildSearchQuery('assigned', 'octocat')).toBe(
+      'is:open is:pr archived:false sort:updated-desc assignee:octocat -author:octocat'
+    )
+  })
+})
+
+describe('diffNewIds', () => {
+  it('returns fetched ids not present in seenIds', () => {
+    expect(diffNewIds(['a', 'b', 'c'], ['a'])).toEqual(['b', 'c'])
+  })
+
+  it('returns nothing when everything was already seen', () => {
+    expect(diffNewIds(['a', 'b'], ['a', 'b'])).toEqual([])
+  })
+})
+
+describe('formatNewPRNotification', () => {
+  it('formats a single new review-requested PR', () => {
+    const result = formatNewPRNotification('review-requested', [givenPR()])
+    expect(result).toEqual({
+      title: 'New review request',
+      body: 'acme/donna#42 · Fix the thing — by octocat',
+    })
+  })
+
+  it('formats a single new assigned PR', () => {
+    const result = formatNewPRNotification('assigned', [givenPR()])
+    expect(result.title).toBe('You were assigned')
+  })
+
+  it('formats multiple new PRs in the same category/tick, truncating repo names at 3', () => {
+    const nodes = [
+      givenPR({ repository: { nameWithOwner: 'acme/donna' } }),
+      givenPR({ repository: { nameWithOwner: 'acme/api' } }),
+      givenPR({ repository: { nameWithOwner: 'acme/web' } }),
+      givenPR({ repository: { nameWithOwner: 'acme/infra' } }),
+    ]
+    const result = formatNewPRNotification('review-requested', nodes)
+    expect(result).toEqual({
+      title: '4 new review requests',
+      body: 'donna, api, web and 1 more',
+    })
+  })
+
+  it('does not append "and N more" when repo names fit within the truncation limit', () => {
+    const nodes = [
+      givenPR({ repository: { nameWithOwner: 'acme/donna' } }),
+      givenPR({ repository: { nameWithOwner: 'acme/api' } }),
+    ]
+    const result = formatNewPRNotification('assigned', nodes)
+    expect(result).toEqual({ title: '2 new assignments', body: 'donna, api' })
+  })
+})

--- a/electron/notificationCopy.ts
+++ b/electron/notificationCopy.ts
@@ -1,0 +1,60 @@
+export type NotificationCategory = 'review-requested' | 'assigned' | 'reviewed'
+
+export type NewPRNode = {
+  number: number
+  title: string
+  author: { login: string } | null
+  repository: { nameWithOwner: string }
+}
+
+const SINGLE_TITLE: Record<NotificationCategory, string> = {
+  'review-requested': 'New review request',
+  assigned: 'You were assigned',
+  reviewed: 'New PR to review',
+}
+
+const PLURAL_LABEL: Record<NotificationCategory, string> = {
+  'review-requested': 'new review requests',
+  assigned: 'new assignments',
+  reviewed: 'new PRs to review',
+}
+
+const MAX_REPOS_IN_BODY = 3
+
+export const buildSearchQuery = (category: NotificationCategory, login: string): string => {
+  const base = 'is:open is:pr archived:false sort:updated-desc'
+  switch (category) {
+    case 'review-requested':
+      return `${base} review-requested:${login}`
+    case 'assigned':
+      return `${base} assignee:${login} -author:${login}`
+    case 'reviewed':
+      return `${base} reviewed-by:${login} -author:${login}`
+  }
+}
+
+export const diffNewIds = (fetchedIds: string[], seenIds: string[]): string[] => {
+  const seen = new Set(seenIds)
+  return fetchedIds.filter((id) => !seen.has(id))
+}
+
+export const formatNewPRNotification = (
+  category: NotificationCategory,
+  nodes: NewPRNode[]
+): { title: string; body: string } => {
+  if (nodes.length === 1) {
+    const pr = nodes[0]
+    return {
+      title: SINGLE_TITLE[category],
+      body: `${pr.repository.nameWithOwner}#${pr.number} · ${pr.title} — by ${pr.author?.login ?? 'unknown'}`,
+    }
+  }
+
+  const repoNames = [...new Set(nodes.map((n) => n.repository.nameWithOwner.split('/')[1]))]
+  const shown = repoNames.slice(0, MAX_REPOS_IN_BODY)
+  const rest = repoNames.length - shown.length
+  return {
+    title: `${nodes.length} ${PLURAL_LABEL[category]}`,
+    body: rest > 0 ? `${shown.join(', ')} and ${rest} more` : shown.join(', '),
+  }
+}

--- a/electron/notificationCopy.ts
+++ b/electron/notificationCopy.ts
@@ -7,6 +7,24 @@ export type NewPRNode = {
   repository: { nameWithOwner: string }
 }
 
+// supports "owner/repo" (exact) or "owner" (org-wide) — mirrors prFilters.ts's isRepoMatchedBy
+export const isRepoMatchedBy = (repoNameWithOwner: string, pattern: string): boolean => {
+  const repo = repoNameWithOwner.toLowerCase()
+  return pattern.includes('/') ? repo === pattern : repo.split('/')[0] === pattern
+}
+
+export const filterMuted = <T extends NewPRNode>(
+  nodes: T[],
+  hiddenAuthors: string[],
+  hiddenRepos: string[]
+): T[] =>
+  nodes.filter((n) => {
+    if (n.author && hiddenAuthors.some((a) => n.author!.login.toLowerCase() === a.toLowerCase()))
+      return false
+    if (hiddenRepos.some((r) => isRepoMatchedBy(n.repository.nameWithOwner, r))) return false
+    return true
+  })
+
 const SINGLE_TITLE: Record<NotificationCategory, string> = {
   'review-requested': 'New review request',
   assigned: 'You were assigned',

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -97,7 +97,8 @@ const ensureViewerLogin = async (): Promise<string | null> => {
   try {
     const res = await graphql<{ data: { viewer: { login: string } } }>(VIEWER_QUERY, {})
     viewerLogin = res.data.viewer.login
-  } catch {
+  } catch (e) {
+    console.error('[notifications] viewer lookup failed', e)
     return null
   }
   return viewerLogin
@@ -126,6 +127,9 @@ const handleSinglePRClick = (pr: NotificationPR) => {
 
 const fireNotification = (title: string, body: string, onClick: () => void) => {
   const notification = new Notification({ title, body })
+  // ponytail: UNUserNotificationCenter can silently refuse an unsigned dev-mode Electron
+  // bundle (UNErrorDomain error 1) — this only surfaces the failure, packaging is the fix.
+  notification.on('failed', (_e, error) => console.error('[notifications] failed', error))
   notification.on('click', () => {
     focusWindow()
     onClick()

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -1,8 +1,12 @@
-import { app, ipcMain, BrowserWindow } from 'electron'
+import { app, ipcMain, BrowserWindow, Notification, shell } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
+import { runGh } from './gh'
+import { createWindow } from './main'
+import { buildSearchQuery, diffNewIds, formatNewPRNotification } from './notificationCopy'
+import type { NotificationCategory } from './notificationCopy'
 
-export type NotificationCategory = 'review-requested' | 'assigned' | 'reviewed'
+export type { NotificationCategory }
 
 export type NotificationSettings = {
   enabledCategories: NotificationCategory[]
@@ -12,52 +16,171 @@ export type NotificationSettings = {
 
 export type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }
 
+type NotificationPR = {
+  id: string
+  number: number
+  title: string
+  url: string
+  author: { login: string } | null
+  repository: { nameWithOwner: string }
+}
+
 const DEFAULT_SETTINGS: NotificationSettings = {
   enabledCategories: ['review-requested', 'assigned'],
   pollIntervalMs: 5 * 60_000,
   openPRsInDonna: true,
 }
 
+type PersistedState = {
+  settings: NotificationSettings
+  seenIds: Partial<Record<NotificationCategory, string[]>>
+}
+
+const DEFAULT_STATE: PersistedState = { settings: DEFAULT_SETTINGS, seenIds: {} }
+
 const storePath = () => path.join(app.getPath('userData'), 'notifications.json')
 
-const loadSettings = (): NotificationSettings => {
+const loadState = (): PersistedState => {
   try {
     const raw = fs.readFileSync(storePath(), 'utf-8')
-    return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
+    const parsed = JSON.parse(raw)
+    return {
+      settings: { ...DEFAULT_SETTINGS, ...parsed.settings },
+      seenIds: parsed.seenIds ?? {},
+    }
   } catch {
-    return DEFAULT_SETTINGS
+    return DEFAULT_STATE
   }
 }
 
-const saveSettings = (settings: NotificationSettings) => {
-  fs.writeFileSync(storePath(), JSON.stringify(settings, null, 2))
-}
+const saveState = () => fs.writeFileSync(storePath(), JSON.stringify(state, null, 2))
 
-let settings: NotificationSettings = DEFAULT_SETTINGS
+let state: PersistedState = DEFAULT_STATE
+let viewerLogin: string | null = null
 let pollTimer: NodeJS.Timeout | null = null
 
-// ponytail: detection (new-PR / CI-failed / review-left) lands in a later PR — this tick is a
-// no-op placeholder so the interval is wired and restartable before any GitHub call exists.
-const tick = () => {}
-
-const startPolling = () => {
-  if (pollTimer) clearInterval(pollTimer)
-  pollTimer = setInterval(tick, settings.pollIntervalMs)
+const graphql = async <T>(query: string, variables: Record<string, unknown>): Promise<T> => {
+  const out = await runGh(['api', 'graphql', '--input', '-'], JSON.stringify({ query, variables }))
+  return JSON.parse(out) as T
 }
 
-export const initNotifications = () => {
-  settings = loadSettings()
-  startPolling()
+const VIEWER_QUERY = `query { viewer { login } }`
 
-  ipcMain.handle('notifications:updateSettings', (_e, partial: Partial<NotificationSettings>) => {
-    settings = { ...settings, ...partial }
-    saveSettings(settings)
-    startPolling()
-  })
+const SEARCH_QUERY = `
+  query NotificationSearch($searchQuery: String!) {
+    search(query: $searchQuery, type: ISSUE, first: 20) {
+      nodes {
+        ... on PullRequest {
+          id
+          number
+          title
+          url
+          author { login }
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }
+`
+
+const ensureViewerLogin = async (): Promise<string | null> => {
+  if (viewerLogin) return viewerLogin
+  try {
+    const res = await graphql<{ data: { viewer: { login: string } } }>(VIEWER_QUERY, {})
+    viewerLogin = res.data.viewer.login
+  } catch {
+    return null
+  }
+  return viewerLogin
 }
 
-export const sendNavigate = (payload: NotificationNavigatePayload) => {
+const focusWindow = () => {
+  const win = BrowserWindow.getAllWindows()[0] ?? createWindow()
+  win.show()
+  win.focus()
+}
+
+const sendNavigate = (payload: NotificationNavigatePayload) => {
   BrowserWindow.getAllWindows().forEach((w) =>
     w.webContents.send('notifications:navigate', payload)
   )
+}
+
+const handleSinglePRClick = (pr: NotificationPR) => {
+  if (state.settings.openPRsInDonna) {
+    const [owner, repo] = pr.repository.nameWithOwner.split('/')
+    sendNavigate({ route: `/prs/${owner}/${repo}/${pr.number}` })
+  } else {
+    shell.openExternal(pr.url)
+  }
+}
+
+const fireNotification = (title: string, body: string, onClick: () => void) => {
+  const notification = new Notification({ title, body })
+  notification.on('click', () => {
+    focusWindow()
+    onClick()
+  })
+  notification.show()
+}
+
+const notifyNewPRs = (category: NotificationCategory, nodes: NotificationPR[]) => {
+  const { title, body } = formatNewPRNotification(category, nodes)
+  const onClick =
+    nodes.length === 1
+      ? () => handleSinglePRClick(nodes[0])
+      : () => sendNavigate({ section: category })
+  fireNotification(title, body, onClick)
+}
+
+const checkCategory = async (category: NotificationCategory) => {
+  if (!viewerLogin) return
+  let nodes: NotificationPR[]
+  try {
+    const res = await graphql<{ data: { search: { nodes: NotificationPR[] } } }>(SEARCH_QUERY, {
+      searchQuery: buildSearchQuery(category, viewerLogin),
+    })
+    nodes = res.data.search.nodes
+  } catch {
+    return
+  }
+
+  const fetchedIds = nodes.map((n) => n.id)
+  const seenIds = state.seenIds[category]
+  state.seenIds[category] = fetchedIds
+  saveState()
+
+  // First run for this category: seed seenIds, don't fire a notification storm.
+  if (seenIds === undefined) return
+
+  const newIds = diffNewIds(fetchedIds, seenIds)
+  if (newIds.length === 0) return
+  notifyNewPRs(
+    category,
+    nodes.filter((n) => newIds.includes(n.id))
+  )
+}
+
+const tick = async () => {
+  const login = await ensureViewerLogin()
+  if (!login) return
+  for (const category of state.settings.enabledCategories) {
+    await checkCategory(category)
+  }
+}
+
+const startPolling = () => {
+  if (pollTimer) clearInterval(pollTimer)
+  pollTimer = setInterval(tick, state.settings.pollIntervalMs)
+}
+
+export const initNotifications = () => {
+  state = loadState()
+  startPolling()
+
+  ipcMain.handle('notifications:updateSettings', (_e, partial: Partial<NotificationSettings>) => {
+    state.settings = { ...state.settings, ...partial }
+    saveState()
+    startPolling()
+  })
 }

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -125,14 +125,26 @@ const handleSinglePRClick = (pr: NotificationPR) => {
   }
 }
 
+// ponytail: Electron GCs a Notification with no surviving reference, silently killing its
+// 'click' handler — hold one until it's dismissed/clicked so the click-through actually fires.
+const liveNotifications = new Set<Notification>()
+
 const fireNotification = (title: string, body: string, onClick: () => void) => {
   const notification = new Notification({ title, body })
+  liveNotifications.add(notification)
+  const release = () => liveNotifications.delete(notification)
+
   // ponytail: UNUserNotificationCenter can silently refuse an unsigned dev-mode Electron
   // bundle (UNErrorDomain error 1) — this only surfaces the failure, packaging is the fix.
-  notification.on('failed', (_e, error) => console.error('[notifications] failed', error))
+  notification.on('failed', (_e, error) => {
+    console.error('[notifications] failed', error)
+    release()
+  })
+  notification.on('close', release)
   notification.on('click', () => {
     focusWindow()
     onClick()
+    release()
   })
   notification.show()
 }

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -3,7 +3,12 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { runGh } from './gh'
 import { createWindow } from './main'
-import { buildSearchQuery, diffNewIds, formatNewPRNotification } from './notificationCopy'
+import {
+  buildSearchQuery,
+  diffNewIds,
+  filterMuted,
+  formatNewPRNotification,
+} from './notificationCopy'
 import type { NotificationCategory } from './notificationCopy'
 
 export type { NotificationCategory }
@@ -12,6 +17,8 @@ export type NotificationSettings = {
   enabledCategories: NotificationCategory[]
   pollIntervalMs: number
   openPRsInDonna: boolean
+  hiddenAuthors: string[]
+  hiddenRepos: string[]
 }
 
 export type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }
@@ -29,6 +36,8 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   enabledCategories: ['review-requested', 'assigned'],
   pollIntervalMs: 5 * 60_000,
   openPRsInDonna: true,
+  hiddenAuthors: [],
+  hiddenRepos: [],
 }
 
 type PersistedState = {
@@ -140,7 +149,11 @@ const checkCategory = async (category: NotificationCategory) => {
     const res = await graphql<{ data: { search: { nodes: NotificationPR[] } } }>(SEARCH_QUERY, {
       searchQuery: buildSearchQuery(category, viewerLogin),
     })
-    nodes = res.data.search.nodes
+    nodes = filterMuted(
+      res.data.search.nodes,
+      state.settings.hiddenAuthors,
+      state.settings.hiddenRepos
+    )
   } catch {
     return
   }

--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react'
 import { LogOut, Moon, Sun } from 'lucide-react'
-import { NavLink, Outlet } from 'react-router'
+import { NavLink, Outlet, useNavigate } from 'react-router'
 import { useAuthStore } from '@/features/auth/exports'
+import { usePRStore } from '@/features/pull-requests/exports'
 import { useTheme } from '@/shared/hooks/useTheme'
 import { useFeatures, type Feature } from '@/shared/features'
 import { Footer } from '@/shared/components/Footer/Footer'
@@ -17,6 +19,14 @@ export const AppLayout = () => {
   const { data: latestVersion } = useUpdateCheck()
   const { theme, toggle } = useTheme()
   const features = useFeatures()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    window.electronAPI?.notifications.onNavigate((payload) => {
+      if ('route' in payload) navigate(payload.route)
+      else usePRStore.getState().setSection(payload.section)
+    })
+  }, [navigate])
 
   return (
     <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)] flex flex-col">

--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -20,6 +20,9 @@ export const AppLayout = () => {
   const { theme, toggle } = useTheme()
   const features = useFeatures()
   const navigate = useNavigate()
+  const hiddenAuthors = usePRStore((s) => s.globalFilters.hiddenAuthors)
+  const hiddenRepos = usePRStore((s) => s.globalFilters.hiddenRepos)
+  const openPRsInDonna = usePRStore((s) => s.openPRsInDonna)
 
   useEffect(() => {
     window.electronAPI?.notifications.onNavigate((payload) => {
@@ -27,6 +30,12 @@ export const AppLayout = () => {
       else usePRStore.getState().setSection(payload.section)
     })
   }, [navigate])
+
+  // ponytail: pushes only the fields the main-process poll needs to filter/deep-link;
+  // enabledCategories/pollIntervalMs get pushed from notificationStore once that lands.
+  useEffect(() => {
+    window.electronAPI?.notifications.updateSettings({ hiddenAuthors, hiddenRepos, openPRsInDonna })
+  }, [hiddenAuthors, hiddenRepos, openPRsInDonna])
 
   return (
     <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)] flex flex-col">

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -50,6 +50,8 @@ type NotificationSettings = {
   enabledCategories: NotificationCategory[]
   pollIntervalMs: number
   openPRsInDonna: boolean
+  hiddenAuthors: string[]
+  hiddenRepos: string[]
 }
 
 type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }


### PR DESCRIPTION
## Summary
- Second PR of `specs/notifications.md`'s v3.0.0 milestone (§Shipping plan, PR 2) — group (a) detection
- `electron/notifications.ts`: resolves the viewer login once (cached, retried on failure), runs one lightweight search per enabled category (`review-requested`/`assigned`), diffs against persisted `seenIds` (seeds silently on first run per category), fires a native `Notification` on new PRs
- Respects muted authors/hidden repos: filters fetched PRs against `hiddenAuthors`/`hiddenRepos` (same logic as `prFilters.ts`) before diffing, so a muted author or hidden repo never fires a notification even though it's absent from the in-app list — this wasn't in the original spec, added after review
- `electron/notificationCopy.ts` (+ colocated test): pure, Electron-free title/body formatting (singular vs "N new ..." plural with repo-name truncation at 3), the search-query builder, and the mute filter — kept dependency-free so it's unit-testable without a real Electron runtime, same pattern as `prUtils.ts`/`prFilters.ts` on the renderer side
- Click-through: single new PR → in-app deep link (`/prs/:owner/:repo/:number`) or `shell.openExternal` depending on `openPRsInDonna`; multiple new PRs in one tick → focuses the window and switches section
- `electron/gh.ts`: extracted `runGh`/`GH_PATH` out of `main.ts` so `notifications.ts` can shell out to `gh` without importing `main.ts`'s internals directly (only `createWindow` is still imported from `main.ts`, used lazily inside the click handler)
- `src/containers/AppLayout.tsx`: listens for `notifications:navigate` and calls `navigate(route)` or `setSection(section)`; also pushes `{hiddenAuthors, hiddenRepos, openPRsInDonna}` from `prStore` to main on mount and on change, since main has no access to the renderer's `localStorage`-backed store — `enabledCategories`/`pollIntervalMs` still get pushed once `notificationStore` (PR 3) exists
- Two bugs found and fixed during manual testing:
  - `npm run dev:electron`'s unsigned `Electron.app` bundle gets refused by macOS's `UNUserNotificationCenter` (`UNErrorDomain error 1`) — no permission entry ever appears in System Settings and `.show()` silently fails. Not a code bug; only reproduces with a real signed build (`npm run build:electron`). Added a `notification.on('failed', ...)` error log so this kind of OS-level rejection surfaces instead of vanishing silently.
  - Click-through did nothing beyond focusing the window: Electron GCs a `Notification` instance with no surviving reference, silently dropping its `'click'` handler. Fixed by holding a reference in a module-level `Set` until it closes/fails/is clicked.
- Also added `release` to `.gitignore` (electron-builder's output dir, wasn't ignored)

## Test plan
- [x] `tsc -b` clean
- [x] `electron-vite build` bundles main/preload/renderer without errors (circular `main.ts` ↔ `notifications.ts` import resolves fine — only used inside deferred callbacks, never at module top level)
- [x] `vitest run` — 483 passed (13 new in `notificationCopy.test.ts`)
- [x] `eslint` / `prettier --check` clean on all touched files
- [x] Manual, packaged signed build (`npm run build:electron`, Developer ID signed, not notarized) — all against a real `gh`-authenticated account:
  - Notification fires for a newly-assigned PR
  - Muted `hiddenAuthors`/`hiddenRepos` from `prStore` reach `notifications.json` and suppress notifications correctly
  - Click-through navigates to the right PR with `openPRsInDonna: true`
  - Click-through opens the PR in the external browser with `openPRsInDonna: false`
  - Restart with nothing new doesn't re-notify already-seen PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgJ944dCZK9mpqVAZK5BVx