### PR TITLE
feat: notification settings page + per-section CI check notifications

### DIFF
--- a/electron/notificationCopy.test.ts
+++ b/electron/notificationCopy.test.ts
@@ -4,8 +4,10 @@ import {
   diffNewIds,
   filterDrafts,
   filterMuted,
+  formatCheckStateNotification,
   formatNewPRNotification,
   isRepoMatchedBy,
+  isTerminalCheckState,
 } from './notificationCopy'
 import type { NewPRNode } from './notificationCopy'
 
@@ -27,6 +29,12 @@ describe('buildSearchQuery', () => {
   it('builds an assigned search excluding PRs authored by the login', () => {
     expect(buildSearchQuery('assigned', 'octocat')).toBe(
       'is:open is:pr archived:false sort:updated-desc assignee:octocat -author:octocat'
+    )
+  })
+
+  it('builds an authored search for the given login', () => {
+    expect(buildSearchQuery('authored', 'octocat')).toBe(
+      'is:open is:pr archived:false sort:updated-desc author:octocat'
     )
   })
 })
@@ -123,5 +131,37 @@ describe('filterDrafts', () => {
   it('keeps draft PRs when showDrafts is on', () => {
     const nodes = [{ isDraft: true }, { isDraft: false }]
     expect(filterDrafts(nodes, true)).toEqual(nodes)
+  })
+})
+
+describe('isTerminalCheckState', () => {
+  it('treats SUCCESS and FAILURE as terminal', () => {
+    expect(isTerminalCheckState('SUCCESS')).toBe(true)
+    expect(isTerminalCheckState('FAILURE')).toBe(true)
+  })
+
+  it('treats PENDING, EXPECTED, ERROR and null as non-terminal', () => {
+    expect(isTerminalCheckState('PENDING')).toBe(false)
+    expect(isTerminalCheckState('EXPECTED')).toBe(false)
+    expect(isTerminalCheckState('ERROR')).toBe(false)
+    expect(isTerminalCheckState(null)).toBe(false)
+  })
+})
+
+describe('formatCheckStateNotification', () => {
+  const pr = { number: 42, title: 'Fix the thing', repository: { nameWithOwner: 'acme/donna' } }
+
+  it('formats a CI failure', () => {
+    expect(formatCheckStateNotification(pr, 'FAILURE')).toEqual({
+      title: 'CI failed',
+      body: 'acme/donna#42 · Fix the thing',
+    })
+  })
+
+  it('formats a CI pass', () => {
+    expect(formatCheckStateNotification(pr, 'SUCCESS')).toEqual({
+      title: 'CI passed',
+      body: 'acme/donna#42 · Fix the thing',
+    })
   })
 })

--- a/electron/notificationCopy.test.ts
+++ b/electron/notificationCopy.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   buildSearchQuery,
   diffNewIds,
+  filterDrafts,
   filterMuted,
   formatNewPRNotification,
   isRepoMatchedBy,
@@ -110,5 +111,17 @@ describe('filterMuted', () => {
   it('keeps PRs with no author untouched by author muting', () => {
     const nodes = [givenPR({ author: null })]
     expect(filterMuted(nodes, ['dependabot'], [])).toEqual(nodes)
+  })
+})
+
+describe('filterDrafts', () => {
+  it('drops draft PRs when showDrafts is off', () => {
+    const nodes = [{ isDraft: true }, { isDraft: false }]
+    expect(filterDrafts(nodes, false)).toEqual([{ isDraft: false }])
+  })
+
+  it('keeps draft PRs when showDrafts is on', () => {
+    const nodes = [{ isDraft: true }, { isDraft: false }]
+    expect(filterDrafts(nodes, true)).toEqual(nodes)
   })
 })

--- a/electron/notificationCopy.ts
+++ b/electron/notificationCopy.ts
@@ -1,9 +1,22 @@
 export type NotificationCategory = 'review-requested' | 'assigned' | 'reviewed'
 
+// the per-PR-state-diff sections (checks) — 'authored' has no new-PR notification (group a),
+// only check-state tracking, so it's not part of NotificationCategory
+export type ChecksSection = 'authored' | 'assigned'
+export type NotificationSection = NotificationCategory | 'authored'
+
+export type CheckRollupState = 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED'
+
 export type NewPRNode = {
   number: number
   title: string
   author: { login: string } | null
+  repository: { nameWithOwner: string }
+}
+
+export type CheckedPRNode = {
+  number: number
+  title: string
   repository: { nameWithOwner: string }
 }
 
@@ -44,17 +57,31 @@ const PLURAL_LABEL: Record<NotificationCategory, string> = {
 
 const MAX_REPOS_IN_BODY = 3
 
-export const buildSearchQuery = (category: NotificationCategory, login: string): string => {
+export const buildSearchQuery = (section: NotificationSection, login: string): string => {
   const base = 'is:open is:pr archived:false sort:updated-desc'
-  switch (category) {
+  switch (section) {
     case 'review-requested':
       return `${base} review-requested:${login}`
     case 'assigned':
       return `${base} assignee:${login} -author:${login}`
     case 'reviewed':
       return `${base} reviewed-by:${login} -author:${login}`
+    case 'authored':
+      return `${base} author:${login}`
   }
 }
+
+// terminal = worth notifying about; PENDING/EXPECTED are still in flight
+export const isTerminalCheckState = (state: CheckRollupState | null): boolean =>
+  state === 'SUCCESS' || state === 'FAILURE'
+
+export const formatCheckStateNotification = (
+  pr: CheckedPRNode,
+  checkState: CheckRollupState
+): { title: string; body: string } => ({
+  title: checkState === 'FAILURE' ? 'CI failed' : 'CI passed',
+  body: `${pr.repository.nameWithOwner}#${pr.number} · ${pr.title}`,
+})
 
 export const diffNewIds = (fetchedIds: string[], seenIds: string[]): string[] => {
   const seen = new Set(seenIds)

--- a/electron/notificationCopy.ts
+++ b/electron/notificationCopy.ts
@@ -25,6 +25,11 @@ export const filterMuted = <T extends NewPRNode>(
     return true
   })
 
+export const filterDrafts = <T extends { isDraft: boolean }>(
+  nodes: T[],
+  showDrafts: boolean
+): T[] => (showDrafts ? nodes : nodes.filter((n) => !n.isDraft))
+
 const SINGLE_TITLE: Record<NotificationCategory, string> = {
   'review-requested': 'New review request',
   assigned: 'You were assigned',

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -8,9 +8,16 @@ import {
   diffNewIds,
   filterDrafts,
   filterMuted,
+  formatCheckStateNotification,
   formatNewPRNotification,
+  isTerminalCheckState,
 } from './notificationCopy'
-import type { NotificationCategory } from './notificationCopy'
+import type {
+  ChecksSection,
+  CheckRollupState,
+  NotificationCategory,
+  NotificationSection,
+} from './notificationCopy'
 
 export type { NotificationCategory }
 
@@ -20,7 +27,8 @@ export type NotificationSettings = {
   openPRsInDonna: boolean
   hiddenAuthors: string[]
   hiddenRepos: string[]
-  showDraftsByCategory: Record<NotificationCategory, boolean>
+  showDraftsByCategory: Record<NotificationSection, boolean>
+  checksEnabled: Record<ChecksSection, boolean>
 }
 
 export type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }
@@ -31,6 +39,7 @@ type NotificationPR = {
   title: string
   url: string
   isDraft: boolean
+  checkState: CheckRollupState | null
   author: { login: string } | null
   repository: { nameWithOwner: string }
 }
@@ -41,15 +50,28 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   openPRsInDonna: true,
   hiddenAuthors: [],
   hiddenRepos: [],
-  showDraftsByCategory: { 'review-requested': false, assigned: false, reviewed: false },
+  showDraftsByCategory: {
+    'review-requested': false,
+    assigned: false,
+    reviewed: false,
+    authored: true,
+  },
+  // opt-in: unlike new-PR notifications, per-check-state notifications can fire often on an
+  // active PR (every re-run), so we don't turn this on until the user asks for it in Settings
+  checksEnabled: { authored: false, assigned: false },
 }
 
 type PersistedState = {
   settings: NotificationSettings
   seenIds: Partial<Record<NotificationCategory, string[]>>
+  lastCheckState: Partial<Record<ChecksSection, Record<string, CheckRollupState | null>>>
 }
 
-const DEFAULT_STATE: PersistedState = { settings: DEFAULT_SETTINGS, seenIds: {} }
+const DEFAULT_STATE: PersistedState = {
+  settings: DEFAULT_SETTINGS,
+  seenIds: {},
+  lastCheckState: {},
+}
 
 const storePath = () => path.join(app.getPath('userData'), 'notifications.json')
 
@@ -65,8 +87,13 @@ const loadState = (): PersistedState => {
           ...DEFAULT_SETTINGS.showDraftsByCategory,
           ...parsed.settings?.showDraftsByCategory,
         },
+        checksEnabled: {
+          ...DEFAULT_SETTINGS.checksEnabled,
+          ...parsed.settings?.checksEnabled,
+        },
       },
       seenIds: parsed.seenIds ?? {},
+      lastCheckState: parsed.lastCheckState ?? {},
     }
   } catch {
     return DEFAULT_STATE
@@ -98,11 +125,35 @@ const SEARCH_QUERY = `
           isDraft
           author { login }
           repository { nameWithOwner }
+          commits(last: 1) {
+            nodes {
+              commit {
+                statusCheckRollup {
+                  state
+                }
+              }
+            }
+          }
         }
       }
     }
   }
 `
+
+type RawSearchNode = Omit<NotificationPR, 'checkState'> & {
+  commits: { nodes: { commit: { statusCheckRollup: { state: CheckRollupState } | null } | null }[] }
+}
+
+const toNotificationPR = (raw: RawSearchNode): NotificationPR => ({
+  id: raw.id,
+  number: raw.number,
+  title: raw.title,
+  url: raw.url,
+  isDraft: raw.isDraft,
+  author: raw.author,
+  repository: raw.repository,
+  checkState: raw.commits.nodes[0]?.commit?.statusCheckRollup?.state ?? null,
+})
 
 const ensureViewerLogin = async (): Promise<string | null> => {
   if (viewerLogin) return viewerLogin
@@ -170,20 +221,32 @@ const notifyNewPRs = (category: NotificationCategory, nodes: NotificationPR[]) =
   fireNotification(title, body, onClick)
 }
 
-const checkCategory = async (category: NotificationCategory) => {
-  if (!viewerLogin) return
-  let nodes: NotificationPR[]
+const notifyCheckStateChange = (pr: NotificationPR) => {
+  const { title, body } = formatCheckStateNotification(pr, pr.checkState!)
+  fireNotification(title, body, () => handleSinglePRClick(pr))
+}
+
+// shared by both the new-PR diff (group a) and the check-state diff (group b) — each section can
+// be polled for either or both independently, so the fetch+filter step is the only thing in common
+const fetchSection = async (section: NotificationSection): Promise<NotificationPR[] | null> => {
+  if (!viewerLogin) return null
   try {
-    const res = await graphql<{ data: { search: { nodes: NotificationPR[] } } }>(SEARCH_QUERY, {
-      searchQuery: buildSearchQuery(category, viewerLogin),
+    const res = await graphql<{ data: { search: { nodes: RawSearchNode[] } } }>(SEARCH_QUERY, {
+      searchQuery: buildSearchQuery(section, viewerLogin),
     })
-    nodes = filterDrafts(
-      filterMuted(res.data.search.nodes, state.settings.hiddenAuthors, state.settings.hiddenRepos),
-      state.settings.showDraftsByCategory[category]
+    const nodes = res.data.search.nodes.map(toNotificationPR)
+    return filterDrafts(
+      filterMuted(nodes, state.settings.hiddenAuthors, state.settings.hiddenRepos),
+      state.settings.showDraftsByCategory[section]
     )
   } catch {
-    return
+    return null
   }
+}
+
+const checkNewPRs = async (category: NotificationCategory) => {
+  const nodes = await fetchSection(category)
+  if (!nodes) return
 
   const fetchedIds = nodes.map((n) => n.id)
   const seenIds = state.seenIds[category]
@@ -201,12 +264,36 @@ const checkCategory = async (category: NotificationCategory) => {
   )
 }
 
+// self-pruning like seenIds: nextMap only keeps ids still open, so closed/merged PRs drop out
+const checkChecks = async (section: ChecksSection) => {
+  const nodes = await fetchSection(section)
+  if (!nodes) return
+
+  const prevMap = state.lastCheckState[section] ?? {}
+  const nextMap: Record<string, CheckRollupState | null> = {}
+  for (const pr of nodes) {
+    const prevState = prevMap[pr.id]
+    nextMap[pr.id] = pr.checkState
+    // seed only on first sight of this PR — otherwise every already-green PR would notify once
+    if (
+      prevState !== undefined &&
+      pr.checkState !== prevState &&
+      isTerminalCheckState(pr.checkState)
+    )
+      notifyCheckStateChange(pr)
+  }
+  state.lastCheckState[section] = nextMap
+  saveState()
+}
+
 const tick = async () => {
   const login = await ensureViewerLogin()
   if (!login) return
   for (const category of state.settings.enabledCategories) {
-    await checkCategory(category)
+    await checkNewPRs(category)
   }
+  if (state.settings.checksEnabled.assigned) await checkChecks('assigned')
+  if (state.settings.checksEnabled.authored) await checkChecks('authored')
 }
 
 const startPolling = () => {

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -6,6 +6,7 @@ import { createWindow } from './main'
 import {
   buildSearchQuery,
   diffNewIds,
+  filterDrafts,
   filterMuted,
   formatNewPRNotification,
 } from './notificationCopy'
@@ -19,6 +20,7 @@ export type NotificationSettings = {
   openPRsInDonna: boolean
   hiddenAuthors: string[]
   hiddenRepos: string[]
+  showDraftsByCategory: Record<NotificationCategory, boolean>
 }
 
 export type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }
@@ -28,6 +30,7 @@ type NotificationPR = {
   number: number
   title: string
   url: string
+  isDraft: boolean
   author: { login: string } | null
   repository: { nameWithOwner: string }
 }
@@ -38,6 +41,7 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   openPRsInDonna: true,
   hiddenAuthors: [],
   hiddenRepos: [],
+  showDraftsByCategory: { 'review-requested': false, assigned: false, reviewed: false },
 }
 
 type PersistedState = {
@@ -54,7 +58,14 @@ const loadState = (): PersistedState => {
     const raw = fs.readFileSync(storePath(), 'utf-8')
     const parsed = JSON.parse(raw)
     return {
-      settings: { ...DEFAULT_SETTINGS, ...parsed.settings },
+      settings: {
+        ...DEFAULT_SETTINGS,
+        ...parsed.settings,
+        showDraftsByCategory: {
+          ...DEFAULT_SETTINGS.showDraftsByCategory,
+          ...parsed.settings?.showDraftsByCategory,
+        },
+      },
       seenIds: parsed.seenIds ?? {},
     }
   } catch {
@@ -84,6 +95,7 @@ const SEARCH_QUERY = `
           number
           title
           url
+          isDraft
           author { login }
           repository { nameWithOwner }
         }
@@ -165,10 +177,9 @@ const checkCategory = async (category: NotificationCategory) => {
     const res = await graphql<{ data: { search: { nodes: NotificationPR[] } } }>(SEARCH_QUERY, {
       searchQuery: buildSearchQuery(category, viewerLogin),
     })
-    nodes = filterMuted(
-      res.data.search.nodes,
-      state.settings.hiddenAuthors,
-      state.settings.hiddenRepos
+    nodes = filterDrafts(
+      filterMuted(res.data.search.nodes, state.settings.hiddenAuthors, state.settings.hiddenRepos),
+      state.settings.showDraftsByCategory[category]
     )
   } catch {
     return

--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
-import { LogOut, Moon, Sun } from 'lucide-react'
+import { LogOut, Moon, Settings, Sun } from 'lucide-react'
 import { NavLink, Outlet, useNavigate } from 'react-router'
 import { useAuthStore } from '@/features/auth/exports'
 import { usePRStore } from '@/features/pull-requests/exports'
+import { useNotificationStore } from '@/features/notifications/exports'
 import { useTheme } from '@/shared/hooks/useTheme'
 import { useFeatures, type Feature } from '@/shared/features'
 import { Footer } from '@/shared/components/Footer/Footer'
@@ -23,6 +24,8 @@ export const AppLayout = () => {
   const hiddenAuthors = usePRStore((s) => s.globalFilters.hiddenAuthors)
   const hiddenRepos = usePRStore((s) => s.globalFilters.hiddenRepos)
   const openPRsInDonna = usePRStore((s) => s.openPRsInDonna)
+  const enabledCategories = useNotificationStore((s) => s.enabledCategories)
+  const pollIntervalMs = useNotificationStore((s) => s.pollIntervalMs)
 
   useEffect(() => {
     window.electronAPI?.notifications.onNavigate((payload) => {
@@ -31,11 +34,16 @@ export const AppLayout = () => {
     })
   }, [navigate])
 
-  // ponytail: pushes only the fields the main-process poll needs to filter/deep-link;
-  // enabledCategories/pollIntervalMs get pushed from notificationStore once that lands.
+  // one push carries the full settings blob main needs — avoids a second sync path to keep in step
   useEffect(() => {
-    window.electronAPI?.notifications.updateSettings({ hiddenAuthors, hiddenRepos, openPRsInDonna })
-  }, [hiddenAuthors, hiddenRepos, openPRsInDonna])
+    window.electronAPI?.notifications.updateSettings({
+      hiddenAuthors,
+      hiddenRepos,
+      openPRsInDonna,
+      enabledCategories,
+      pollIntervalMs,
+    })
+  }, [hiddenAuthors, hiddenRepos, openPRsInDonna, enabledCategories, pollIntervalMs])
 
   return (
     <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)] flex flex-col">
@@ -72,6 +80,20 @@ export const AppLayout = () => {
               <img src={user.avatarUrl} alt={user.login} className="w-6 h-6 rounded-full" />
               <span className="text-xs text-[var(--color-text-secondary)]">{user.login}</span>
               <OnboardingGuide />
+              <NavLink
+                to="/settings"
+                title="Settings"
+                className={({ isActive }) =>
+                  `p-1.5 rounded transition-colors cursor-pointer
+                  ${
+                    isActive
+                      ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
+                      : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)]'
+                  }`
+                }
+              >
+                <Settings size={14} />
+              </NavLink>
               <button
                 onClick={toggle}
                 title="Toggle theme"

--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -8,7 +8,6 @@ import { useTheme } from '@/shared/hooks/useTheme'
 import { useFeatures, type Feature } from '@/shared/features'
 import { Footer } from '@/shared/components/Footer/Footer'
 import { useUpdateCheck, UpdateBanner } from '@/features/updates/exports'
-import { OnboardingGuide } from '@/features/onboarding/exports'
 
 const NAV_TABS: { to: string; label: string; feature?: Feature }[] = [
   { to: '/prs', label: 'Pull Requests' },
@@ -102,7 +101,6 @@ export const AppLayout = () => {
             <div className="flex items-center gap-3 shrink-0">
               <img src={user.avatarUrl} alt={user.login} className="w-6 h-6 rounded-full" />
               <span className="text-xs text-[var(--color-text-secondary)]">{user.login}</span>
-              <OnboardingGuide />
               <NavLink
                 to="/settings"
                 title="Settings"

--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -26,9 +26,11 @@ export const AppLayout = () => {
   const openPRsInDonna = usePRStore((s) => s.openPRsInDonna)
   const enabledCategories = useNotificationStore((s) => s.enabledCategories)
   const pollIntervalMs = useNotificationStore((s) => s.pollIntervalMs)
+  const checksEnabled = useNotificationStore((s) => s.checksEnabled)
   const showDraftsReviewRequested = usePRStore((s) => s.viewFilters['review-requested'].showDrafts)
   const showDraftsAssigned = usePRStore((s) => s.viewFilters.assigned.showDrafts)
   const showDraftsReviewed = usePRStore((s) => s.viewFilters.reviewed.showDrafts)
+  const showDraftsAuthored = usePRStore((s) => s.viewFilters.authored.showDrafts)
 
   useEffect(() => {
     window.electronAPI?.notifications.onNavigate((payload) => {
@@ -45,10 +47,12 @@ export const AppLayout = () => {
       openPRsInDonna,
       enabledCategories,
       pollIntervalMs,
+      checksEnabled,
       showDraftsByCategory: {
         'review-requested': showDraftsReviewRequested,
         assigned: showDraftsAssigned,
         reviewed: showDraftsReviewed,
+        authored: showDraftsAuthored,
       },
     })
   }, [
@@ -57,9 +61,11 @@ export const AppLayout = () => {
     openPRsInDonna,
     enabledCategories,
     pollIntervalMs,
+    checksEnabled,
     showDraftsReviewRequested,
     showDraftsAssigned,
     showDraftsReviewed,
+    showDraftsAuthored,
   ])
 
   return (

--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -26,6 +26,9 @@ export const AppLayout = () => {
   const openPRsInDonna = usePRStore((s) => s.openPRsInDonna)
   const enabledCategories = useNotificationStore((s) => s.enabledCategories)
   const pollIntervalMs = useNotificationStore((s) => s.pollIntervalMs)
+  const showDraftsReviewRequested = usePRStore((s) => s.viewFilters['review-requested'].showDrafts)
+  const showDraftsAssigned = usePRStore((s) => s.viewFilters.assigned.showDrafts)
+  const showDraftsReviewed = usePRStore((s) => s.viewFilters.reviewed.showDrafts)
 
   useEffect(() => {
     window.electronAPI?.notifications.onNavigate((payload) => {
@@ -42,8 +45,22 @@ export const AppLayout = () => {
       openPRsInDonna,
       enabledCategories,
       pollIntervalMs,
+      showDraftsByCategory: {
+        'review-requested': showDraftsReviewRequested,
+        assigned: showDraftsAssigned,
+        reviewed: showDraftsReviewed,
+      },
     })
-  }, [hiddenAuthors, hiddenRepos, openPRsInDonna, enabledCategories, pollIntervalMs])
+  }, [
+    hiddenAuthors,
+    hiddenRepos,
+    openPRsInDonna,
+    enabledCategories,
+    pollIntervalMs,
+    showDraftsReviewRequested,
+    showDraftsAssigned,
+    showDraftsReviewed,
+  ])
 
   return (
     <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)] flex flex-col">

--- a/src/features/branches/components/BranchList/BranchList.test.tsx
+++ b/src/features/branches/components/BranchList/BranchList.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BranchCard } from './BranchCard/BranchCard'
 import { BranchList } from './BranchList'
@@ -20,9 +21,11 @@ import { usePullRequests } from '@/features/pull-requests/exports'
 const renderBranchList = () => {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={client}>
-      <BranchList />
-    </QueryClientProvider>
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <BranchList />
+      </QueryClientProvider>
+    </MemoryRouter>
   )
 }
 

--- a/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
@@ -7,6 +7,7 @@ beforeEach(() => {
   useNotificationStore.setState({
     enabledCategories: ['review-requested', 'assigned'],
     pollIntervalMs: 5 * 60_000,
+    checksEnabled: { authored: false, assigned: false },
   })
 })
 
@@ -14,14 +15,14 @@ describe('SettingsPage', () => {
   it('GIVEN both categories enabled WHEN rendered THEN both checkboxes are checked', () => {
     render(<SettingsPage />)
 
-    expect(screen.getByLabelText('New review requests')).toBeChecked()
-    expect(screen.getByLabelText('New PRs assigned to me')).toBeChecked()
+    expect(screen.getByLabelText('Notify me on new review requests')).toBeChecked()
+    expect(screen.getByLabelText('Notify me when assigned')).toBeChecked()
   })
 
   it('GIVEN a checked category WHEN unchecked THEN it is removed from the store', () => {
     render(<SettingsPage />)
 
-    fireEvent.click(screen.getByLabelText('New review requests'))
+    fireEvent.click(screen.getByLabelText('Notify me on new review requests'))
 
     expect(useNotificationStore.getState().enabledCategories).toEqual(['assigned'])
   })
@@ -34,5 +35,33 @@ describe('SettingsPage', () => {
     })
 
     expect(useNotificationStore.getState().pollIntervalMs).toBe(60_000)
+  })
+
+  it('GIVEN checks notifications disabled WHEN the assigned CI checkbox is checked THEN only assigned is enabled', () => {
+    render(<SettingsPage />)
+    const [assignedChecks, authoredChecks] = screen.getAllByLabelText(
+      'Notify me when CI passes or fails'
+    )
+    expect(assignedChecks).not.toBeChecked()
+    expect(authoredChecks).not.toBeChecked()
+
+    fireEvent.click(assignedChecks)
+
+    expect(useNotificationStore.getState().checksEnabled).toEqual({
+      assigned: true,
+      authored: false,
+    })
+  })
+
+  it('GIVEN checks notifications disabled WHEN the authored CI checkbox is checked THEN only authored is enabled', () => {
+    render(<SettingsPage />)
+    const [, authoredChecks] = screen.getAllByLabelText('Notify me when CI passes or fails')
+
+    fireEvent.click(authoredChecks)
+
+    expect(useNotificationStore.getState().checksEnabled).toEqual({
+      assigned: false,
+      authored: true,
+    })
   })
 })

--- a/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
 import { SettingsPage } from './SettingsPage'
 import { useNotificationStore } from '../../stores/notificationStore'
+
+const renderSettingsPage = () =>
+  render(
+    <MemoryRouter>
+      <SettingsPage />
+    </MemoryRouter>
+  )
 
 beforeEach(() => {
   useNotificationStore.setState({
@@ -13,14 +21,14 @@ beforeEach(() => {
 
 describe('SettingsPage', () => {
   it('GIVEN both categories enabled WHEN rendered THEN both checkboxes are checked', () => {
-    render(<SettingsPage />)
+    renderSettingsPage()
 
     expect(screen.getByLabelText('Notify me on new review requests')).toBeChecked()
     expect(screen.getByLabelText('Notify me when assigned')).toBeChecked()
   })
 
   it('GIVEN a checked category WHEN unchecked THEN it is removed from the store', () => {
-    render(<SettingsPage />)
+    renderSettingsPage()
 
     fireEvent.click(screen.getByLabelText('Notify me on new review requests'))
 
@@ -28,7 +36,7 @@ describe('SettingsPage', () => {
   })
 
   it('GIVEN the interval select WHEN changed THEN the store updates', () => {
-    render(<SettingsPage />)
+    renderSettingsPage()
 
     fireEvent.change(screen.getByLabelText('Check for new PRs every'), {
       target: { value: '60000' },
@@ -38,7 +46,7 @@ describe('SettingsPage', () => {
   })
 
   it('GIVEN checks notifications disabled WHEN the assigned CI checkbox is checked THEN only assigned is enabled', () => {
-    render(<SettingsPage />)
+    renderSettingsPage()
     const [assignedChecks, authoredChecks] = screen.getAllByLabelText(
       'Notify me when CI passes or fails'
     )
@@ -54,7 +62,7 @@ describe('SettingsPage', () => {
   })
 
   it('GIVEN checks notifications disabled WHEN the authored CI checkbox is checked THEN only authored is enabled', () => {
-    render(<SettingsPage />)
+    renderSettingsPage()
     const [, authoredChecks] = screen.getAllByLabelText('Notify me when CI passes or fails')
 
     fireEvent.click(authoredChecks)

--- a/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SettingsPage } from './SettingsPage'
+import { useNotificationStore } from '../../stores/notificationStore'
+
+beforeEach(() => {
+  useNotificationStore.setState({
+    enabledCategories: ['review-requested', 'assigned'],
+    pollIntervalMs: 5 * 60_000,
+  })
+})
+
+describe('SettingsPage', () => {
+  it('GIVEN both categories enabled WHEN rendered THEN both checkboxes are checked', () => {
+    render(<SettingsPage />)
+
+    expect(screen.getByLabelText('New review requests')).toBeChecked()
+    expect(screen.getByLabelText('New PRs assigned to me')).toBeChecked()
+  })
+
+  it('GIVEN a checked category WHEN unchecked THEN it is removed from the store', () => {
+    render(<SettingsPage />)
+
+    fireEvent.click(screen.getByLabelText('New review requests'))
+
+    expect(useNotificationStore.getState().enabledCategories).toEqual(['assigned'])
+  })
+
+  it('GIVEN the interval select WHEN changed THEN the store updates', () => {
+    render(<SettingsPage />)
+
+    fireEvent.change(screen.getByLabelText('Check for new PRs every'), {
+      target: { value: '60000' },
+    })
+
+    expect(useNotificationStore.getState().pollIntervalMs).toBe(60_000)
+  })
+})

--- a/src/features/notifications/components/SettingsPage/SettingsPage.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.tsx
@@ -1,12 +1,5 @@
 import { useNotificationStore } from '../../stores/notificationStore'
 
-const CATEGORY_LABELS: Record<'review-requested' | 'assigned', string> = {
-  'review-requested': 'New review requests',
-  assigned: 'New PRs assigned to me',
-}
-
-const CATEGORIES = Object.keys(CATEGORY_LABELS) as (keyof typeof CATEGORY_LABELS)[]
-
 const INTERVAL_OPTIONS: { label: string; value: number }[] = [
   { label: '1 minute', value: 60_000 },
   { label: '5 minutes', value: 5 * 60_000 },
@@ -14,9 +7,31 @@ const INTERVAL_OPTIONS: { label: string; value: number }[] = [
   { label: '30 minutes', value: 30 * 60_000 },
 ]
 
+const Checkbox = ({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  onChange: () => void
+}) => (
+  <label className="flex items-center gap-2 cursor-pointer">
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      className="accent-[var(--color-accent)] cursor-pointer"
+    />
+    <span className="text-xs text-[var(--color-text-primary)]">{label}</span>
+  </label>
+)
+
 export const SettingsPage = () => {
   const enabledCategories = useNotificationStore((s) => s.enabledCategories)
   const toggleCategory = useNotificationStore((s) => s.toggleCategory)
+  const checksEnabled = useNotificationStore((s) => s.checksEnabled)
+  const toggleChecksEnabled = useNotificationStore((s) => s.toggleChecksEnabled)
   const pollIntervalMs = useNotificationStore((s) => s.pollIntervalMs)
   const setPollIntervalMs = useNotificationStore((s) => s.setPollIntervalMs)
 
@@ -29,23 +44,45 @@ export const SettingsPage = () => {
           Notifications
         </h3>
 
-        <div className="space-y-2">
-          {CATEGORIES.map((category) => (
-            <label key={category} className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={enabledCategories.includes(category)}
-                onChange={() => toggleCategory(category)}
-                className="accent-[var(--color-accent)] cursor-pointer"
-              />
-              <span className="text-xs text-[var(--color-text-primary)]">
-                {CATEGORY_LABELS[category]}
-              </span>
-            </label>
-          ))}
+        <div className="space-y-5">
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-[var(--color-text-secondary)]">
+              Review requested
+            </p>
+            <Checkbox
+              label="Notify me on new review requests"
+              checked={enabledCategories.includes('review-requested')}
+              onChange={() => toggleCategory('review-requested')}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-[var(--color-text-secondary)]">Assigned to me</p>
+            <Checkbox
+              label="Notify me when assigned"
+              checked={enabledCategories.includes('assigned')}
+              onChange={() => toggleCategory('assigned')}
+            />
+            <Checkbox
+              label="Notify me when CI passes or fails"
+              checked={checksEnabled.assigned}
+              onChange={() => toggleChecksEnabled('assigned')}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-[var(--color-text-secondary)]">
+              My pull requests
+            </p>
+            <Checkbox
+              label="Notify me when CI passes or fails"
+              checked={checksEnabled.authored}
+              onChange={() => toggleChecksEnabled('authored')}
+            />
+          </div>
         </div>
 
-        <div className="mt-4">
+        <div className="mt-5">
           <label
             htmlFor="poll-interval"
             className="block text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2"

--- a/src/features/notifications/components/SettingsPage/SettingsPage.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.tsx
@@ -1,3 +1,5 @@
+import { ArrowLeft } from 'lucide-react'
+import { useNavigate } from 'react-router'
 import { useNotificationStore } from '../../stores/notificationStore'
 
 const INTERVAL_OPTIONS: { label: string; value: number }[] = [
@@ -28,6 +30,7 @@ const Checkbox = ({
 )
 
 export const SettingsPage = () => {
+  const navigate = useNavigate()
   const enabledCategories = useNotificationStore((s) => s.enabledCategories)
   const toggleCategory = useNotificationStore((s) => s.toggleCategory)
   const checksEnabled = useNotificationStore((s) => s.checksEnabled)
@@ -37,11 +40,22 @@ export const SettingsPage = () => {
 
   return (
     <div className="max-w-lg space-y-6">
+      <button
+        onClick={() => navigate(-1)}
+        className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none rounded"
+      >
+        <ArrowLeft size={13} />
+        Back
+      </button>
+
       <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Settings</h2>
 
       <section>
-        <h3 className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">
+        <h3 className="flex items-center gap-2 text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">
           Notifications
+          <span className="normal-case tracking-normal text-[10px] font-semibold px-1.5 py-0.5 rounded bg-[var(--color-accent)]/15 text-[var(--color-accent)]">
+            Beta
+          </span>
         </h3>
 
         <div className="space-y-5">

--- a/src/features/notifications/components/SettingsPage/SettingsPage.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.tsx
@@ -1,0 +1,71 @@
+import { useNotificationStore } from '../../stores/notificationStore'
+
+const CATEGORY_LABELS: Record<'review-requested' | 'assigned', string> = {
+  'review-requested': 'New review requests',
+  assigned: 'New PRs assigned to me',
+}
+
+const CATEGORIES = Object.keys(CATEGORY_LABELS) as (keyof typeof CATEGORY_LABELS)[]
+
+const INTERVAL_OPTIONS: { label: string; value: number }[] = [
+  { label: '1 minute', value: 60_000 },
+  { label: '5 minutes', value: 5 * 60_000 },
+  { label: '15 minutes', value: 15 * 60_000 },
+  { label: '30 minutes', value: 30 * 60_000 },
+]
+
+export const SettingsPage = () => {
+  const enabledCategories = useNotificationStore((s) => s.enabledCategories)
+  const toggleCategory = useNotificationStore((s) => s.toggleCategory)
+  const pollIntervalMs = useNotificationStore((s) => s.pollIntervalMs)
+  const setPollIntervalMs = useNotificationStore((s) => s.setPollIntervalMs)
+
+  return (
+    <div className="max-w-lg space-y-6">
+      <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Settings</h2>
+
+      <section>
+        <h3 className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">
+          Notifications
+        </h3>
+
+        <div className="space-y-2">
+          {CATEGORIES.map((category) => (
+            <label key={category} className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={enabledCategories.includes(category)}
+                onChange={() => toggleCategory(category)}
+                className="accent-[var(--color-accent)] cursor-pointer"
+              />
+              <span className="text-xs text-[var(--color-text-primary)]">
+                {CATEGORY_LABELS[category]}
+              </span>
+            </label>
+          ))}
+        </div>
+
+        <div className="mt-4">
+          <label
+            htmlFor="poll-interval"
+            className="block text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2"
+          >
+            Check for new PRs every
+          </label>
+          <select
+            id="poll-interval"
+            value={pollIntervalMs}
+            onChange={(e) => setPollIntervalMs(Number(e.target.value))}
+            className="text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] bg-[var(--color-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)] cursor-pointer"
+          >
+            {INTERVAL_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/features/notifications/exports.ts
+++ b/src/features/notifications/exports.ts
@@ -1,0 +1,2 @@
+export { useNotificationStore } from './stores/notificationStore'
+export { SettingsPage } from './components/SettingsPage/SettingsPage'

--- a/src/features/notifications/stores/notificationStore.test.ts
+++ b/src/features/notifications/stores/notificationStore.test.ts
@@ -5,6 +5,7 @@ beforeEach(() => {
   useNotificationStore.setState({
     enabledCategories: ['review-requested', 'assigned'],
     pollIntervalMs: 5 * 60_000,
+    checksEnabled: { authored: false, assigned: false },
   })
 })
 
@@ -29,5 +30,21 @@ describe('notificationStore', () => {
     useNotificationStore.getState().setPollIntervalMs(60_000)
 
     expect(useNotificationStore.getState().pollIntervalMs).toBe(60_000)
+  })
+
+  it('GIVEN checks disabled for a section WHEN toggled THEN it is enabled', () => {
+    useNotificationStore.getState().toggleChecksEnabled('authored')
+
+    expect(useNotificationStore.getState().checksEnabled).toEqual({
+      authored: true,
+      assigned: false,
+    })
+  })
+
+  it('GIVEN checks enabled for a section WHEN toggled twice THEN it is back to disabled', () => {
+    useNotificationStore.getState().toggleChecksEnabled('assigned')
+    useNotificationStore.getState().toggleChecksEnabled('assigned')
+
+    expect(useNotificationStore.getState().checksEnabled.assigned).toBe(false)
   })
 })

--- a/src/features/notifications/stores/notificationStore.test.ts
+++ b/src/features/notifications/stores/notificationStore.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useNotificationStore } from './notificationStore'
+
+beforeEach(() => {
+  useNotificationStore.setState({
+    enabledCategories: ['review-requested', 'assigned'],
+    pollIntervalMs: 5 * 60_000,
+  })
+})
+
+describe('notificationStore', () => {
+  it('GIVEN an enabled category WHEN toggled THEN it is removed', () => {
+    useNotificationStore.getState().toggleCategory('review-requested')
+
+    expect(useNotificationStore.getState().enabledCategories).toEqual(['assigned'])
+  })
+
+  it('GIVEN a disabled category WHEN toggled THEN it is added', () => {
+    useNotificationStore.getState().toggleCategory('reviewed')
+
+    expect(useNotificationStore.getState().enabledCategories).toEqual([
+      'review-requested',
+      'assigned',
+      'reviewed',
+    ])
+  })
+
+  it('GIVEN a poll interval WHEN setPollIntervalMs is called THEN the store updates', () => {
+    useNotificationStore.getState().setPollIntervalMs(60_000)
+
+    expect(useNotificationStore.getState().pollIntervalMs).toBe(60_000)
+  })
+})

--- a/src/features/notifications/stores/notificationStore.ts
+++ b/src/features/notifications/stores/notificationStore.ts
@@ -4,8 +4,10 @@ import { persist } from 'zustand/middleware'
 export type NotificationStore = {
   enabledCategories: NotificationCategory[]
   pollIntervalMs: number
+  checksEnabled: Record<ChecksSection, boolean>
   toggleCategory: (category: NotificationCategory) => void
   setPollIntervalMs: (ms: number) => void
+  toggleChecksEnabled: (section: ChecksSection) => void
 }
 
 const defaultEnabledCategories: NotificationCategory[] = ['review-requested', 'assigned']
@@ -15,6 +17,7 @@ export const useNotificationStore = create<NotificationStore>()(
     (set) => ({
       enabledCategories: defaultEnabledCategories,
       pollIntervalMs: 5 * 60_000,
+      checksEnabled: { authored: false, assigned: false },
       toggleCategory: (category) =>
         set((state) => ({
           enabledCategories: state.enabledCategories.includes(category)
@@ -22,6 +25,10 @@ export const useNotificationStore = create<NotificationStore>()(
             : [...state.enabledCategories, category],
         })),
       setPollIntervalMs: (ms) => set({ pollIntervalMs: ms }),
+      toggleChecksEnabled: (section) =>
+        set((state) => ({
+          checksEnabled: { ...state.checksEnabled, [section]: !state.checksEnabled[section] },
+        })),
     }),
     { name: 'notification-preferences' }
   )

--- a/src/features/notifications/stores/notificationStore.ts
+++ b/src/features/notifications/stores/notificationStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type NotificationStore = {
+  enabledCategories: NotificationCategory[]
+  pollIntervalMs: number
+  toggleCategory: (category: NotificationCategory) => void
+  setPollIntervalMs: (ms: number) => void
+}
+
+const defaultEnabledCategories: NotificationCategory[] = ['review-requested', 'assigned']
+
+export const useNotificationStore = create<NotificationStore>()(
+  persist(
+    (set) => ({
+      enabledCategories: defaultEnabledCategories,
+      pollIntervalMs: 5 * 60_000,
+      toggleCategory: (category) =>
+        set((state) => ({
+          enabledCategories: state.enabledCategories.includes(category)
+            ? state.enabledCategories.filter((c) => c !== category)
+            : [...state.enabledCategories, category],
+        })),
+      setPollIntervalMs: (ms) => set({ pollIntervalMs: ms }),
+    }),
+    { name: 'notification-preferences' }
+  )
+)

--- a/src/features/onboarding/components/OnboardingGuide/OnboardingGuide.tsx
+++ b/src/features/onboarding/components/OnboardingGuide/OnboardingGuide.tsx
@@ -85,9 +85,10 @@ export const OnboardingGuide = () => {
         onClick={open}
         aria-label={GUIDE_TITLE}
         title={GUIDE_TITLE}
-        className="p-1.5 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+        className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
       >
-        <Compass size={14} />
+        <Compass size={13} />
+        Guide
       </button>
 
       <Modal isOpen={isOpen} title={GUIDE_TITLE} onClose={close} transition className="min-w-1/2">

--- a/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.test.tsx
+++ b/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.test.tsx
@@ -7,7 +7,9 @@ import { usePRStore } from '../../stores/prStore'
 import { useOnboardingStore } from '@/features/onboarding/stores/onboardingStore'
 import type { PRStore } from '../../stores/prStore'
 
-vi.mock('../../stores/prStore', () => ({ usePRStore: Object.assign(vi.fn(), { getState: vi.fn() }) }))
+vi.mock('../../stores/prStore', () => ({
+  usePRStore: Object.assign(vi.fn(), { getState: vi.fn() }),
+}))
 const mockUsePRStore = vi.mocked(usePRStore)
 
 const mockStore = (section = 'review-requested', setSection = vi.fn()) => {

--- a/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.test.tsx
+++ b/src/features/pull-requests/components/PRSectionsTabs/PRSectionsTabs.test.tsx
@@ -1,33 +1,39 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { PRSectionsTabs } from './PRSectionsTabs'
 import { usePRStore } from '../../stores/prStore'
 import { useOnboardingStore } from '@/features/onboarding/stores/onboardingStore'
 import type { PRStore } from '../../stores/prStore'
 
-vi.mock('../../stores/prStore', () => ({ usePRStore: vi.fn() }))
+vi.mock('../../stores/prStore', () => ({ usePRStore: Object.assign(vi.fn(), { getState: vi.fn() }) }))
 const mockUsePRStore = vi.mocked(usePRStore)
 
 const mockStore = (section = 'review-requested', setSection = vi.fn()) => {
-  mockUsePRStore.mockImplementation((selector: (s: PRStore) => unknown) => {
-    const state = { section, setSection }
-    return selector(state as unknown as PRStore)
-  })
+  const state = { section, setSection }
+  mockUsePRStore.mockImplementation((selector: (s: PRStore) => unknown) =>
+    selector(state as unknown as PRStore)
+  )
+  vi.mocked(mockUsePRStore.getState).mockReturnValue(state as unknown as PRStore)
 }
 
 const renderWithClient = () => {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={client}>
-      <PRSectionsTabs />
-    </QueryClientProvider>
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <PRSectionsTabs />
+      </QueryClientProvider>
+    </MemoryRouter>
   )
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  useOnboardingStore.setState({ spotlight: null })
+  // hasSeenGuide: true keeps the onboarding guide's own modal (rendered via ContributeLinks) closed,
+  // so its content doesn't collide with these tests' section-label queries.
+  useOnboardingStore.setState({ spotlight: null, hasSeenGuide: true })
   mockStore()
 })
 

--- a/src/routes/AppRouter/AppRouter.tsx
+++ b/src/routes/AppRouter/AppRouter.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from '@/containers/AppLayout'
 import { PRDashboard } from '@/features/pull-requests/exports'
 import { BranchDashboard } from '@/features/branches/exports'
 import { PRDetailPage } from '@/features/pr-review/exports'
+import { SettingsPage } from '@/features/notifications/exports'
 import { RequireFeature } from '@/shared/components/RequireFeature/RequireFeature'
 
 // HashRouter is mandatory: the packaged app loads renderer/index.html via file://, which
@@ -14,6 +15,7 @@ export const AppRouter = () => (
         <Route index element={<Navigate to="/prs" replace />} />
         <Route path="prs" element={<PRDashboard />} />
         <Route path="prs/:owner/:repo/:number" element={<PRDetailPage />} />
+        <Route path="settings" element={<SettingsPage />} />
         <Route
           path="branches"
           element={

--- a/src/shared/components/ContributeLinks/ContributeLinks.tsx
+++ b/src/shared/components/ContributeLinks/ContributeLinks.tsx
@@ -1,5 +1,6 @@
 import { Bug, Lightbulb } from 'lucide-react'
 import { ChangelogButton } from '@/features/updates/exports.ts'
+import { OnboardingGuide } from '@/features/onboarding/exports'
 
 const LINK_CLASSES =
   'flex items-center gap-1.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors'
@@ -8,6 +9,7 @@ export const ContributeLinks = () => {
   return (
     <>
       <p className="text-xs text-[var(--color-text-muted)]">Donna is open source. Make it yours.</p>
+      <OnboardingGuide />
       <a
         href="https://github.com/adelbeke/donna/issues/new?template=feature_request.md"
         target="_blank"

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -52,6 +52,7 @@ type NotificationSettings = {
   openPRsInDonna: boolean
   hiddenAuthors: string[]
   hiddenRepos: string[]
+  showDraftsByCategory: Record<NotificationCategory, boolean>
 }
 
 type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -45,6 +45,8 @@ interface Window {
 }
 
 type NotificationCategory = 'review-requested' | 'assigned' | 'reviewed'
+type ChecksSection = 'authored' | 'assigned'
+type NotificationSection = NotificationCategory | 'authored'
 
 type NotificationSettings = {
   enabledCategories: NotificationCategory[]
@@ -52,7 +54,8 @@ type NotificationSettings = {
   openPRsInDonna: boolean
   hiddenAuthors: string[]
   hiddenRepos: string[]
-  showDraftsByCategory: Record<NotificationCategory, boolean>
+  showDraftsByCategory: Record<NotificationSection, boolean>
+  checksEnabled: Record<ChecksSection, boolean>
 }
 
 type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }


### PR DESCRIPTION
## Summary
Started as PR 3 of `specs/notifications.md`'s v3.0.0 milestone (settings page) but grew significantly after review — see below.

### Settings page (original scope)
- Real `/settings` route (`SettingsPage`), reachable from the navbar next to the theme toggle — app-wide, independent of the current PR view, unlike the view-scoped `SettingsModal` which stays untouched
- `notificationStore` (Zustand, persisted): `enabledCategories`, `pollIntervalMs`
- `AppLayout`'s settings-push effect (from PR 2) now sends the full blob to main's `notifications:updateSettings` — one push path, no second sync mechanism

### Audit pass: does detection respect all the relevant PR-list settings?
- **`viewFilters[section].showDrafts`** — real gap, fixed: `review-requested`/`assigned`/`reviewed` default to hiding drafts in-app, but the poll notified about them unconditionally. Added `filterDrafts` + `showDraftsByCategory`, same per-section default the list uses.
- **`globalFilters.showHidden`** — deliberately ignored: a mute stays a mute for notifications even while this toggle temporarily reveals muted items in-app.
- **`viewFilters[section].repos`** (per-view repo allow-list) — deliberately not respected: narrows what you're currently browsing, not a "never tell me" preference.

### Scope expansion: granular per-section triggers (requested mid-review, goes beyond the original spec's "authored-only, CI-failed-only" v3.1.0 plan)
- New opt-in trigger: notify when a PR's checks land on a **terminal state** (SUCCESS or FAILURE — not every PENDING/EXPECTED transition), toggleable independently for **"my pull requests"** (authored) and **"assigned to me"**. Review-received notifications stay authored-only (being assigned to a PR doesn't make you its review target).
- `SettingsPage` restructured into per-section groups (Review requested / Assigned to me / My pull requests) instead of one flat toggle list, so the granularity is visible.
- `electron/notificationCopy.ts`: `buildSearchQuery` widened to accept `'authored'` (checks-only — never part of the new-PR/group-a diff), `isTerminalCheckState` + `formatCheckStateNotification` added.
- `electron/notifications.ts`: `fetchSection()` factors out the fetch+mute+draft-filter step shared by the new-PR diff and the new check-state diff. `lastCheckState` persists per section, keyed by PR id, self-pruning like `seenIds` (closed/merged PRs drop out on their own). Each section polls independently per enabled trigger — an "assigned" PR list can be fetched twice a tick if both toggles are on; accepted as simpler than merging two different diff algorithms into one fetch.
- `specs/notifications.md` intentionally **not** updated yet — code is the source of truth for now, can catch up later if this direction sticks.

## Test plan
- [x] `tsc -b` clean
- [x] `electron-vite build` bundles main/preload/renderer without errors
- [x] `vitest run` — 500 passed (17 new across `notificationCopy.test.ts`, `notificationStore.test.ts`, `SettingsPage.test.tsx`)
- [x] `eslint` / `prettier --check` clean on all touched files
- [x] Manual: `npm run dev` + `npm run dev:electron` — launched cleanly, `notifications.json` picks up pushed settings on mount
- [ ] Manual: toggle each of the 4 checkboxes on `/settings`, confirm main's `checksEnabled`/`enabledCategories` reflect it; push a PR to SUCCESS/FAILURE on an authored and an assigned PR with checks notifications on, confirm exactly one notification per terminal transition (not on PENDING, not repeated while state is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgJ944dCZK9mpqVAZK5BVx