### PR TITLE
feat: review-left notifications for assigned PRs too

### DIFF
--- a/electron/notificationCopy.test.ts
+++ b/electron/notificationCopy.test.ts
@@ -184,23 +184,30 @@ describe('isNotifiableReviewState', () => {
 describe('formatReviewNotification', () => {
   const pr = { number: 42, title: 'Fix the thing', repository: { nameWithOwner: 'acme/donna' } }
 
-  it('formats an approval', () => {
-    expect(formatReviewNotification(pr, 'octocat', 'APPROVED')).toEqual({
+  it('formats an approval on an authored PR', () => {
+    expect(formatReviewNotification(pr, 'authored', 'octocat', 'APPROVED')).toEqual({
       title: 'octocat approved your PR',
       body: 'acme/donna#42 · Fix the thing',
     })
   })
 
-  it('formats requested changes', () => {
-    expect(formatReviewNotification(pr, 'octocat', 'CHANGES_REQUESTED')).toEqual({
+  it('formats requested changes on an authored PR', () => {
+    expect(formatReviewNotification(pr, 'authored', 'octocat', 'CHANGES_REQUESTED')).toEqual({
       title: 'octocat requested changes on your PR',
       body: 'acme/donna#42 · Fix the thing',
     })
   })
 
-  it('formats a comment', () => {
-    expect(formatReviewNotification(pr, 'octocat', 'COMMENTED')).toEqual({
+  it('formats a comment on an authored PR', () => {
+    expect(formatReviewNotification(pr, 'authored', 'octocat', 'COMMENTED')).toEqual({
       title: 'octocat commented on your PR',
+      body: 'acme/donna#42 · Fix the thing',
+    })
+  })
+
+  it('formats an approval on an assigned PR', () => {
+    expect(formatReviewNotification(pr, 'assigned', 'octocat', 'APPROVED')).toEqual({
+      title: "octocat approved a PR you're assigned to",
       body: 'acme/donna#42 · Fix the thing',
     })
   })

--- a/electron/notificationCopy.ts
+++ b/electron/notificationCopy.ts
@@ -95,12 +95,18 @@ const REVIEW_VERB: Record<NotifiableReviewState, string> = {
   COMMENTED: 'commented on',
 }
 
+const REVIEW_TARGET_LABEL: Record<ChecksSection, string> = {
+  authored: 'your PR',
+  assigned: "a PR you're assigned to",
+}
+
 export const formatReviewNotification = (
   pr: CheckedPRNode,
+  section: ChecksSection,
   reviewerLogin: string,
   state: NotifiableReviewState
 ): { title: string; body: string } => ({
-  title: `${reviewerLogin} ${REVIEW_VERB[state]} your PR`,
+  title: `${reviewerLogin} ${REVIEW_VERB[state]} ${REVIEW_TARGET_LABEL[section]}`,
   body: `${pr.repository.nameWithOwner}#${pr.number} · ${pr.title}`,
 })
 

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -32,7 +32,7 @@ export type NotificationSettings = {
   hiddenRepos: string[]
   showDraftsByCategory: Record<NotificationSection, boolean>
   checksEnabled: Record<ChecksSection, boolean>
-  reviewLeftEnabled: boolean
+  reviewLeftEnabled: Record<ChecksSection, boolean>
 }
 
 export type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }
@@ -66,15 +66,15 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   // opt-in: unlike new-PR notifications, per-check-state notifications can fire often on an
   // active PR (every re-run), so we don't turn this on until the user asks for it in Settings
   checksEnabled: { authored: false, assigned: false },
-  reviewLeftEnabled: false,
+  reviewLeftEnabled: { authored: false, assigned: false },
 }
 
 type PersistedState = {
   settings: NotificationSettings
   seenIds: Partial<Record<NotificationCategory, string[]>>
   lastCheckState: Partial<Record<ChecksSection, Record<string, CheckRollupState | null>>>
-  // PR id -> review ids already notified about (or seeded on first sighting of that PR)
-  seenReviewIds: Record<string, string[]>
+  // section -> PR id -> review ids already notified about (or seeded on first sighting of that PR)
+  seenReviewIds: Partial<Record<ChecksSection, Record<string, string[]>>>
 }
 
 const DEFAULT_STATE: PersistedState = {
@@ -101,6 +101,10 @@ const loadState = (): PersistedState => {
         checksEnabled: {
           ...DEFAULT_SETTINGS.checksEnabled,
           ...parsed.settings?.checksEnabled,
+        },
+        reviewLeftEnabled: {
+          ...DEFAULT_SETTINGS.reviewLeftEnabled,
+          ...parsed.settings?.reviewLeftEnabled,
         },
       },
       seenIds: parsed.seenIds ?? {},
@@ -247,9 +251,9 @@ const notifyCheckStateChange = (pr: NotificationPR) => {
   fireNotification(title, body, () => handleSinglePRClick(pr))
 }
 
-const notifyReviewLeft = (pr: NotificationPR, review: Review) => {
+const notifyReviewLeft = (pr: NotificationPR, section: ChecksSection, review: Review) => {
   if (!review.author || !isNotifiableReviewState(review.state)) return
-  const { title, body } = formatReviewNotification(pr, review.author.login, review.state)
+  const { title, body } = formatReviewNotification(pr, section, review.author.login, review.state)
   fireNotification(title, body, () => handleSinglePRClick(pr))
 }
 
@@ -314,11 +318,11 @@ const checkChecks = async (section: ChecksSection) => {
 }
 
 // self-pruning like lastCheckState/seenIds: nextMap only keeps ids for PRs still open
-const checkReviews = async () => {
-  const nodes = await fetchSection('authored')
+const checkReviews = async (section: ChecksSection) => {
+  const nodes = await fetchSection(section)
   if (!nodes) return
 
-  const prevMap = state.seenReviewIds
+  const prevMap = state.seenReviewIds[section] ?? {}
   const nextMap: Record<string, string[]> = {}
   for (const pr of nodes) {
     const reviewIds = pr.reviews.map((r) => r.id)
@@ -328,10 +332,10 @@ const checkReviews = async () => {
     if (prevIds === undefined) continue
     const newIds = diffNewIds(reviewIds, prevIds)
     for (const review of pr.reviews.filter((r) => newIds.includes(r.id))) {
-      if (review.author?.login !== viewerLogin) notifyReviewLeft(pr, review)
+      if (review.author?.login !== viewerLogin) notifyReviewLeft(pr, section, review)
     }
   }
-  state.seenReviewIds = nextMap
+  state.seenReviewIds[section] = nextMap
   saveState()
 }
 
@@ -343,7 +347,8 @@ const tick = async () => {
   }
   if (state.settings.checksEnabled.assigned) await checkChecks('assigned')
   if (state.settings.checksEnabled.authored) await checkChecks('authored')
-  if (state.settings.reviewLeftEnabled) await checkReviews()
+  if (state.settings.reviewLeftEnabled.assigned) await checkReviews('assigned')
+  if (state.settings.reviewLeftEnabled.authored) await checkReviews('authored')
 }
 
 const startPolling = () => {

--- a/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
@@ -16,7 +16,7 @@ beforeEach(() => {
     enabledCategories: ['review-requested', 'assigned'],
     pollIntervalMs: 5 * 60_000,
     checksEnabled: { authored: false, assigned: false },
-    reviewLeftEnabled: false,
+    reviewLeftEnabled: { authored: false, assigned: false },
   })
 })
 
@@ -74,11 +74,25 @@ describe('SettingsPage', () => {
     })
   })
 
-  it('GIVEN review-left disabled WHEN the checkbox is checked THEN it is enabled in the store', () => {
+  it('GIVEN review-left disabled for authored WHEN the checkbox is checked THEN only authored is enabled', () => {
     renderSettingsPage()
 
     fireEvent.click(screen.getByLabelText('Notify me when someone reviews my PR'))
 
-    expect(useNotificationStore.getState().reviewLeftEnabled).toBe(true)
+    expect(useNotificationStore.getState().reviewLeftEnabled).toEqual({
+      authored: true,
+      assigned: false,
+    })
+  })
+
+  it('GIVEN review-left disabled for assigned WHEN the checkbox is checked THEN only assigned is enabled', () => {
+    renderSettingsPage()
+
+    fireEvent.click(screen.getByLabelText('Notify me when someone reviews'))
+
+    expect(useNotificationStore.getState().reviewLeftEnabled).toEqual({
+      authored: false,
+      assigned: true,
+    })
   })
 })

--- a/src/features/notifications/components/SettingsPage/SettingsPage.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.tsx
@@ -96,6 +96,11 @@ export const SettingsPage = () => {
               checked={checksEnabled.assigned}
               onChange={() => toggleChecksEnabled('assigned')}
             />
+            <Checkbox
+              label="Notify me when someone reviews"
+              checked={reviewLeftEnabled.assigned}
+              onChange={() => toggleReviewLeftEnabled('assigned')}
+            />
           </div>
 
           <div className="space-y-2">
@@ -109,8 +114,8 @@ export const SettingsPage = () => {
             />
             <Checkbox
               label="Notify me when someone reviews my PR"
-              checked={reviewLeftEnabled}
-              onChange={toggleReviewLeftEnabled}
+              checked={reviewLeftEnabled.authored}
+              onChange={() => toggleReviewLeftEnabled('authored')}
             />
           </div>
         </div>

--- a/src/features/notifications/stores/notificationStore.test.ts
+++ b/src/features/notifications/stores/notificationStore.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
     enabledCategories: ['review-requested', 'assigned'],
     pollIntervalMs: 5 * 60_000,
     checksEnabled: { authored: false, assigned: false },
-    reviewLeftEnabled: false,
+    reviewLeftEnabled: { authored: false, assigned: false },
   })
 })
 
@@ -49,16 +49,19 @@ describe('notificationStore', () => {
     expect(useNotificationStore.getState().checksEnabled.assigned).toBe(false)
   })
 
-  it('GIVEN review-left disabled WHEN toggled THEN it is enabled', () => {
-    useNotificationStore.getState().toggleReviewLeftEnabled()
+  it('GIVEN review-left disabled for a section WHEN toggled THEN it is enabled', () => {
+    useNotificationStore.getState().toggleReviewLeftEnabled('authored')
 
-    expect(useNotificationStore.getState().reviewLeftEnabled).toBe(true)
+    expect(useNotificationStore.getState().reviewLeftEnabled).toEqual({
+      authored: true,
+      assigned: false,
+    })
   })
 
-  it('GIVEN review-left enabled WHEN toggled twice THEN it is back to disabled', () => {
-    useNotificationStore.getState().toggleReviewLeftEnabled()
-    useNotificationStore.getState().toggleReviewLeftEnabled()
+  it('GIVEN review-left enabled for a section WHEN toggled twice THEN it is back to disabled', () => {
+    useNotificationStore.getState().toggleReviewLeftEnabled('assigned')
+    useNotificationStore.getState().toggleReviewLeftEnabled('assigned')
 
-    expect(useNotificationStore.getState().reviewLeftEnabled).toBe(false)
+    expect(useNotificationStore.getState().reviewLeftEnabled.assigned).toBe(false)
   })
 })

--- a/src/features/notifications/stores/notificationStore.ts
+++ b/src/features/notifications/stores/notificationStore.ts
@@ -5,11 +5,11 @@ export type NotificationStore = {
   enabledCategories: NotificationCategory[]
   pollIntervalMs: number
   checksEnabled: Record<ChecksSection, boolean>
-  reviewLeftEnabled: boolean
+  reviewLeftEnabled: Record<ChecksSection, boolean>
   toggleCategory: (category: NotificationCategory) => void
   setPollIntervalMs: (ms: number) => void
   toggleChecksEnabled: (section: ChecksSection) => void
-  toggleReviewLeftEnabled: () => void
+  toggleReviewLeftEnabled: (section: ChecksSection) => void
 }
 
 const defaultEnabledCategories: NotificationCategory[] = ['review-requested', 'assigned']
@@ -20,7 +20,7 @@ export const useNotificationStore = create<NotificationStore>()(
       enabledCategories: defaultEnabledCategories,
       pollIntervalMs: 5 * 60_000,
       checksEnabled: { authored: false, assigned: false },
-      reviewLeftEnabled: false,
+      reviewLeftEnabled: { authored: false, assigned: false },
       toggleCategory: (category) =>
         set((state) => ({
           enabledCategories: state.enabledCategories.includes(category)
@@ -32,8 +32,13 @@ export const useNotificationStore = create<NotificationStore>()(
         set((state) => ({
           checksEnabled: { ...state.checksEnabled, [section]: !state.checksEnabled[section] },
         })),
-      toggleReviewLeftEnabled: () =>
-        set((state) => ({ reviewLeftEnabled: !state.reviewLeftEnabled })),
+      toggleReviewLeftEnabled: (section) =>
+        set((state) => ({
+          reviewLeftEnabled: {
+            ...state.reviewLeftEnabled,
+            [section]: !state.reviewLeftEnabled[section],
+          },
+        })),
     }),
     { name: 'notification-preferences' }
   )

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -56,7 +56,7 @@ type NotificationSettings = {
   hiddenRepos: string[]
   showDraftsByCategory: Record<NotificationSection, boolean>
   checksEnabled: Record<ChecksSection, boolean>
-  reviewLeftEnabled: boolean
+  reviewLeftEnabled: Record<ChecksSection, boolean>
 }
 
 type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }


### PR DESCRIPTION
## What

Extends the review-left notification trigger shipped in #225 (authored PRs only) to also cover PRs you're **assigned** to. `reviewLeftEnabled` becomes `Record<ChecksSection, boolean>` (mirroring the existing `checksEnabled` toggle), `seenReviewIds` nests by section, and the notification wording adapts by section ("approved your PR" vs. "approved a PR you're assigned to").

Two new checkboxes in Settings: "Notify me when someone reviews" under **Assigned to me**, and the existing "Notify me when someone reviews my PR" under **My pull requests** is now backed by its own per-section toggle.

## Why

Requested: get notified when a review lands on a PR I'm assigned to, not just ones I authored.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes
- [x] `npx electron-vite build` passes