### PR TITLE
feat: custom notification sound

### DIFF
--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, BrowserWindow, Notification, shell } from 'electron'
+import { app, ipcMain, BrowserWindow, Notification, shell, dialog } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
 import { runGh } from './gh'
@@ -37,6 +37,8 @@ export type NotificationSettings = {
   showDraftsByCategory: Record<NotificationSection, boolean>
   checksEnabled: Record<ChecksSection, boolean>
   reviewLeftEnabled: Record<ChecksSection, boolean>
+  soundName: string | null
+  silent: boolean
 }
 
 export type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }
@@ -77,6 +79,8 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   // active PR (every re-run), so we don't turn this on until the user asks for it in Settings
   checksEnabled: { authored: false, assigned: false },
   reviewLeftEnabled: { authored: false, assigned: false },
+  soundName: 'Pop',
+  silent: false,
 }
 
 type PersistedState = {
@@ -258,7 +262,12 @@ const fireNotification = (
   onClick: () => void,
   onDismiss: () => void = () => {}
 ) => {
-  const notification = new Notification({ title, body })
+  const notification = new Notification({
+    title,
+    body,
+    silent: state.settings.silent,
+    sound: state.settings.silent ? undefined : (state.settings.soundName ?? undefined),
+  })
   liveNotifications.add(notification)
   const release = () => liveNotifications.delete(notification)
   const handlers = createNotificationLifecycleHandlers({ onClick, onDismiss, release })
@@ -430,5 +439,23 @@ export const initNotifications = () => {
   })
   ipcMain.handle('notifications:setActiveSection', (_e, section: NotificationSection | null) => {
     setActiveSection(section)
+  })
+  ipcMain.handle('notifications:pickSound', async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      properties: ['openFile'],
+      filters: [{ name: 'Audio', extensions: ['aiff', 'aif', 'wav', 'caf', 'm4a', 'mp3'] }],
+    })
+    if (canceled || !filePaths[0]) return null
+    // ponytail: macOS only resolves notification sounds by name from a fixed set of
+    // directories (~/Library/Sounds among them) — an arbitrary path never plays, so the
+    // file has to be copied there first and referenced by its filename.
+    const soundsDir = path.join(app.getPath('home'), 'Library', 'Sounds')
+    fs.mkdirSync(soundsDir, { recursive: true })
+    const fileName = path.basename(filePaths[0])
+    fs.copyFileSync(filePaths[0], path.join(soundsDir, fileName))
+    return fileName
+  })
+  ipcMain.handle('notifications:test', () => {
+    fireNotification('Test notification', 'This is what your notifications sound like.', () => {})
   })
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -50,6 +50,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('notifications:updateSettings', partial),
     setActiveSection: (section: NotificationSection | null): Promise<void> =>
       ipcRenderer.invoke('notifications:setActiveSection', section),
+    pickSound: (): Promise<string | null> => ipcRenderer.invoke('notifications:pickSound'),
+    test: (): Promise<void> => ipcRenderer.invoke('notifications:test'),
     onNavigate: (cb: (payload: NotificationNavigatePayload) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, payload: NotificationNavigatePayload) =>
         cb(payload)

--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -29,6 +29,8 @@ export const AppLayout = () => {
   const pollIntervalMs = useNotificationStore((s) => s.pollIntervalMs)
   const checksEnabled = useNotificationStore((s) => s.checksEnabled)
   const reviewLeftEnabled = useNotificationStore((s) => s.reviewLeftEnabled)
+  const soundName = useNotificationStore((s) => s.soundName)
+  const silent = useNotificationStore((s) => s.silent)
   const showDraftsReviewRequested = usePRStore((s) => s.viewFilters['review-requested'].showDrafts)
   const showDraftsAssigned = usePRStore((s) => s.viewFilters.assigned.showDrafts)
   const showDraftsReviewed = usePRStore((s) => s.viewFilters.reviewed.showDrafts)
@@ -67,6 +69,8 @@ export const AppLayout = () => {
       pollIntervalMs,
       checksEnabled,
       reviewLeftEnabled,
+      soundName,
+      silent,
       showDraftsByCategory: {
         'review-requested': showDraftsReviewRequested,
         assigned: showDraftsAssigned,
@@ -86,6 +90,8 @@ export const AppLayout = () => {
     pollIntervalMs,
     checksEnabled,
     reviewLeftEnabled,
+    soundName,
+    silent,
     showDraftsReviewRequested,
     showDraftsAssigned,
     showDraftsReviewed,

--- a/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.test.tsx
@@ -17,6 +17,8 @@ beforeEach(() => {
     pollIntervalMs: 5 * 60_000,
     checksEnabled: { authored: false, assigned: false },
     reviewLeftEnabled: { authored: false, assigned: false },
+    soundName: 'Pop',
+    silent: false,
   })
 })
 
@@ -94,5 +96,24 @@ describe('SettingsPage', () => {
       authored: false,
       assigned: true,
     })
+  })
+
+  it('GIVEN the sound select WHEN changed THEN the store updates', () => {
+    renderSettingsPage()
+
+    fireEvent.change(screen.getByLabelText('Notification sound'), {
+      target: { value: 'Glass' },
+    })
+
+    expect(useNotificationStore.getState().soundName).toBe('Glass')
+  })
+
+  it('GIVEN silent unchecked WHEN toggled THEN the store updates and the sound controls disable', () => {
+    renderSettingsPage()
+
+    fireEvent.click(screen.getByLabelText('Silent (no sound)'))
+
+    expect(useNotificationStore.getState().silent).toBe(true)
+    expect(screen.getByLabelText('Notification sound')).toBeDisabled()
   })
 })

--- a/src/features/notifications/components/SettingsPage/SettingsPage.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft } from 'lucide-react'
 import { useNavigate } from 'react-router'
 import { useNotificationStore } from '../../stores/notificationStore'
+import { SYSTEM_SOUNDS } from '../../lib/sounds'
 
 const INTERVAL_OPTIONS: { label: string; value: number }[] = [
   { label: '1 minute', value: 60_000 },
@@ -39,6 +40,17 @@ export const SettingsPage = () => {
   const toggleReviewLeftEnabled = useNotificationStore((s) => s.toggleReviewLeftEnabled)
   const pollIntervalMs = useNotificationStore((s) => s.pollIntervalMs)
   const setPollIntervalMs = useNotificationStore((s) => s.setPollIntervalMs)
+  const soundName = useNotificationStore((s) => s.soundName)
+  const setSoundName = useNotificationStore((s) => s.setSoundName)
+  const silent = useNotificationStore((s) => s.silent)
+  const toggleSilent = useNotificationStore((s) => s.toggleSilent)
+
+  const isCustomSound = soundName !== null && !(SYSTEM_SOUNDS as readonly string[]).includes(soundName)
+
+  const handlePickSound = async () => {
+    const fileName = await window.electronAPI?.notifications.pickSound()
+    if (fileName) setSoundName(fileName)
+  }
 
   return (
     <div className="max-w-lg space-y-6">
@@ -139,6 +151,49 @@ export const SettingsPage = () => {
               </option>
             ))}
           </select>
+        </div>
+
+        <div className="mt-5 space-y-2">
+          <label
+            htmlFor="notification-sound"
+            className="block text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2"
+          >
+            Notification sound
+          </label>
+          <div className="flex items-center gap-2">
+            <select
+              id="notification-sound"
+              value={soundName ?? ''}
+              disabled={silent}
+              onChange={(e) => setSoundName(e.target.value)}
+              className="text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] bg-[var(--color-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isCustomSound && (
+                <option value={soundName ?? ''}>{soundName} (custom)</option>
+              )}
+              {SYSTEM_SOUNDS.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={handlePickSound}
+              disabled={silent}
+              className="text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Choose local file…
+            </button>
+            <button
+              type="button"
+              onClick={() => void window.electronAPI?.notifications.test()}
+              className="text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-overlay)] transition-colors cursor-pointer"
+            >
+              Test
+            </button>
+          </div>
+          <Checkbox label="Silent (no sound)" checked={silent} onChange={toggleSilent} />
         </div>
       </section>
     </div>

--- a/src/features/notifications/components/SettingsPage/SettingsPage.tsx
+++ b/src/features/notifications/components/SettingsPage/SettingsPage.tsx
@@ -45,7 +45,8 @@ export const SettingsPage = () => {
   const silent = useNotificationStore((s) => s.silent)
   const toggleSilent = useNotificationStore((s) => s.toggleSilent)
 
-  const isCustomSound = soundName !== null && !(SYSTEM_SOUNDS as readonly string[]).includes(soundName)
+  const isCustomSound =
+    soundName !== null && !(SYSTEM_SOUNDS as readonly string[]).includes(soundName)
 
   const handlePickSound = async () => {
     const fileName = await window.electronAPI?.notifications.pickSound()
@@ -168,9 +169,7 @@ export const SettingsPage = () => {
               onChange={(e) => setSoundName(e.target.value)}
               className="text-xs px-2 py-1.5 rounded border border-[var(--color-border-subtle)] bg-[var(--color-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isCustomSound && (
-                <option value={soundName ?? ''}>{soundName} (custom)</option>
-              )}
+              {isCustomSound && <option value={soundName ?? ''}>{soundName} (custom)</option>}
               {SYSTEM_SOUNDS.map((name) => (
                 <option key={name} value={name}>
                   {name}

--- a/src/features/notifications/lib/sounds.ts
+++ b/src/features/notifications/lib/sounds.ts
@@ -1,0 +1,17 @@
+// macOS system sounds, resolvable by name from /System/Library/Sounds
+export const SYSTEM_SOUNDS = [
+  'Basso',
+  'Blow',
+  'Bottle',
+  'Frog',
+  'Funk',
+  'Glass',
+  'Hero',
+  'Morse',
+  'Ping',
+  'Pop',
+  'Purr',
+  'Sosumi',
+  'Submarine',
+  'Tink',
+] as const

--- a/src/features/notifications/stores/notificationStore.test.ts
+++ b/src/features/notifications/stores/notificationStore.test.ts
@@ -7,6 +7,8 @@ beforeEach(() => {
     pollIntervalMs: 5 * 60_000,
     checksEnabled: { authored: false, assigned: false },
     reviewLeftEnabled: { authored: false, assigned: false },
+    soundName: 'Pop',
+    silent: false,
   })
 })
 
@@ -63,5 +65,24 @@ describe('notificationStore', () => {
     useNotificationStore.getState().toggleReviewLeftEnabled('assigned')
 
     expect(useNotificationStore.getState().reviewLeftEnabled.assigned).toBe(false)
+  })
+
+  it('GIVEN a sound name WHEN setSoundName is called THEN the store updates', () => {
+    useNotificationStore.getState().setSoundName('Glass')
+
+    expect(useNotificationStore.getState().soundName).toBe('Glass')
+  })
+
+  it('GIVEN silent is off WHEN toggleSilent is called THEN it is enabled', () => {
+    useNotificationStore.getState().toggleSilent()
+
+    expect(useNotificationStore.getState().silent).toBe(true)
+  })
+
+  it('GIVEN silent is on WHEN toggled twice THEN it is back to disabled', () => {
+    useNotificationStore.getState().toggleSilent()
+    useNotificationStore.getState().toggleSilent()
+
+    expect(useNotificationStore.getState().silent).toBe(false)
   })
 })

--- a/src/features/notifications/stores/notificationStore.ts
+++ b/src/features/notifications/stores/notificationStore.ts
@@ -6,10 +6,14 @@ export type NotificationStore = {
   pollIntervalMs: number
   checksEnabled: Record<ChecksSection, boolean>
   reviewLeftEnabled: Record<ChecksSection, boolean>
+  soundName: string | null
+  silent: boolean
   toggleCategory: (category: NotificationCategory) => void
   setPollIntervalMs: (ms: number) => void
   toggleChecksEnabled: (section: ChecksSection) => void
   toggleReviewLeftEnabled: (section: ChecksSection) => void
+  setSoundName: (soundName: string | null) => void
+  toggleSilent: () => void
 }
 
 const defaultEnabledCategories: NotificationCategory[] = ['review-requested', 'assigned']
@@ -21,6 +25,8 @@ export const useNotificationStore = create<NotificationStore>()(
       pollIntervalMs: 5 * 60_000,
       checksEnabled: { authored: false, assigned: false },
       reviewLeftEnabled: { authored: false, assigned: false },
+      soundName: 'Pop',
+      silent: false,
       toggleCategory: (category) =>
         set((state) => ({
           enabledCategories: state.enabledCategories.includes(category)
@@ -39,6 +45,8 @@ export const useNotificationStore = create<NotificationStore>()(
             [section]: !state.reviewLeftEnabled[section],
           },
         })),
+      setSoundName: (soundName) => set({ soundName }),
+      toggleSilent: () => set((state) => ({ silent: !state.silent })),
     }),
     {
       name: 'notification-preferences',
@@ -47,6 +55,8 @@ export const useNotificationStore = create<NotificationStore>()(
         pollIntervalMs: state.pollIntervalMs,
         checksEnabled: state.checksEnabled,
         reviewLeftEnabled: state.reviewLeftEnabled,
+        soundName: state.soundName,
+        silent: state.silent,
       }),
     }
   )

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -40,6 +40,8 @@ interface Window {
     notifications: {
       updateSettings: (partial: Partial<NotificationSettings>) => Promise<void>
       setActiveSection: (section: NotificationSection | null) => Promise<void>
+      pickSound: () => Promise<string | null>
+      test: () => Promise<void>
       onNavigate: (cb: (payload: NotificationNavigatePayload) => void) => () => void
     }
   }
@@ -59,6 +61,8 @@ type NotificationSettings = {
   showDraftsByCategory: Record<NotificationSection, boolean>
   checksEnabled: Record<ChecksSection, boolean>
   reviewLeftEnabled: Record<ChecksSection, boolean>
+  soundName: string | null
+  silent: boolean
 }
 
 type NotificationNavigatePayload = { route: string } | { section: NotificationCategory }


### PR DESCRIPTION
## What

Adds a "Notification sound" section to Settings: pick any macOS system sound from a dropdown, link a local audio file, or mute notifications entirely (Silent). A "Test" button fires a sample notification with the current settings.

## Why

Closes #234 — the fixed notification sound was reported as unpleasant, and users asked for both a choice of presets and the ability to link their own sound file.

Implementation notes: macOS only resolves `Notification.sound` by name from a fixed set of directories (`/System/Library/Sounds`, `~/Library/Sounds`, the app bundle). A "custom local file" therefore means picking a file via `dialog.showOpenDialog` and copying it into `~/Library/Sounds`, then referencing it by filename — an arbitrary path can't be played directly.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] `npm run build` passes